### PR TITLE
feat: Add course export s3 plugin

### DIFF
--- a/src/ol_openedx_course_export/.coveragerc
+++ b/src/ol_openedx_course_export/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+data_file = .coverage
+source=ol_openedx_course_export
+omit =
+    test_settings
+    *migrations*
+    *admin.py
+    *static*
+    *templates*

--- a/src/ol_openedx_course_export/BUILD
+++ b/src/ol_openedx_course_export/BUILD
@@ -1,0 +1,19 @@
+python_library(
+    name="course_export",
+    dependencies=["src/ol_openedx_course_export/settings:course_export_settings"]
+)
+
+python_distribution(
+    name="course_export_package",
+    dependencies=[":course_export"],
+    provides=setup_py(
+        name="ol-openedx-course-export",
+        version="0.1.0",
+        description="An Open edX plugin to add API for course export to s3",
+        entry_points={
+            "lms.djangoapp": [],
+            "cms.djangoapp": ["ol_openedx_course_export = ol_openedx_course_export.app:CourseExportConfig"]
+        }
+    ),
+    setup_py_commands=["sdist", "bdist_wheel"]
+)

--- a/src/ol_openedx_course_export/CHANGELOG.rst
+++ b/src/ol_openedx_course_export/CHANGELOG.rst
@@ -1,0 +1,11 @@
+Change Log
+----------
+
+..
+   All enhancements and patches to ol_openedx_course_export will be documented
+   in this file.  It adheres to the structure of https://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+
+   This project adheres to Semantic Versioning (https://semver.org/).
+.. There should always be an "Unreleased" section for changes pending release.

--- a/src/ol_openedx_course_export/LICENSE.txt
+++ b/src/ol_openedx_course_export/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (C) 2022  MIT Open Learning
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/ol_openedx_course_export/MANIFEST.in
+++ b/src/ol_openedx_course_export/MANIFEST.in
@@ -1,0 +1,4 @@
+include CHANGELOG.rst
+include LICENSE.txt
+include README.rst
+recursive-include ol_openedx_course_export *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg *.py

--- a/src/ol_openedx_course_export/README.rst
+++ b/src/ol_openedx_course_export/README.rst
@@ -1,0 +1,89 @@
+Course Export S3 Plugin
+=============================
+
+A django app plugin to add a new API to Open edX to export courses to S3 buckets.
+
+
+Installation
+------------
+
+You can install this plugin into any Open edX instance by using any of the following methods:
+
+
+**Option 1: Install from PyPI**
+
+.. code-block::
+
+    # If running devstack in docker, first open a shell in CMS (make studio-shell)
+
+    pip install ol-openedx-course-export
+
+
+**Option 2: Build the package locally and install it**
+
+Follow these steps in a terminal on your machine:
+
+1. Navigate to ``open-edx-plugins`` directory
+2. If you haven't done so already, run ``./pants build``
+3. Run ``./pants package ::``. This will create a "dist" directory inside "open-edx-plugins" directory with ".whl" & ".tar.gz" format packages for all the "ol_openedx_*" plugins in "open-edx-plugins/src")
+4. Move/copy any of the ".whl" or ".tar.gz" files for this plugin that were generated in the above step to the machine/container running Open edX (NOTE: If running devstack via Docker, you can use ``docker cp`` to copy these files into your CMS container)
+5. Run a shell in the machine/container running Open edX, and install this plugin using pip
+
+Configuration
+------------
+
+**1) edx-platform configuration**
+
+You might need to add the following configuration values to the config file in Open edX. For any release after Juniper, that config file is ``/edx/etc/lms.yml``. These should be added to the top level. **Ask a fellow developer or devops for these values.**
+
+.. code-block::
+
+
+    AWS_ACCESS_KEY_ID: <your aws access id>
+    AWS_SECRET_ACCESS_KEY: <your api access key>
+    COURSE_IMPORT_EXPORT_BUCKET: <bucket name to export the courses to>
+
+
+How To Use
+----------
+The API supports a POST API call that accepts the list of course Ids and returns the uploaded paths of the courses on S3
+
+To call the API, Send a POST request to `<STUDIO_BASE>/api/courses/v0/export/` with the a payload with a list of course IDs that might look like:
+
+
+.. code-block::
+
+
+    {
+       "courses": ["course-v1:edX+DemoX+Demo_Course"]
+    }
+
+
+The successful response would look like:
+
+
+.. code-block::
+
+    With 200
+
+    {
+        "successful_uploads": {
+            "course-v1:edX+DemoX+Demo_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+DemoX+Demo_Course.tar.gz",
+            "course-v1:edX+Test+Test_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+Test+Test_Course.tar.gz"
+        },
+        "failed_uploads": {}
+    }
+
+    With 400
+
+    {
+        "successful_uploads": {
+            "course-v1:edX+DemoX+Demo_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+DemoX+Demo_Course.tar.gz",
+        },
+        "failed_uploads": {
+            "course-v1:edX+Test+Test_Course": "Error message"
+        }
+    }
+
+
+The response will contain either the s3 bucket url for successful uploads and/or an error message for failed uploads.

