### PR TITLE
feat: add external checkout api plugin

### DIFF
--- a/src/ol_openedx_checkout_external/.coveragerc
+++ b/src/ol_openedx_checkout_external/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+data_file = .coverage
+source=ol_openedx_checkout_external
+omit =
+    test_settings
+    *migrations*
+    *admin.py
+    *static*
+    *templates*

--- a/src/ol_openedx_checkout_external/BUILD
+++ b/src/ol_openedx_checkout_external/BUILD
@@ -1,0 +1,18 @@
+python_sources(
+    name="external_checkout",
+    dependencies=["src/ol_openedx_checkout_external/settings:checkout_external_settings"]
+)
+
+python_distribution(
+    name="checkout_external_package",
+    dependencies=[":external_checkout"],
+    provides=setup_py(
+        name="ol-openedx-checkout-external",
+        version="0.1.0",
+        description="An Open edX plugin to add API for external checkouts",
+        entry_points={
+            "lms.djangoapp": ["ol_openedx_checkout_external = ol_openedx_checkout_external.app:ExternalCheckoutConfig"],
+            "cms.djangoapp": []
+        }
+    ),
+)

--- a/src/ol_openedx_checkout_external/CHANGELOG.rst
+++ b/src/ol_openedx_checkout_external/CHANGELOG.rst
@@ -1,0 +1,11 @@
+Change Log
+----------
+
+..
+   All enhancements and patches to ol_openedx_checkout_external will be documented
+   in this file.  It adheres to the structure of https://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+
+   This project adheres to Semantic Versioning (https://semver.org/).
+.. There should always be an "Unreleased" section for changes pending release.

--- a/src/ol_openedx_checkout_external/LICENSE.txt
+++ b/src/ol_openedx_checkout_external/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (C) 2022  MIT Open Learning
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/ol_openedx_checkout_external/MANIFEST.in
+++ b/src/ol_openedx_checkout_external/MANIFEST.in
@@ -1,0 +1,4 @@
+include CHANGELOG.rst
+include LICENSE.txt
+include README.rst
+recursive-include ol_openedx_checkout_external *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg *.py

--- a/src/ol_openedx_checkout_external/README.rst
+++ b/src/ol_openedx_checkout_external/README.rst
@@ -1,0 +1,82 @@
+External Checkout Plugin
+=============================
+
+A django app plugin to add a new API to Open edX for external checkouts.
+The plugin redirects the user the desired external ecommerce service upon clicking the **Upgrade** button in LMS dashboard or Learning MFE.
+
+
+Installation
+------------
+
+You can install this plugin into any Open edX instance by using any of the following methods:
+
+
+**Option 1: Install from PyPI**
+
+.. code-block::
+
+    # If running devstack in docker, first open a shell in LMS (make lms-shell)
+
+    pip install ol-openedx-checkout-external
+
+
+**Option 2: Build the package locally and install it**
+
+Follow these steps in a terminal on your machine:
+
+1. Navigate to ``open-edx-plugins`` directory
+2. If you haven't done so already, run ``./pants build``
+3. Run ``./pants package ::``. This will create a "dist" directory inside "open-edx-plugins" directory with ".whl" & ".tar.gz" format packages for all the "ol_openedx_*" plugins in "open-edx-plugins/src")
+4. Move/copy any of the ".whl" or ".tar.gz" files for this plugin that were generated in the above step to the machine/container running Open edX (NOTE: If running devstack via Docker, you can use ``docker cp`` to copy these files into your LMS container)
+5. Run a shell in the machine/container running Open edX, and install this plugin using pip
+
+Configuration
+------------
+
+**1) edx-platform configuration**
+
+You might need to add the following configuration values to the config file in Open edX. For any release after Juniper, that config file is ``/edx/etc/lms.yml``. These should be added to the top level. **Ask a fellow developer or devops for these values.**
+
+.. code-block::
+
+
+    1) MARKETING_SITE_CHECKOUT_URL=<checkout url of marketing site> # This settings is not part of Open Edx, It's added by this plugin
+    2) ECOMMERCE_PUBLIC_URL_ROOT=<LMS_BASE_URL> (Because we want to use external ecommerce using this API plugin for redirection)
+    3) Create an new ecommerce configuration in http://<LMS_BASE>/admin/commerce/commerceconfiguration with "basket_checkout_page=/checkout-external/" in the above ecommerce configuration
+
+
+How To Use
+----------
+
+The API supports a GET call with sku as query parameter.
+
+**API Request**
+
+To manually call the API, Send a GET request to `<LMS_BASE>/checkout-external?sku=<sku_id>`:
+
+A sample request looks like below:
+
+.. code-block::
+
+
+    http://localhost:18000/checkout-external?sku=ABC45F
+
+
+**API Response**
+
+The successful response would be a redirect to the marketing site with 302 status code:
+
+
+.. code-block::
+
+    With 302 (If your marketing checkout URL is "https://<marketing_site_base>/checkout")
+
+    The resulting redirect would be:
+    https://<marketing_site_base>/checkout/?course_id=<course_id against the sku in CourseMode>
+
+    With 400
+
+    {
+        "developer_message": "<Message for the developer>",
+        "error_code": "internal_error"
+    }

