### PR TITLE
docs: update commit references for Rapid Response, Canvas Plugin

### DIFF
--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -9,7 +9,7 @@ We had to make some changes to edx-platform itself in order to add the "Canvas" 
 
 The ``edx-platform`` branch/tag you're using must include below commit for ``ol-openedx-canvas-integration`` plugin to work properly:
 
-- https://github.com/mitodl/edx-platform/commit/a9c4e667b658d710c02e0e811c1d5b067d94677e
+- https://github.com/mitodl/edx-platform/pull/274/commits/97a51d208f3cdfd26df0a62281b0964de10ff40a
 
 
 Installation

--- a/src/ol_openedx_rapid_response_reports/README.rst
+++ b/src/ol_openedx_rapid_response_reports/README.rst
@@ -11,7 +11,7 @@ A django app plugin for edx-platform to enable "Rapid Response Reports" function
 
 We had to make some changes to edx-platform itself in order to add the ``Rapid Responses`` tab to the instructor dashboard, so the ``edx-platform`` branch/tag you're using must include this commit for the plugin to work properly:
 
-- https://github.com/mitodl/edx-platform/commit/91b24d30454a2a4042039486fd5499a7a7843d0c
+- https://github.com/mitodl/edx-platform/pull/275/commits/bcad8505918993dac7de099d8e9d48f868bceda7
 
 Dependencies
 ---------------


### PR DESCRIPTION
## Related tickets:
Recently noticed, the commits mentioned in `README.rst` were picked from the `mitx/maple` branch after the relevant PRs(https://github.com/mitodl/edx-platform/pull/274, https://github.com/mitodl/edx-platform/pull/275) were merged there believing they will persist as part of that branch. But recently these commits were removed from `mitx/maple` history showing these commit doesn't belong to any branch.

To fix: Since the PRs for both have only one commit each, So, I have now referred to the commits that are associated with the PR itself & not the `mitx/maple`.