--- a/src/ol_openedx_course_export/__init__.py
+++ b/src/ol_openedx_course_export/__init__.py
@@ -1,0 +1,9 @@
+"""
+This is an integration of course export API.
+"""
+
+__version__ = "0.1.0"
+
+default_app_config = (
+    "ol_openedx_course_export.app.CourseExportConfig"  # pylint: disable=invalid-name
+)

--- a/src/ol_openedx_course_export/app.py
+++ b/src/ol_openedx_course_export/app.py
@@ -1,0 +1,33 @@
+"""
+Course Export Application Configuration
+"""
+
+from django.apps import AppConfig
+from edx_django_utils.plugins import PluginSettings, PluginURLs
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
+
+
+class CourseExportConfig(AppConfig):
+    """
+    Configuration class for course export app
+    """
+
+    name = "ol_openedx_course_export"
+
+    plugin_app = {
+        PluginURLs.CONFIG: {
+            ProjectType.CMS: {
+                PluginURLs.NAMESPACE: "",
+                PluginURLs.REGEX: "^api/courses/v0/export/",
+                PluginURLs.RELATIVE_PATH: "urls",
+            }
+        },
+        PluginSettings.CONFIG: {
+            ProjectType.CMS: {
+                SettingsType.PRODUCTION: {
+                    PluginSettings.RELATIVE_PATH: "settings.production"
+                },
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
+            }
+        },
+    }

--- a/src/ol_openedx_course_export/constants.py
+++ b/src/ol_openedx_course_export/constants.py
@@ -1,0 +1,1 @@
+AWS_S3_DEFAULT_URL_PREFIX = "s3.amazonaws.com"

--- a/src/ol_openedx_course_export/s3_client.py
+++ b/src/ol_openedx_course_export/s3_client.py
@@ -1,0 +1,28 @@
+import boto3
+from django.conf import settings
+
+from ol_openedx_course_export.utils import get_file_name_with_extension
+
+
+class S3Client:
+    def __init__(self):
+        self.client = self.get_s3_client()
+
+    @staticmethod
+    def get_s3_client():
+        return boto3.resource(
+            "s3",
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        )
+
+    def upload_course_s3(self, course_tar, course_id):
+        self.client.Bucket(settings.COURSE_IMPORT_EXPORT_BUCKET).put_object(
+            Key=f"{get_file_name_with_extension(course_id)}", Body=course_tar
+        )
+
+    def get_bucket_url(self):
+        """Returns a URL for the bucket, which is then used to add in the API response"""
+        return self.client.get_bucket_location(
+            Bucket=settings.COURSE_IMPORT_EXPORT_BUCKET
+        )

--- a/src/ol_openedx_course_export/settings/BUILD
+++ b/src/ol_openedx_course_export/settings/BUILD
@@ -1,0 +1,1 @@
+python_library(name="course_export_settings")

--- a/src/ol_openedx_course_export/settings/common.py
+++ b/src/ol_openedx_course_export/settings/common.py
@@ -1,0 +1,5 @@
+"""Common settings unique to the course export plugin."""
+
+
+def plugin_settings(settings):
+    """Settings for the course export s3 location plugin."""