--- a/src/ol_openedx_checkout_external/__init__.py
+++ b/src/ol_openedx_checkout_external/__init__.py
@@ -1,0 +1,7 @@
+"""
+This is an integration external checkout API.
+"""
+
+__version__ = "0.1.0"
+
+default_app_config = "ol_openedx_checkout_external.app.ExternalCheckoutConfig"  # pylint: disable=invalid-name

--- a/src/ol_openedx_checkout_external/app.py
+++ b/src/ol_openedx_checkout_external/app.py
@@ -1,0 +1,33 @@
+"""
+External checkout application configuration
+"""
+
+from django.apps import AppConfig
+from edx_django_utils.plugins import PluginSettings, PluginURLs
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
+
+
+class ExternalCheckoutConfig(AppConfig):
+    """
+    Configuration class for external checkout app
+    """
+
+    name = "ol_openedx_checkout_external"
+
+    plugin_app = {
+        PluginURLs.CONFIG: {
+            ProjectType.LMS: {
+                PluginURLs.NAMESPACE: "",
+                PluginURLs.REGEX: "^checkout-external/",
+                PluginURLs.RELATIVE_PATH: "urls",
+            }
+        },
+        PluginSettings.CONFIG: {
+            ProjectType.LMS: {
+                SettingsType.PRODUCTION: {
+                    PluginSettings.RELATIVE_PATH: "settings.production"
+                },
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
+            }
+        },
+    }

--- a/src/ol_openedx_checkout_external/exceptions.py
+++ b/src/ol_openedx_checkout_external/exceptions.py
@@ -1,0 +1,11 @@
+"""Exceptions for External Checkout plugin"""
+
+
+class ExternalCheckoutError(Exception):
+    """
+    Convenience exception class for external checkout errors
+    """
+
+    def __init__(self, message):
+        # Force the lazy i18n values to turn into actual unicode objects
+        super().__init__(str(message))

--- a/src/ol_openedx_checkout_external/settings/BUILD
+++ b/src/ol_openedx_checkout_external/settings/BUILD
@@ -1,0 +1,1 @@
+python_sources(name="checkout_external_settings")

--- a/src/ol_openedx_checkout_external/settings/common.py
+++ b/src/ol_openedx_checkout_external/settings/common.py
@@ -1,0 +1,6 @@
+"""Common settings unique to the external checkout plugin."""
+
+
+def plugin_settings(settings):
+    """Settings for the external checkout plugin."""
+    settings.MARKETING_SITE_CHECKOUT_URL = None

--- a/src/ol_openedx_checkout_external/settings/production.py
+++ b/src/ol_openedx_checkout_external/settings/production.py
@@ -1,0 +1,6 @@
+"""Production settings unique to the external checkout plugin."""
+
+
+def plugin_settings(settings):
+    """Settings for the external checkout plugin."""
+    settings.MARKETING_SITE_CHECKOUT_URL = None

