### PR TITLE
perf: enhance course export to use celery tasks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - --remove-unused-variables
     - --remove-all-unused-imports
 - repo: https://github.com/Yelp/detect-secrets
-  rev: v1.1.0
+  rev: v1.2.0
   hooks:
   - id: detect-secrets
     args:

--- a/src/ol_openedx_course_export/s3_client.py
+++ b/src/ol_openedx_course_export/s3_client.py
@@ -5,11 +5,13 @@ from ol_openedx_course_export.utils import get_file_name_with_extension
 
 
 class S3Client:
-    def __init__(self):
-        self.client = self.get_s3_client()
+    client = None
 
-    @staticmethod
-    def get_s3_client():
+    def __init__(self):
+        if not self.client:
+            self.client = self.get_s3_client()
+
+    def get_s3_client(self):
         return boto3.resource(
             "s3",
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,

--- a/src/ol_openedx_course_export/tasks.py
+++ b/src/ol_openedx_course_export/tasks.py
@@ -1,0 +1,49 @@
+"""
+This file contains celery tasks related to S3 course export plugin.
+"""
+import logging
+
+from botocore.exceptions import ClientError
+from celery import shared_task  # pylint: disable=import-error
+from cms.djangoapps.contentstore.tasks import CourseExportTask, create_export_tarball
+from opaque_keys.edx.keys import CourseKey
+from user_tasks.models import UserTaskStatus
+from xmodule.modulestore.django import modulestore
+
+from ol_openedx_course_export.s3_client import S3Client
+
+log = logging.getLogger(__name__)
+
+
+@shared_task(base=CourseExportTask, bind=True)
+def task_upload_course_s3(self, user_id, course_key_string):
+    """
+    A task to generate course tarball and upload to s3 bucket, Also creates task status object to keep track of the
+    task updates.
+    The status update implementation of (UserTaskStatus) edX also sends an email to the initiator of the export request
+    upon completion.
+
+    Args:
+        user_id (int): Id of the user who initiated the request
+        course_key_string (str): Key of the course to be uploaded
+
+    Returns:
+        task_id, Just starts a task and returns it's id as part of Celery's base implementation. Used for status updates
+    """
+    try:
+        self.status.set_state(UserTaskStatus.IN_PROGRESS)
+        s3_client = S3Client()
+        course_key = CourseKey.from_string(course_key_string)
+        module_store = modulestore()
+        course_module = module_store.get_course(course_key)
+        course_tarball = create_export_tarball(course_module, course_key, {}, None)
+        s3_client.upload_course_s3(
+            course_tar=course_tarball, course_id=course_key_string
+        )
+        self.status.set_state(UserTaskStatus.SUCCEEDED)
+    except ClientError as ex:
+        log.exception(
+            f"Course export {course_key_string}: A ClientError in course export:"
+        )
+        if self.status.state != UserTaskStatus.FAILED:
+            self.status.fail({"raw_error_msg": str(ex)})

--- a/src/ol_openedx_course_export/urls.py
+++ b/src/ol_openedx_course_export/urls.py
@@ -2,10 +2,16 @@
 Course export API endpoint urls.
 """
 
+from django.conf import settings
 from django.urls import re_path
 
 from ol_openedx_course_export.views import CourseExportView
 
 urlpatterns = [
+    re_path(
+        rf"^{settings.COURSE_ID_PATTERN}/$",
+        CourseExportView.as_view(),
+        name="course_export_status",
+    ),
     re_path(r"^", CourseExportView.as_view(), name="course_export"),
 ]

--- a/src/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/views.py
@@ -2,19 +2,18 @@
 
 import logging
 
-from botocore.exceptions import ClientError
 from cms.djangoapps.contentstore.api.views.course_import import (
     CourseImportExportViewMixin,
 )
-from cms.djangoapps.contentstore.tasks import create_export_tarball
-from opaque_keys.edx.keys import CourseKey
+from cms.djangoapps.contentstore.tasks import CourseExportTask
+from openedx.core.lib.api.view_utils import verify_course_exists
 from rest_framework import status
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
-from xmodule.modulestore.django import modulestore
+from user_tasks.models import UserTaskStatus
 
-from ol_openedx_course_export.s3_client import S3Client
+from ol_openedx_course_export.tasks import task_upload_course_s3
 from ol_openedx_course_export.utils import (
     get_aws_file_url,
     is_bucket_configuration_valid,
@@ -30,6 +29,7 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
     **Example Requests**
 
     POST /api/courses/v0/export/
+    GET /api/courses/v0/export/{course_id}/?task_id={task_id}
 
     **POST Parameters**
 
@@ -46,10 +46,14 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
     A 200 with successful_uploads when all the passed courses IDs were uploaded successfully
 
     {
-        "successful_uploads": {
+        "upload_urls": {
             "course-v1:edX+DemoX+Demo_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+DemoX+Demo_Course.tar.gz",
             "course-v1:edX+Test+Test_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+Test+Test_Course.tar.gz"
         },
+        "upload_task_ids": {
+            "course-v1:edX+DemoX+Demo_Course"": "3f609080-3b68-460e-a660-473d7e6b096e",
+            "course-v1:edX+Test+Test_Course": "bdae40e1-426a-4276-9409-020987545871"
+        }
         "failed_uploads": {}
     }
 
@@ -59,7 +63,7 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
 
     2- When there is error in any or all passed course IDs related to uploading or generating a course OLX
         {
-        "successful_uploads": {
+        "upload_urls": {
             "course-v1:edX+DemoX+Demo_Course": "https://bucket_name.s3.amazonaws.com/course-v1:edX+DemoX+Demo_Course.tar.gz",
         },
         "failed_uploads": {
@@ -67,9 +71,32 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
         }
     }
 
+    **GET Parameters**
+
+    A GET request must include the following parameters.
+
+    * task_id: (required) The UUID of the task to check, e.g. "3f609080-3b68-460e-a660-473d7e6b096e"
+
+    **GET Response Values**
+
+        If the import task is found successfully by the UUID provided, an HTTP
+        200 "OK" response is returned.
+
+        The HTTP 200 response has the following values.
+
+        * state: String description of the state of the task
+
+
+    **Example GET Response**
+
+        {
+            "state": "Succeeded"
+        }
+
+
     """
 
-    http_method_names = ["post"]
+    http_method_names = ["get", "post"]
     permission_classes = [
         IsAdminUser,
     ]
@@ -94,38 +121,45 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
                 error_code="internal_error",
             )
 