--- a/src/ol_openedx_course_export/settings/production.py
+++ b/src/ol_openedx_course_export/settings/production.py
@@ -1,0 +1,5 @@
+"""Production settings unique to the course export plugin."""
+
+
+def plugin_settings(settings):
+    """Settings for the course export plugin."""

--- a/src/ol_openedx_course_export/urls.py
+++ b/src/ol_openedx_course_export/urls.py
@@ -1,0 +1,11 @@
+"""
+Course export API endpoint urls.
+"""
+
+from django.urls import re_path
+
+from ol_openedx_course_export.views import CourseExportView
+
+urlpatterns = [
+    re_path(r"^", CourseExportView.as_view(), name="course_export"),
+]

--- a/src/ol_openedx_course_export/utils.py
+++ b/src/ol_openedx_course_export/utils.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+
+from ol_openedx_course_export.constants import AWS_S3_DEFAULT_URL_PREFIX
+
+
+def is_bucket_configuration_valid():
+    """
+    For course export to work properly we need all the AWS settings configured properly
+    """
+    return (
+        settings.COURSE_IMPORT_EXPORT_BUCKET is not None
+        and settings.COURSE_IMPORT_EXPORT_BUCKET.strip() != ""
+    )
+
+
+def get_file_name_with_extension(course_id):
+    """
+    Args:
+        course_id: (str) course_id of the generated course tarball/OLX file
+        e.g. 'course-v1:edX+DemoX+Demo_Course'
+    Returns:
+        str: Returns the file name with file extension suffix .tar.gz
+    """
+    return course_id + ".tar.gz"
+
+
+def get_aws_file_url(course_id):
+    """
+    Args:
+        course_id: (str) course_id of the generated course tarball/OLX file
+        e.g. 'course-v1:edX+DemoX+Demo_Course'
+    Returns:
+        str: Returns the S3 specific access URL for the file
+    """
+
+    return f"https://{settings.COURSE_IMPORT_EXPORT_BUCKET}.{AWS_S3_DEFAULT_URL_PREFIX}/{get_file_name_with_extension(course_id)}"

