### PR TITLE
Enhancement: Don't show Canvas tab if no associated Canvas Course ID is set

### DIFF
--- a/src/ol_openedx_canvas_integration/BUILD
+++ b/src/ol_openedx_canvas_integration/BUILD
@@ -20,7 +20,7 @@ python_distribution(
     dependencies=[":canvas_integration", ":canvas_plugin_templates", ":canvas_plugin_js"],
     provides=setup_py(
         name="ol-openedx-canvas-integration",
-        version="0.2.1",
+        version="0.2.2",
         description="An Open edX plugin to add canvas integration support",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -9,8 +9,15 @@ from web_fragments.fragment import Fragment
 
 def plugin_context(context):
     """Provide context based data for Canvas Integration plugin (For Instructor Dashboard)"""
-    fragment = Fragment()
+
     course = context.get("course")
+
+    # Don't add Canvas tab is the Instructor Dashboard if it doesn't have any associated
+    # canvas_course_id set from Canvas Service
+    if not course.canvas_course_id:
+        return
+
+    fragment = Fragment()
 
     fragment.add_javascript_url(staticfiles_storage.url("/js/canvas_integration.js"))
 


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
None - This is basically the implementation of https://github.com/mitodl/edx-platform/pull/266/files from platform to plugin

#### What's this PR do?
- Adds a check to show the Canvas tab only if there is an Associated Canvas Course ID set in the course through studio advanced settings.

#### How should this be manually tested?
- Follow the setup steps for Canvas
- Open any course that has no Canvas course id (Canvas tab shouldn't be shown)
- Now, go to Advanced settings for the course and set `Canvas Course ID` and reload the course (The Canvas tab should now be shown)