-        successful_course_uploads = {}
+        course_upload_urls = {}
         failed_course_uploads = {}
-        s3_client = S3Client()
-
+        upload_task_ids = {}
         for course_id in course_ids:
             try:
-                course_key = CourseKey.from_string(course_id)
-                module_store = modulestore()
-                course_module = module_store.get_course(course_key)
-                course_tarball = create_export_tarball(
-                    course_module, course_key, {}, None
-                )
-                s3_client.upload_course_s3(
-                    course_tar=course_tarball, course_id=course_id
-                )
-                successful_course_uploads[course_id] = get_aws_file_url(course_id)
-
-            except ClientError as e:
-                log.exception(
-                    f"Course export {course_id}: A ClientError in course export:"
-                )
-                failed_course_uploads[course_id] = str(e)
-
+                task_detail = task_upload_course_s3.delay(request.user.id, course_id)
+                course_upload_urls[course_id] = get_aws_file_url(course_id)
+                upload_task_ids[course_id] = task_detail.task_id
             except Exception as e:
-                log.exception(f"Course export {course_id}: An Error in course export:")
+                log.exception(f"Course export {course_id}: An error has occurred:")
                 failed_course_uploads[course_id] = str(e)
 
         response_data = {
-            "successful_uploads": successful_course_uploads,
+            "upload_urls": course_upload_urls,
+            "upload_task_ids": upload_task_ids,
             "failed_uploads": failed_course_uploads,
         }
 
         if not failed_course_uploads:
             return Response(response_data, status=status.HTTP_200_OK)
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+
+    @verify_course_exists()
+    def get(self, request, course_id):
+        """
+        Check the status of the specified task
+        """
+        try:
+            task_id = request.GET["task_id"]
+            args = {"course_key_string": course_id}
+            name = CourseExportTask.generate_name(args)
+            task_status = UserTaskStatus.objects.filter(
+                name=name, task_id=task_id
+            ).first()
+            return Response({"state": task_status.state})
+        except Exception as e:
+            log.exception(str(e))
+            raise self.api_error(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                developer_message=str(e),
+                error_code="internal_error",
+            )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-edx-plugins/issues/27

