### PR TITLE
chore: fix deprecated celery task

### DIFF
--- a/src/ol_openedx_canvas_integration/tasks.py
+++ b/src/ol_openedx_canvas_integration/tasks.py
@@ -3,7 +3,7 @@ import hashlib
 import logging
 from functools import partial
 
-from celery import shared_task  # pylint: disable=import-error
+from celery import shared_task
 from lms.djangoapps.instructor_task.api_helper import submit_task
 from lms.djangoapps.instructor_task.tasks_base import BaseInstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.runner import run_main_task

--- a/src/ol_openedx_canvas_integration/tasks.py
+++ b/src/ol_openedx_canvas_integration/tasks.py
@@ -3,7 +3,7 @@ import hashlib
 import logging
 from functools import partial
 
-from celery import task
+from celery import shared_task  # pylint: disable=import-error
 from lms.djangoapps.instructor_task.api_helper import submit_task
 from lms.djangoapps.instructor_task.tasks_base import BaseInstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.runner import run_main_task
@@ -35,7 +35,7 @@ def run_sync_canvas_enrollments(
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-@task(base=BaseInstructorTask)
+@shared_task(base=BaseInstructorTask)
 def sync_canvas_enrollments_task(entry_id, xmodule_instance_args):
     """
     Fetch enrollments from canvas and update
@@ -62,7 +62,7 @@ def run_push_edx_grades_to_canvas(request, course_id):
     return submit_task(request, task_type, task_class, course_id, task_input, task_key)
 
 
-@task(base=BaseInstructorTask)
+@shared_task(base=BaseInstructorTask)
 def push_edx_grades_to_canvas_task(entry_id, xmodule_instance_args):
     """
     Push edX grades to Canvas


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#37 

#### What's this PR do?
- Replaces the usage of deprecated `celery.task` with `celery.shared_task` (More details on the associated ticket)

#### How should this be manually tested?
- First of all, you should get to [mitx/maple](https://github.com/mitodl/edx-platform/tree/mitx/maple) branch of edx-platform
- Install this plugin as per the docs mentioned in https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_canvas_integration
- Make sure that the celery tasks are being called properly.

