### PR TITLE
fix: use subsection format function instead of property

### DIFF
--- a/src/ol_openedx_canvas_integration/api.py
+++ b/src/ol_openedx_canvas_integration/api.py
@@ -99,7 +99,7 @@ def get_subsection_user_grades(course):
         for (
             graded_item_type,
             subsection_dict,
-        ) in course_grade.graded_subsections_by_format.items():
+        ) in course_grade.graded_subsections_by_format().items():
             for subsection_block_locator, subsection_grade in subsection_dict.items():
                 subsection_grade_dict[subsection_block_locator].update(
                     # Only include grades if the assignment/exam/etc. has been attempted


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/edx-platform/issues/298

#### What's this PR do?
- Refactors the usage of `graded_subsections_by_format` to be called like a function.

#### How should this be manually tested?
- Clicking `Push all MITs grades to canvas` should push the grades to canvas.

#### Any background context you want to provide?
- In response to some recent changes in the platform, [here](https://github.com/openedx/edx-platform/commit/a162140492d256be7cde5a53cb24ba221bc5cf5b#diff-f0d17d91bec07c249a69bfeb1b4be40078e8c433136af33644f429eeddcab9b3L74-R86)