#### What's this PR do?
- As the next part of the course export enhancement we attempted running the course export in separate celery tasks to avoid any timeout issues that we see. (This is something similar that the existing course export functionality is doing, and we intend to follow the same track in our plugin)
- Trying to implement course export tasks and structure that would match Open edX's local course export but support the celery tasks for exporting courses to s3.
- Add a new API to `GET` the status of the running tasks by course key & task ID

#### How should this be manually tested?
- Install the plugin through the steps mentioned in the Readme of the plugin (Or the steps mentioned in https://github.com/mitodl/open-edx-plugins/pull/29)
- Configure the required AWS keys mentioned in https://github.com/mitodl/open-edx-plugins/pull/29

**1) Now test the POST API with an admin User** 
    - API: `http://localhost:18010/api/courses/v0/export/`
    -  Sample Payload: `{"courses": ["course-v1:MIT+MIT_IK_0001+R1", "course-v1:MIT+MIT_RR_002+R1"}`
    - Sample Response: 
```
{
    "upload_urls": {
        "course-v1:MIT+MIT_IK_0001+R1": "https://defaultcourseexports.s3.amazonaws.com/course-v1:MIT+MIT_IK_0001+R1.tar.gz",
        "course-v1:MIT+MIT_RR_002+R1": "https://defaultcourseexports.s3.amazonaws.com/course-v1:MIT+MIT_RR_002+R1.tar.gz",
    },
    "upload_task_ids": {
        "course-v1:MIT+MIT_IK_0001+R1": "0bc21ee1-1679-407f-839d-3527f38535d6",
        "course-v1:MIT+MIT_RR_002+R1": "dfbc05c1-30f6-4f23-b7f7-d101079cf27d",
    },
    "failed_uploads": {}
}
```


**2) Now test the new GET API:**
    - API: `http://localhost:18010/api/courses/v0/export/<course_id>/?task_id=<task_id>` (You will get both in the result of above POST request)
    - Test the response which could be something like 
```
{
    "state": "Succeeded"
}
(Other responses could be `Failed`, `In Progress`)
``` 

#### Where should the reviewer start?
- Plugin installation and configurations

#### Any background context you want to provide?
We recently implemented course export to s3 feat. The feat was initially implemented as a `synchronous operation` because it was going to run within a Pipeline and keeping it synchronous and returning the upload results when the API was successful was an initial requirement. But we saw some timeout issues when the course sizes are big. So, we decided to enhance the plugin to use celery tasks to upload the course. More details on https://github.com/mitodl/open-edx-plugins/issues/27 & https://github.com/mitodl/open-edx-plugins/pull/29

**Steps to setup celery worker locally:**
1. Set this if it is not already set in devstack_with_worker.py
`BROKER_URL = 'redis://:password@edx.devstack.redis:6379/'`
2. update docker-compose file of devstack and change cms service setting to devstack_with_worker
3. `make dev.up.redis`
4. dev.stop
5. dev.up
6. in new terminal run celery worker using this command `DJANGO_SETTINGS_MODULE=cms.envs.devstack_with_worker celery worker --app=cms.celery:APP -l=DEBUG`


It appears edx has wrong values for  CELERY_QUEUES  setting in /edx/etc/lms.yml
 if we change the value of that setting to this workers work as expected
  'edx.lms.core.default',
    'edx.lms.core.high',
    'edx.lms.core.high_mem'

might have to set C_FORCE_ROOT environment variable to allow running celery worker with root user



### Reviewer Note:
1) After this PR An email would be sent upon task completion for every course, this will happen because we are reusing some part of the existing course export from Open Edx. For 

**Some References:**
- Email sending implementation task that runs after a user task completion single is sent [Ref](https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/cms_user_tasks/tasks.py#L24)
- Existing course export celery based implementation can be seen in [Here](https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/contentstore/views/import_export.py#L337) and [Here](https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/contentstore/tasks.py#L294)