### PR TITLE
fix: load configuration from env_tokens for checkout plugin

### DIFF
--- a/src/ol_openedx_checkout_external/BUILD
+++ b/src/ol_openedx_checkout_external/BUILD
@@ -8,7 +8,7 @@ python_distribution(
     dependencies=[":external_checkout"],
     provides=setup_py(
         name="ol-openedx-checkout-external",
-        version="0.1.0",
+        version="0.1.1",
         description="An Open edX plugin to add API for external checkouts",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_checkout_external/settings/production.py
+++ b/src/ol_openedx_checkout_external/settings/production.py
@@ -3,4 +3,6 @@
 
 def plugin_settings(settings):
     """Settings for the external checkout plugin."""
-    settings.MARKETING_SITE_CHECKOUT_URL = None
+    settings.MARKETING_SITE_CHECKOUT_URL = settings.ENV_TOKENS.get(
+        "MARKETING_SITE_CHECKOUT_URL", settings.MARKETING_SITE_CHECKOUT_URL
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
None (When the checkout plugin was deployed we noticed that the configuration added by the plugin was not getting picked up in the actual edX environment)

#### What's this PR do?
- loads the configuration values from the extended edX settings.

#### How should this be manually tested?
Nothing specific to test but it should load the configuration value in an actual edX instance.

#### Deployemnt:
I've bumped the version for this and we need to update and push a new release for this `ol-openedx-checkout-external` to PyPI followed by a rebuild of our edX MITxOnline-QA instance. @rhysyngsun @blarghmatey 

