### PR TITLE
fix: commit urls associated with platform

### DIFF
--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -9,7 +9,7 @@ We had to make some changes to edx-platform itself in order to add the "Canvas" 
 
 The ``edx-platform`` branch/tag you're using must include below commit for ``ol-openedx-canvas-integration`` plugin to work properly:
 
-- https://github.com/mitodl/edx-platform/commit/5b8acfceb7fcebab6b5e3aff0493876f439f2b80
+- https://github.com/mitodl/edx-platform/commit/a9c4e667b658d710c02e0e811c1d5b067d94677e
 
 
 Installation

--- a/src/ol_openedx_rapid_response_reports/README.rst
+++ b/src/ol_openedx_rapid_response_reports/README.rst
@@ -11,7 +11,7 @@ A django app plugin for edx-platform to enable "Rapid Response Reports" function
 
 We had to make some changes to edx-platform itself in order to add the ``Rapid Responses`` tab to the instructor dashboard, so the ``edx-platform`` branch/tag you're using must include this commit for the plugin to work properly:
 
-- https://github.com/mitodl/edx-platform/commit/f6c7cc6ea528819e8779e3137c806911a81a3198
+- https://github.com/mitodl/edx-platform/commit/91b24d30454a2a4042039486fd5499a7a7843d0c
 
 Dependencies
 ---------------


### PR DESCRIPTION
## Related Tickets:
None

## What this PR does?
- Fixes the references in the READMEs.

## Why?
Our plugin PRs were merged first and then the platform counterparts which were squashed and the commit hashes changed with new commit. So, This PR just fixes that.

## How to test?
Just verify the links point to the correct URLs.