--- a/src/ol_openedx_checkout_external/urls.py
+++ b/src/ol_openedx_checkout_external/urls.py
@@ -1,0 +1,11 @@
+"""
+External checkout API endpoint urls.
+"""
+
+from django.urls import re_path
+
+from ol_openedx_checkout_external.views import external_checkout
+
+urlpatterns = [
+    re_path(r"^", external_checkout, name="checkout_external"),
+]

--- a/src/ol_openedx_checkout_external/views.py
+++ b/src/ol_openedx_checkout_external/views.py
@@ -1,0 +1,67 @@
+"""Views for External Checkout"""
+
+import logging
+
+from common.djangoapps.course_modes.models import CourseMode
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.http import Http404, HttpResponseRedirect
+
+from ol_openedx_checkout_external.exceptions import ExternalCheckoutError
+
+log = logging.getLogger(__name__)
+
+
+@login_required
+def external_checkout(request):
+    """
+    An API View for external checkout that redirects to the marketing site for checkout
+
+    **Example Requests**
+
+    GET /checkout-external/?sku=TESTSKU
+
+    **Example Responses**
+
+    The API will return two types of response codes in general
+    302, 404, 500
+
+    A 302 redirect for the marketing site checkout would be returned in case the request was successful
+
+    A 404 would be returned in case there is no sku matching products
+
+    A 500 would be returned if there are any configuration errors
+    """
+
+    if request.method != "GET":
+        raise NotImplementedError("API only supports GET requests")
+
+    if not settings.MARKETING_SITE_CHECKOUT_URL:
+        raise ExternalCheckoutError(
+            "MARKETING_SITE_CHECKOUT_URL value is not configured properly"
+        )
+
+    product_sku = request.GET.get("sku")
+
+    if not product_sku:
+        log.error("No Product SKU was found")
+        raise Http404
+
+    course_modes = CourseMode.objects.filter(sku=product_sku)
+    if not course_modes:
+        log.error(
+            f"No CourseMode was found against the given product SKU ({product_sku})"
+        )
+        raise Http404
+
+    # Because there is no unique constraint on SKU, so there could be multiple CourseModes with same SKU
+    if len(course_modes) > 1:
+        raise ExternalCheckoutError(
+            f"Found multiple CourseModes for the same SKU ({product_sku})"
+        )
+
+    #  Generate a URL to redirect to marketing site based on its checkout URL with and added
+    #  course ID query param)
+    course_id = str(course_modes.first().course.id)
+    redirect_url = f"{settings.MARKETING_SITE_CHECKOUT_URL}?course_id={course_id}"
+    return HttpResponseRedirect(redirect_to=redirect_url)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#28 

#### What's this PR do?
- Adds an API to map SKU to external checkout pages.
- Adds a new configuration to set custom external checkout URL for the marketing site
Based on the above, The API works as the alternate to the built-in eCommerce of edX by taking the upgrade URLs request in place of edX's eCommerce, customizes the URL w.r.t the external website with added params, and redirecting the user to that.

#### How should this be manually tested?
You can test the API with steps mentioned in the README (https://github.com/mitodl/open-edx-plugins/tree/arslan/28-external-checkout/src/ol_openedx_checkout_external)

_for TLDR;_
1) Generate & install the plugin with [common instructions](https://github.com/mitodl/open-edx-plugins/tree/arslan/28-external-checkout/src/ol_openedx_checkout_external#installation)
 2) In `private.py` set `MARKETING_SITE_CHECKOUT_URL=http://mitxonline.odl.local:8013/checkout/` # This setting is not part of Open Edx, It's added by this plugin
3) In `private.py` set `ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:18000'` (Because we want to use external eCommerce using this API plugin for redirection)
4) Create an new ecommerce configuration in `http://<LMS_BASE>/admin/commerce/commerceconfiguration` with "basket_checkout_page=/checkout-external/"
5) Create a CourseMode entry for your test course by visiting `http://localhost:18000/admin/course_modes/coursemode/` and adding some value for the SKU.
6) Enroll in your test course and click `Upgrade` button in the dashboard or learning MFE. You should be redirected to the checkout page of MITxOnline e.g. (`http://mitxonline.odl.local:8013/checkout/?course_id=test_course_id`).


#### Where should the reviewer start?
Plugin build generation and configurations