--- a/src/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/views.py
@@ -1,0 +1,131 @@
+"""Views for Course Export"""
+
+import logging
+
+from botocore.exceptions import ClientError
+from cms.djangoapps.contentstore.api.views.course_import import (
+    CourseImportExportViewMixin,
+)
+from cms.djangoapps.contentstore.tasks import create_export_tarball
+from opaque_keys.edx.keys import CourseKey
+from rest_framework import status
+from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+from xmodule.modulestore.django import modulestore
+
+from ol_openedx_course_export.s3_client import S3Client
+from ol_openedx_course_export.utils import (
+    get_aws_file_url,
+    is_bucket_configuration_valid,
+)
+
+log = logging.getLogger(__name__)
+
+
+class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
+    """
+    An API View to export courses to S3 buckets instead of local storage
+
+    **Example Requests**
+
+    POST /api/courses/v0/export/
+
+    **POST Parameters**
+
+    A POST request must include a JSON list of course Ids to be exported
+    e.g. A sample payload might look like below:
+    {
+        "courses": ["course-v1:edX+DemoX+Demo_Course", "course-v1:edX+Test+Test_Course"]
+    }
+
+    **Example POST Response**
+    The API will return two types of response codes in general
+    200, 400
+
+    A 200 with successful_uploads when all the passed courses IDs were uploaded successfully
+
+    {
+        "successful_uploads": {
+            "course-v1:edX+DemoX+Demo_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+DemoX+Demo_Course.tar.gz",
+            "course-v1:edX+Test+Test_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+Test+Test_Course.tar.gz"
+        },
+        "failed_uploads": {}
+    }
+
+    A 400 Will return in 2 cases:
+
+    1 - There is an error with API parameters or AWS configuration. The response will be edX basic API error response
+
+    2- When there is error in any or all passed course IDs related to uploading or generating a course OLX
+        {
+        "successful_uploads": {
+            "course-v1:edX+DemoX+Demo_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+DemoX+Demo_Course.tar.gz",
+        },
+        "failed_uploads": {
+            "course-v1:edX+Test+Test_Course": "Error message"
+        }
+    }
+
+    """
+
+    http_method_names = ["post"]
+    permission_classes = [
+        IsAdminUser,
+    ]
+
+    def post(self, request):
+        """
+        This will take list of course id as param and will export them to S3
+        """
+        if not is_bucket_configuration_valid():
+            raise self.api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                developer_message="COURSE_IMPORT_EXPORT_BUCKET value is not configured properly",
+                error_code="internal_error",
+            )
+
+        # Course Ids of the courses to be uploaded
+        course_ids = request.data.get("courses", [])
+        if not course_ids:
+            raise self.api_error(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                developer_message="No course Id was provided",
+                error_code="internal_error",
+            )
+
+        successful_course_uploads = {}
+        failed_course_uploads = {}
+        s3_client = S3Client()
+
+        for course_id in course_ids:
+            try:
+                course_key = CourseKey.from_string(course_id)
+                module_store = modulestore()
+                course_module = module_store.get_course(course_key)
+                course_tarball = create_export_tarball(
+                    course_module, course_key, {}, None
+                )
+                s3_client.upload_course_s3(
+                    course_tar=course_tarball, course_id=course_id
+                )
+                successful_course_uploads[course_id] = get_aws_file_url(course_id)
+
+            except ClientError as e:
+                log.exception(
+                    f"Course export {course_id}: A ClientError in course export:"
+                )
+                failed_course_uploads[course_id] = str(e)
+
+            except Exception as e:
+                log.exception(f"Course export {course_id}: An Error in course export:")
+                failed_course_uploads[course_id] = str(e)
+
+        response_data = {
+            "successful_uploads": successful_course_uploads,
+            "failed_uploads": failed_course_uploads,
+        }
+
+        if not failed_course_uploads:
+            return Response(response_data, status=status.HTTP_200_OK)
+        return Response(response_data, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Related Ticket:
#27 

## What this PR does?
- Add basic architecture of a django plugin for edX
- Adds a new API to generate OLX course exports and upload to s3

## How should this be tested?
-  Generate a build for the package. We are using 'Pants' for that. Run `./pants package ::` in the main directory in the terminal which will generate many `.tar.gz & .whl` packages for you.
- Run `make studio-shell` and install `ol-openedx-coruse-course.*` (.gz or .whl)
-  You need to set the configuration values for the S3/AWS. e.g. set proper values for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `COURSE_IMPORT_EXPORT_BUCKET`. (All of these can be set in `private.py`)
- You will need a django admin user to test this API otherwise you would not be authorized
- Check access by calling the API without `Authorization` header and notice `400 with authorization error message`
- Check access with `Authorization` header with a token of some non admin User and `notice 400 with the error message`
- Call the API without setting AWS settings or bucket name, You should see a `400 with the proper error message`
- Now call the API (`<STUDIO_BASE>/api/courses/v0/export/`) and POST course IDs like:
```
{
   "courses": ["course-v1:edX+DemoX+Demo_Course", "course-v1:edX+Test+Test_Course"]
}
```
- If everything is set properly you should be able to notice a `200` status code with response something like:
```
{
    "successful_uploads": {
        "course-v1:edX+DemoX+Demo_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+DemoX+Demo_Course.tar.gz",
        "course-v1:edX+Test+Test_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+Test+Test_Course.tar.gz"
    },
    "failed_uploads": {}
} 
```

- If `COURSE_IMPORT_EXPORT_BUCKET` is set to `courseexports`, That means your courses will be uploaded/exported to a bucket named `courseexports`.
- The API is authenticated and only permitted to admin users so that Access Token you use should belong to an admin user. (be mindful of this while hitting the API).


## Reviewer Note:
- The API uploads the courses synchronously, I decided to make it synchronous since it is going to be a part of a pipeline and we might look on waiting for the API to properly respond because we are looking for the uploaded location URLs for the posted cours IDs.