### PR TITLE
feat: serve rapid_response_reports assets and add instructor tab from plugin

### DIFF
--- a/src/ol_openedx_rapid_response_reports/BUILD
+++ b/src/ol_openedx_rapid_response_reports/BUILD
@@ -1,13 +1,20 @@
 python_sources(
     name="rapid_response_plugin_dependencies",
+    dependencies=["src/ol_openedx_rapid_response_reports/settings:rapid_response_settings"],
+)
+
+resources(
+  name="rapid_response_plugin_templates",
+  sources=[],
+  dependencies=["src/ol_openedx_rapid_response_reports/templates:rapid_response_templates"]
 )
 
 python_distribution(
     name="rapid_response_plugin_dist",
-    dependencies=[":rapid_response_plugin_dependencies"],
+    dependencies=[":rapid_response_plugin_dependencies", ":rapid_response_plugin_templates"],
     provides=setup_py(
         name="ol-openedx-rapid-response-reports",
-        version="0.1.0",
+        version="0.2.0",
         description="An Open edX plugin to add rapid response reports support",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_rapid_response_reports/README.rst
+++ b/src/ol_openedx_rapid_response_reports/README.rst
@@ -9,7 +9,9 @@ A django app plugin for edx-platform to enable "Rapid Response Reports" function
 
 **NOTE:**
 
-We had to make some changes to edx-platform itself in order to add the ``Rapid Responses`` tab to the instructor dashboard, so the ``edx-platform`` branch/tag you're using must include this commit for the plugin to work properly:
+If you are using `Nutmeg <https://github.com/openedx/edx-platform/tree/open-release/nutmeg.master>`_ release of open edX, You can skip the cherry-picking step mentioned below and just use ``0.2.0`` version of the plugin. For any releases prior to ``Nutmeg`` please keep reading below.
+
+(For Open edX releases prior to `Nutmeg`) We had to make some changes to edx-platform itself in order to add the ``Rapid Responses`` tab to the instructor dashboard, so the ``edx-platform`` branch/tag you're using must include this commit for the plugin to work properly:
 
 - https://github.com/mitodl/edx-platform/pull/275/commits/bcad8505918993dac7de099d8e9d48f868bceda7
 

--- a/src/ol_openedx_rapid_response_reports/app.py
+++ b/src/ol_openedx_rapid_response_reports/app.py
@@ -3,11 +3,10 @@ ol_openedx_rapid_response_reports Django application initialization.
 """
 
 from django.apps import AppConfig
-from edx_django_utils.plugins import PluginContexts, PluginURLs
+from edx_django_utils.plugins import PluginContexts, PluginSettings, PluginURLs
+from lms.djangoapps.instructor.constants import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from openedx.core.constants import COURSE_ID_PATTERN
-from openedx.core.djangoapps.plugins.constants import ProjectType
-
-from ol_openedx_rapid_response_reports.constants import RAPID_RESPONSE_PLUGIN_VIEW_NAME
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 
 
 class RapidResponsePluginConfig(AppConfig):
@@ -25,9 +24,16 @@ class RapidResponsePluginConfig(AppConfig):
                 PluginURLs.RELATIVE_PATH: "urls",
             }
         },
+        PluginSettings.CONFIG: {
+            ProjectType.LMS: {
+                SettingsType.PRODUCTION: {
+                    PluginSettings.RELATIVE_PATH: "settings.production"
+                },
+            }
+        },
         PluginContexts.CONFIG: {
             ProjectType.LMS: {
-                RAPID_RESPONSE_PLUGIN_VIEW_NAME: "ol_openedx_rapid_response_reports.context_api.plugin_context"
+                INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME: "ol_openedx_rapid_response_reports.context_api.plugin_context"
             }
         },
     }

--- a/src/ol_openedx_rapid_response_reports/context_api.py
+++ b/src/ol_openedx_rapid_response_reports/context_api.py
@@ -1,14 +1,27 @@
+"""
+ol_openedx_rapid_response_reports Django application plugin context initialization.
+"""
+
 from django.utils.translation import ugettext as _
 from rapid_response_xblock.utils import get_run_data_for_course
+from web_fragments.fragment import Fragment
 
 
 def plugin_context(context):
     """Provide data for the rapid responses dashboard section"""
-    course_key = context["course_key"]
-    return {
+    course_key = context["course"].id
+    sections = context.get("sections", [])
+
+    rapid_response_context = {
         "section_key": "rapid_response",
         "section_display_name": _("Rapid Responses"),
         "problem_runs": get_run_data_for_course(course_key=course_key),
         "course_key": course_key,
         "download_url": "get_rapid_response_report",
+        "fragment": Fragment(),
+        "template_path_prefix": "/",
     }
+    sections.append(rapid_response_context)
+    context["sections"] = sections
+
+    return context

--- a/src/ol_openedx_rapid_response_reports/settings/BUILD
+++ b/src/ol_openedx_rapid_response_reports/settings/BUILD
@@ -1,0 +1,1 @@
+python_sources(name="rapid_response_settings")

--- a/src/ol_openedx_rapid_response_reports/settings/production.py
+++ b/src/ol_openedx_rapid_response_reports/settings/production.py
@@ -1,0 +1,13 @@
+"""Production settings unique to the rapid response plugin."""
+
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+def plugin_settings(settings):
+    """Settings for the rapid response plugin."""
+    PLUGIN_TEMPLATES_ROOT = os.path.join(BASE_DIR, "templates")
+    for template_engine in settings.TEMPLATES:
+        template_dirs = template_engine["DIRS"]
+        template_dirs.append(PLUGIN_TEMPLATES_ROOT)

--- a/src/ol_openedx_rapid_response_reports/templates/BUILD
+++ b/src/ol_openedx_rapid_response_reports/templates/BUILD
@@ -1,0 +1,4 @@
+resources(
+  name="rapid_response_templates",
+  sources=["*.html"],
+)

--- a/src/ol_openedx_rapid_response_reports/templates/rapid_response.html
+++ b/src/ol_openedx_rapid_response_reports/templates/rapid_response.html
@@ -1,0 +1,30 @@
+<%page args="section_data" expression_filter="h"/>
+<%!
+from itertools import groupby
+
+from django.utils.translation import ugettext as _
+from django.urls import reverse
+
+from lms.djangoapps.courseware.courses import get_course_by_id
+from ol_openedx_rapid_response_reports.utils import get_display_name_from_usage_key
+%>
+
+
+<div>
+    <% course = get_course_by_id(section_data['course_key'], depth=None) %>
+    % for date,runs in groupby(section_data['problem_runs'],key=lambda x:x['created'].date()):
+    <ul>
+        <li>${date.strftime('%Y/%m/%d')}</li>
+        <ul>
+            % for run in runs:
+            <li>${get_display_name_from_usage_key(run['problem_usage_key'], course)} - ${run['created'].strftime('%I:%M:%S %p')}:
+                <a type="button" class="btn-link"
+                   href="${reverse('get_rapid_response_report', kwargs={'course_id': section_data['course_key'], 'run_id': run['id']})}">
+                    ${_("Download")}
+                </a>
+            </li>
+            % endfor
+        </ul>
+    </ul>
+    % endfor
+</div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#50 

#### What's this PR do?
- Adds settings for templates based on pants
- Adds templates for rapid response reports
- Updates the context_api to support context that the `Instructor dashboard` can understand
- Add settings for serving templates through pants
- Updates dependencies for templates

#### How should this be manually tested?
(For installation steps you can look at the plugin's readme file -- Also note that you will need to restart your lms e.g. `make lms-restart` once you install the plugin)
- Just install the plugin and it should work without any cherry-pick as mentioned in README.
- You should be able to load the `Rapid Responses` tab and download the reports

#### RELEASE NOTES:
- After the plugin is installed we will need to compile assets(`make lms-static`) otherwise we might see missing assets/JS errors and things might not work properly.

#### Screenshots:
The `Rapid Responses` tab you see now comes without any commit cherry-pick. 🥳 

<img width="1679" alt="Screenshot 2022-05-13 at 11 06 53 AM" src="https://user-images.githubusercontent.com/34372316/168221488-61c1ab97-15e2-4da3-b304-ec7e3d08feb6.png">

