### PR TITLE
feat: serve assets from plugin - nutmeg support

### DIFF
--- a/src/ol_openedx_canvas_integration/BUILD
+++ b/src/ol_openedx_canvas_integration/BUILD
@@ -3,12 +3,24 @@ python_sources(
     dependencies=["src/ol_openedx_canvas_integration/settings:canvas_settings"],
 )
 
+resources(
+  name="canvas_plugin_templates",
+  sources=[],
+  dependencies=["src/ol_openedx_canvas_integration/templates:canvas_templates"]
+)
+
+resources(
+  name="canvas_plugin_js",
+  sources=[],
+  dependencies=["src/ol_openedx_canvas_integration/static/js:canvas_js"]
+)
+
 python_distribution(
     name="canvas_integration_package",
-    dependencies=[":canvas_integration"],
+    dependencies=[":canvas_integration", ":canvas_plugin_templates", ":canvas_plugin_js"],
     provides=setup_py(
         name="ol-openedx-canvas-integration",
-        version="0.1.1",
+        version="0.2.0",
         description="An Open edX plugin to add canvas integration support",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -9,8 +9,13 @@ We had to make some changes to edx-platform itself in order to add the "Canvas" 
 
 The ``edx-platform`` branch/tag you're using must include below commit for ``ol-openedx-canvas-integration`` plugin to work properly:
 
+**For any release prior to `Nutmeg` you should cherry-pick this commit:**
+
 - https://github.com/mitodl/edx-platform/pull/274/commits/97a51d208f3cdfd26df0a62281b0964de10ff40a
 
+**For Nutmeg release or more recent, you should cherry-pick this commit**
+
+- https://github.com/mitodl/edx-platform/pull/297/commits/a802833193e490beab301491d82894e19907f9fe
 
 Installation
 ------------

--- a/src/ol_openedx_canvas_integration/app.py
+++ b/src/ol_openedx_canvas_integration/app.py
@@ -3,7 +3,8 @@ Canvas Integration Application Configuration
 """
 
 from django.apps import AppConfig
-from edx_django_utils.plugins import PluginSettings, PluginURLs
+from edx_django_utils.plugins import PluginContexts, PluginSettings, PluginURLs
+from lms.djangoapps.instructor.constants import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from openedx.core.constants import COURSE_ID_PATTERN
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 
@@ -29,6 +30,11 @@ class CanvasIntegrationConfig(AppConfig):
                     PluginSettings.RELATIVE_PATH: "settings.production"
                 },
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
+            }
+        },
+        PluginContexts.CONFIG: {
+            ProjectType.LMS: {
+                INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME: "ol_openedx_canvas_integration.context_api.plugin_context"
             }
         },
     }

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -1,0 +1,47 @@
+"""
+The initialization of the context for the Canvas Integration Plugin
+"""
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from web_fragments.fragment import Fragment
+
+
+def plugin_context(context):
+    """Provide context based data for Canvas Integration plugin (For Instructor Dashboard)"""
+    fragment = Fragment()
+    course = context.get("course")
+
+    fragment.add_javascript_url(staticfiles_storage.url("/js/canvas_integration.js"))
+
+    canvas_context = {
+        "section_key": "canvas_integration",
+        "section_display_name": _("Canvas"),
+        "course": context["course"],
+        "add_canvas_enrollments_url": reverse(
+            "add_canvas_enrollments", kwargs={"course_id": course.id}
+        ),
+        "list_canvas_enrollments_url": reverse(
+            "list_canvas_enrollments", kwargs={"course_id": course.id}
+        ),
+        "list_canvas_assignments_url": reverse(
+            "list_canvas_assignments", kwargs={"course_id": course.id}
+        ),
+        "list_canvas_grades_url": reverse(
+            "list_canvas_grades", kwargs={"course_id": course.id}
+        ),
+        "list_instructor_tasks_url": "{}?include_canvas=true".format(
+            reverse("list_instructor_tasks", kwargs={"course_id": course.id})
+        ),
+        "push_edx_grades_url": reverse(
+            "push_edx_grades", kwargs={"course_id": course.id}
+        ),
+        "fragment": fragment,
+        "template_path_prefix": "/",
+    }
+
+    sections = context.get("sections", [])
+    sections.append(canvas_context)
+    context["sections"] = sections
+
+    return context

--- a/src/ol_openedx_canvas_integration/settings/production.py
+++ b/src/ol_openedx_canvas_integration/settings/production.py
@@ -1,5 +1,9 @@
 """Production settings unique to canvas integration plugin."""
 
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
 
 def plugin_settings(settings):
     """Settings for the canvas integration plugin."""
@@ -9,3 +13,8 @@ def plugin_settings(settings):
     settings.CANVAS_BASE_URL = settings.ENV_TOKENS.get(
         "CANVAS_BASE_URL", settings.CANVAS_BASE_URL
     )
+
+    PLUGIN_TEMPLATES_ROOT = os.path.join(BASE_DIR, "templates")
+    for template_engine in settings.TEMPLATES:
+        template_dirs = template_engine["DIRS"]
+        template_dirs.append(PLUGIN_TEMPLATES_ROOT)

--- a/src/ol_openedx_canvas_integration/static/js/BUILD
+++ b/src/ol_openedx_canvas_integration/static/js/BUILD
@@ -1,0 +1,4 @@
+resources(
+  name="canvas_js",
+  sources=["*.js"],
+)

--- a/src/ol_openedx_canvas_integration/static/js/canvas_integration.js
+++ b/src/ol_openedx_canvas_integration/static/js/canvas_integration.js
@@ -1,0 +1,201 @@
+/* globals _, edx */
+
+(function($, _) {  // eslint-disable-line wrap-iife
+    'use strict';
+    var PendingInstructorTasks = function() {
+        return window.InstructorDashboard.util.PendingInstructorTasks;
+    };
+    var ReportDownloads = function() {
+        return window.InstructorDashboard.util.ReportDownloads;
+    };
+
+    var CanvasIntegration = (function() {
+        function tableify(data) {
+            var keys = Object.keys(data[0]);
+            var keysLookup = {};
+            keys.forEach(function(key, i) {
+                keysLookup[key] = i;
+            });
+
+            var rows = data.map(function(dict) {
+                var cols = keys.map(function(key) { return '<td>'.concat(dict[key], '</td>'); }).join('');
+                return '<tr>'.concat(cols, '</tr>');
+            }).join('');
+            var headerRow = '<tr>'.concat(keys.map(function(key) {
+                return '<th>'.concat(key, '</th>');
+            }).join(''), '</tr>');
+            return '<table>'.concat(headerRow, rows, '</table>');
+        }
+
+        function InstructorDashboardCanvasIntegration($section) {
+            this.$section = $section;
+            this.$section.data('wrapper', this);
+            var $results = this.$section.find('#results');
+            var $errors = this.$section.find('#errors');
+            var $loading = this.$section.find('#loading');
+            var $listEnrollmentsBtn = this.$section.find(
+          "input[name='list-canvas-enrollments']"
+        );
+            var $mergeCanvasEnrollmentsBtn = this.$section.find(
+          "input[name='merge-canvas-enrollments']"
+        );
+            var $overloadCanvasEnrollmentsBtn = this.$section.find(
+          "input[name='overload-canvas-enrollments']"
+        );
+            var $loadCanvasAssignmentsBtn = this.$section.find(
+          "input[name='load-canvas-assignments']"
+        );
+            var $listCanvasGradesBtn = this.$section.find("input[name='list-canvas-grades']");
+            var $canvasAssignSection = this.$section.find('#canvas-assignment-section');
+            var $pushAllEdxGradesBtn = this.$section.find("input[name='push-all-edx-grades']");
+            var $assignmentInput = this.$section.find("select[name='assignment-id']");
+            this.report_downloads = new (ReportDownloads())(this.$section);
+            this.instructor_tasks = new (PendingInstructorTasks())(this.$section);
+
+            var setLoading = function() {
+                $errors.html('');
+                $results.html('');
+                $loading.show();
+            };
+            var stopLoading = function() {
+                $loading.hide();
+            };
+            var showErrors = function(error) {
+                $loading.hide();
+                $results.html('');
+                // xss-lint: disable=javascript-jquery-html
+                $errors.html('Error: <pre>'.concat(JSON.stringify(error, null, 4), '</pre>'));
+            };
+            var showResults = function(title, asTable) {
+                return function(data) {
+                    var results = asTable ? tableify(data) : (
+              '<pre>'.concat(JSON.stringify(data, null, 4), '</pre>')
+            );
+                    $loading.hide();
+                    $errors.html('');
+                    // xss-lint: disable=javascript-jquery-html
+                    $results.html(title.concat(': ', results));
+                };
+            };
+
+            var mergeHandler = function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    url: url,
+                    data: {unenroll_current: $el.data('unenroll-current')}
+                }).then(
+            showResults('Status', false)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            };
+
+            $mergeCanvasEnrollmentsBtn.click(mergeHandler);
+            $overloadCanvasEnrollmentsBtn.click(mergeHandler);
+            $listEnrollmentsBtn.click(function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'GET',
+                    dataType: 'json',
+                    url: url
+                }).then(
+            showResults('Enrollments on Canvas', true)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+            $loadCanvasAssignmentsBtn.click(function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                $canvasAssignSection.hide();
+                return $.ajax({
+                    type: 'GET',
+                    dataType: 'json',
+                    url: url
+                }).then(function(assignments) {
+                    $canvasAssignSection.show();
+                    $assignmentInput.empty();
+                    assignments.forEach(function(assignment) {
+                        var $option = $('<option />');
+                        $option.val(assignment.id).text(assignment.name);
+                        $assignmentInput.append($option);
+                    });
+                }).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+            $listCanvasGradesBtn.click(function(event) {
+                var assignmentId = parseInt($assignmentInput.val());
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'GET',
+                    dataType: 'json',
+                    url: url,
+                    data: {
+                        assignment_id: assignmentId
+                    }
+                }).then(
+            showResults('Grades on Canvas', false)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+            $pushAllEdxGradesBtn.click(function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    url: url
+                }).then(
+            showResults('Grade Update Results', false)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+        }
+        InstructorDashboardCanvasIntegration.prototype.onClickTitle = function() {
+            this.instructor_tasks.task_poller.start();
+            return this.report_downloads.downloads_poller.start();
+        };
+
+        InstructorDashboardCanvasIntegration.prototype.onExit = function() {
+            this.instructor_tasks.task_poller.stop();
+            return this.report_downloads.downloads_poller.stop();
+        };
+
+        return InstructorDashboardCanvasIntegration;
+    }());
+
+    _.defaults(window, {
+        InstructorDashboard: {}
+    });
+
+    _.defaults(window.InstructorDashboard, {
+        sections: {}
+    });
+
+    _.defaults(window.InstructorDashboard.sections, {
+        CanvasIntegration: CanvasIntegration
+    });
+}).call(this, $, _);

--- a/src/ol_openedx_canvas_integration/templates/BUILD
+++ b/src/ol_openedx_canvas_integration/templates/BUILD
@@ -1,0 +1,4 @@
+resources(
+  name="canvas_templates",
+  sources=["*.html"],
+)

--- a/src/ol_openedx_canvas_integration/templates/canvas_integration.html
+++ b/src/ol_openedx_canvas_integration/templates/canvas_integration.html
@@ -1,0 +1,58 @@
+<%page args="section_data" expression_filter="h"/>
+<%namespace name='static' file='../../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<section>
+    <h4 class="hd hd-4">${_("Canvas enrollments")}</h4>
+    <p>
+
+        <input type="button" name="list-canvas-enrollments" value="List enrollments on Canvas"
+               data-endpoint="${ section_data['list_canvas_enrollments_url'] }"/>
+    </p>
+    <p>
+        <input type="button" name="merge-canvas-enrollments" value="Merge enrollment list using Canvas"
+               data-endpoint="${ section_data['add_canvas_enrollments_url'] }" data-unenroll-current="false"/>
+        <input type="button" name="overload-canvas-enrollments" value="Overload enrollment list using Canvas"
+               data-endpoint="${ section_data['add_canvas_enrollments_url'] }" data-unenroll-current="true"/>
+    </p>
+    <hr/>
+    <h4 class="hd hd-4">${_("Export grades to Canvas")}</h4>
+    <p>
+        <input type="button" name="push-all-edx-grades"
+               value="Push all MITx grades to Canvas"
+               data-endpoint="${ section_data['push_edx_grades_url'] }"
+        />&nbsp;
+        <input type="button" name="load-canvas-assignments"
+               value="Load Canvas assignments"
+               data-endpoint="${ section_data['list_canvas_assignments_url'] }"
+        />
+    </p>
+    <p id="canvas-assignment-section" style="display: none;">
+        <label for="assignment_id">Assignment id: </label>
+        <select name="assignment-id" id="assignment_id"></select>
+        <br /><br />
+        <input type="button" name="list-canvas-grades"
+               value="List Canvas assignment grades"
+               data-endpoint="${ section_data['list_canvas_grades_url'] }"
+        />
+    </p>
+    <hr/>
+    <div id="loading" style="display: none;">
+        <img src="${static.url('images/spinner.gif')}" alt="Loading..." />
+    </div>
+    <div id="errors" class="errors"></div>
+    <div id="results"></div>
+%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+  <div class="running-tasks-container action-type-container">
+    <h3 class="hd hd-3">${_("Pending Tasks")}</h3>
+    <div class="running-tasks-section">
+      <p>${_("The status for any active tasks appears in a table below.")} </p>
+      <br />
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
+  </div>
+%endif
+</section>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#13 

#### What's this PR do?
- Integrations the context api
- Adds the assets within the plugin
- adds configurations to serve the assets from the plugin
- will add configurations for pants build

#### How should this be manually tested?
- Setup edx-platform on nutmeg release
- cherry-pick the commit (A shortened version of the commit will be added once the PR is finalized because the current cherry-pick mentioned in this plugin's readme has all the things that won't be needed after this migration but some will still be there)
- Install the plugin

#### Where should the reviewer start?
- Setting up edx-platform on Nutmeg

#### RELEASE NOTE:
- We might need to compile assets(`make lms-static`) once this plugin is released and installed on the platform. Otherwise we might notice assets issues like we used to face in past.

#### Any background context you want to provide?
When we added this plugin in the first place, edX won't support serving the assets right from within the plugin. That support was added in the recent Nutmeg release so it's the right time to migrate this plugin and reduce it's cherry-picking to minimum

#### Screenshots (if appropriate)
<img width="1660" alt="Screenshot 2022-05-18 at 1 44 54 PM" src="https://user-images.githubusercontent.com/34372316/168997712-75c71131-41a8-4947-8a84-e462d53160cf.png">
