### PR TITLE
fix: load JS as bytes and add to fragment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,3 +84,4 @@ repos:
     additional_dependencies:
     - types-pytz
     - types-requests
+    - types-pkg_resources

--- a/src/ol_openedx_canvas_integration/BUILD
+++ b/src/ol_openedx_canvas_integration/BUILD
@@ -20,7 +20,7 @@ python_distribution(
     dependencies=[":canvas_integration", ":canvas_plugin_templates", ":canvas_plugin_js"],
     provides=setup_py(
         name="ol-openedx-canvas-integration",
-        version="0.2.2",
+        version="0.2.3",
         description="An Open edX plugin to add canvas integration support",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -1,10 +1,24 @@
 """
 The initialization of the context for the Canvas Integration Plugin
 """
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from web_fragments.fragment import Fragment
+import pkg_resources
+
+
+def get_resource_bytes(path):
+    """
+    Helper method to get the unicode contents of a resource in this repo.
+
+    Args:
+        path (str): The path of the resource
+
+    Returns:
+        unicode: The unicode contents of the resource at the given path
+    """
+    resource_contents = pkg_resources.resource_string(__name__, path)
+    return resource_contents.decode('utf-8')
 
 
 def plugin_context(context):
@@ -18,8 +32,10 @@ def plugin_context(context):
         return
 
     fragment = Fragment()
+    # Adding JS as bytes (Inspired by what we are doing with Rapid Response xBlock)
+    fragment.add_javascript(get_resource_bytes("static/js//canvas_integration.js"))
 
-    fragment.add_javascript_url(staticfiles_storage.url("/js/canvas_integration.js"))
+    # fragment.add_javascript_url(staticfiles_storage.url("/js/canvas_integration.js"))
 
     canvas_context = {
         "section_key": "canvas_integration",

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -35,8 +35,6 @@ def plugin_context(context):
     # Adding JS as bytes (Inspired by what we are doing with Rapid Response xBlock)
     fragment.add_javascript(get_resource_bytes("static/js//canvas_integration.js"))
 
-    # fragment.add_javascript_url(staticfiles_storage.url("/js/canvas_integration.js"))
-
     canvas_context = {
         "section_key": "canvas_integration",
         "section_display_name": _("Canvas"),

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -33,7 +33,7 @@ def plugin_context(context):
 
     fragment = Fragment()
     # Adding JS as bytes (Inspired by what we are doing with Rapid Response xBlock)
-    fragment.add_javascript(get_resource_bytes("static/js//canvas_integration.js"))
+    fragment.add_javascript(get_resource_bytes("static/js/canvas_integration.js"))
 
     canvas_context = {
         "section_key": "canvas_integration",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
None, https://sentry.io/organizations/mit-office-of-digital-learning/issues/3317544672/?project=1757731&referrer=slack - When we moved assets to the plugin we started seeing SuspeciousPath error because it won't accept JS file path from outside of the MEDIA_ROOT.

#### What's this PR do?
- Inspired by Rapid Response xBlock - It adds the JS bytes to the fragment.

#### How should this be manually tested?
The Canvas Plugin should work without error, The Canvas tab should show.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)
