### PR TITLE
fix: quote course id before adding into redirect URL params

### DIFF
--- a/src/ol_openedx_checkout_external/BUILD
+++ b/src/ol_openedx_checkout_external/BUILD
@@ -8,7 +8,7 @@ python_distribution(
     dependencies=[":external_checkout"],
     provides=setup_py(
         name="ol-openedx-checkout-external",
-        version="0.1.1",
+        version="0.1.2",
         description="An Open edX plugin to add API for external checkouts",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_checkout_external/views.py
+++ b/src/ol_openedx_checkout_external/views.py
@@ -1,6 +1,7 @@
 """Views for External Checkout"""
 
 import logging
+from urllib.parse import quote
 
 from common.djangoapps.course_modes.models import CourseMode
 from django.conf import settings
@@ -62,6 +63,6 @@ def external_checkout(request):
 
     #  Generate a URL to redirect to marketing site based on its checkout URL with and added
     #  course ID query param)
-    course_id = str(course_modes.first().course.id)
+    course_id = quote(str(course_modes.first().course.id))
     redirect_url = f"{settings.MARKETING_SITE_CHECKOUT_URL}?course_id={course_id}"
     return HttpResponseRedirect(redirect_to=redirect_url)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/610

#### What's this PR do?
Quotes the course id before adding it to the query parameters in the redirect URL. This is needed because course IDs in edX contain reserved chars e.g. `+`. When the GET API in the marketing application gets the parameters it's then converted into a space that ends up not finding the course.

However, this could have been done on the marketing site using `quote_plus` but I figured it would be better to just `quote`
 it is in the plugins so that all the calling applications don't have to `quote_plus` the course Ids from the GET query params.

Currently, if the course id is `course-v1:MIT+MIT_GT_0001+1` it turns into `course-v1:MIT MIT_GT_0001 1` when we get it through request GET params.

For ref, take a look at [this](https://github.com/mitodl/mitxonline/blob/main/ecommerce/views/v0/__init__.py#L510) because this is how the `course_id` passed from will be obtained on the marketing site.

#### How should this be manually tested?
- If the course id was something like `course-v1:MIT+MIT_GT_0001+1` (This is how the Ids are in edX) it should be converted to something like `course-v1%3AMIT%2BMIT_GT_0001%2B1`.

