### PR TITLE
Update linting from Flake8 to Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,52 +31,22 @@ repos:
   hooks:
   - id: yamllint
     args: [--format, parsable, -d, relaxed]
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.2
-  hooks:
-  - id: pyupgrade
-    args:
-    - --py38-plus
-- repo: https://github.com/myint/autoflake/
-  rev: v1.7.7
-  hooks:
-  - id: autoflake
-    args:
-    - --in-place
-    - --ignore-init-module-imports
-    - --expand-star-imports
-    - --remove-unused-variables
-    - --remove-all-unused-imports
 - repo: https://github.com/Yelp/detect-secrets
   rev: v1.4.0
   hooks:
   - id: detect-secrets
     args:
     - --exclude-files '(poetry.lock|pants)'
-- repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
-- repo: https://github.com/asottile/yesqa
-  rev: v1.4.0
-  hooks:
-  - id: yesqa
-    additional_dependencies:
-    - git+https://github.com/wemake-services/wemake-python-styleguide#egg=wemake-python-styleguide
 - repo: https://github.com/psf/black
   rev: 22.10.0
   hooks:
   - id: black
-- repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  # Ruff version.
+  rev: 'v0.0.238'
   hooks:
-  - id: flake8
-    additional_dependencies:
-    - git+https://github.com/wemake-services/wemake-python-styleguide#egg=wemake-python-styleguide
-    args:
-    - --config=setup.cfg
-    - --extend-ignore=D1
-    - --diff
+  - id: ruff
+    args: [--extend-ignore=D1, --fix]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.991
   hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,18 +31,6 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "astor"
-version = "0.8.1"
-description = "Read/rewrite/write Python ASTs"
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-files = [
-    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
-    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
-]
-
-[[package]]
 name = "attrs"
 version = "22.2.0"
 description = "Classes Without Boilerplate"
@@ -89,29 +77,6 @@ files = [
 
 [package.extras]
 tzdata = ["tzdata"]
-
-[[package]]
-name = "bandit"
-version = "1.7.4"
-description = "Security oriented static analyser for python code."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "bandit-1.7.4-py3-none-any.whl", hash = "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"},
-    {file = "bandit-1.7.4.tar.gz", hash = "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
-GitPython = ">=1.0.1"
-PyYAML = ">=5.3.1"
-stevedore = ">=1.20.0"
-
-[package.extras]
-test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "toml"]
-toml = ["toml"]
-yaml = ["PyYAML"]
 
 [[package]]
 name = "billiard"
@@ -572,18 +537,6 @@ test-randomorder = ["pytest-randomly"]
 tox = ["tox"]
 
 [[package]]
-name = "darglint"
-version = "1.8.1"
-description = "A utility for ensuring Google-style docstrings stay up to date with the source code."
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4.0"
-files = [
-    {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
-    {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
-]
-
-[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -597,14 +550,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.1.6"
+version = "4.1.7"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Django-4.1.6-py3-none-any.whl", hash = "sha256:c6fe7ebe7c017fe59f1029821dae0acb5a2ddcd6c9a0138fd20a8bfefac914bc"},
-    {file = "Django-4.1.6.tar.gz", hash = "sha256:bceb0fe1a386781af0788cae4108622756cd05e7775448deec04a71ddf87685d"},
+    {file = "Django-4.1.7-py3-none-any.whl", hash = "sha256:f2f431e75adc40039ace496ad3b9f17227022e8b11566f4b363da44c7e44761e"},
+    {file = "Django-4.1.7.tar.gz", hash = "sha256:44f714b81c5f190d9d2ddad01a532fe502fa01c4cb8faf1d081f4264ed15dcd8"},
 ]
 
 [package.dependencies]
@@ -695,18 +648,6 @@ pymongo = ">=2.7.2,<4.0"
 stevedore = ">=0.14.1"
 
 [[package]]
-name = "eradicate"
-version = "2.1.0"
-description = "Removes commented-out code."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "eradicate-2.1.0-py3-none-any.whl", hash = "sha256:8bfaca181db9227dc88bdbce4d051a9627604c2243e7d85324f6d6ce0fd08bb2"},
-    {file = "eradicate-2.1.0.tar.gz", hash = "sha256:aac7384ab25b1bf21c4c012de9b4bf8398945a14c98c911545b2ea50ab558014"},
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.1.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -738,259 +679,15 @@ docs = ["furo (>=2022.12.7)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.1
 testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "flake8"
-version = "5.0.4"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = ">=3.6.1"
-files = [
-    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
-    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.9.0,<2.10.0"
-pyflakes = ">=2.5.0,<2.6.0"
-
-[[package]]
-name = "flake8-bandit"
-version = "4.1.1"
-description = "Automated security testing with bandit and flake8."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "flake8_bandit-4.1.1-py3-none-any.whl", hash = "sha256:4c8a53eb48f23d4ef1e59293657181a3c989d0077c9952717e98a0eace43e06d"},
-    {file = "flake8_bandit-4.1.1.tar.gz", hash = "sha256:068e09287189cbfd7f986e92605adea2067630b75380c6b5733dab7d87f9a84e"},
-]
-
-[package.dependencies]
-bandit = ">=1.7.3"
-flake8 = ">=5.0.0"
-
-[[package]]
-name = "flake8-broken-line"
-version = "0.6.0"
-description = "Flake8 plugin to forbid backslashes for line breaks"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "flake8-broken-line-0.6.0.tar.gz", hash = "sha256:a02268f11a18837c83c59013a36cc00fee9e17a042745cc0c9895f1c9f6acc16"},
-    {file = "flake8_broken_line-0.6.0-py3-none-any.whl", hash = "sha256:c0ab336ff7de228dbffbe56d67b3615bb21fb15f3ed0604fa7bdf9feb72d7d88"},
-]
-
-[package.dependencies]
-flake8 = ">=3.5,<6"
-
-[[package]]
-name = "flake8-bugbear"
-version = "22.12.6"
-description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-bugbear-22.12.6.tar.gz", hash = "sha256:4cdb2c06e229971104443ae293e75e64c6107798229202fbe4f4091427a30ac0"},
-    {file = "flake8_bugbear-22.12.6-py3-none-any.whl", hash = "sha256:b69a510634f8a9c298dfda2b18a8036455e6b19ecac4fe582e4d7a0abfa50a30"},
-]
-
-[package.dependencies]
-attrs = ">=19.2.0"
-flake8 = ">=3.0.0"
-
-[package.extras]
-dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit", "tox"]
-
-[[package]]
-name = "flake8-commas"
-version = "2.1.0"
-description = "Flake8 lint for trailing commas."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "flake8-commas-2.1.0.tar.gz", hash = "sha256:940441ab8ee544df564ae3b3f49f20462d75d5c7cac2463e0b27436e2050f263"},
-    {file = "flake8_commas-2.1.0-py2.py3-none-any.whl", hash = "sha256:ebb96c31e01d0ef1d0685a21f3f0e2f8153a0381430e748bf0bbbb5d5b453d54"},
-]
-
-[package.dependencies]
-flake8 = ">=2"
-
-[[package]]
-name = "flake8-comprehensions"
-version = "3.10.1"
-description = "A flake8 plugin to help you write better list/set/dict comprehensions."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-comprehensions-3.10.1.tar.gz", hash = "sha256:412052ac4a947f36b891143430fef4859705af11b2572fbb689f90d372cf26ab"},
-    {file = "flake8_comprehensions-3.10.1-py3-none-any.whl", hash = "sha256:d763de3c74bc18a79c039a7ec732e0a1985b0c79309ceb51e56401ad0a2cd44e"},
-]
-
-[package.dependencies]
-flake8 = ">=3.0,<3.2.0 || >3.2.0"
-
-[[package]]
-name = "flake8-debugger"
-version = "4.1.2"
-description = "ipdb/pdb statement checker plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-debugger-4.1.2.tar.gz", hash = "sha256:52b002560941e36d9bf806fca2523dc7fb8560a295d5f1a6e15ac2ded7a73840"},
-    {file = "flake8_debugger-4.1.2-py3-none-any.whl", hash = "sha256:0a5e55aeddcc81da631ad9c8c366e7318998f83ff00985a49e6b3ecf61e571bf"},
-]
-
-[package.dependencies]
-flake8 = ">=3.0"
-pycodestyle = "*"
-
-[[package]]
-name = "flake8-docstrings"
-version = "1.7.0"
-description = "Extension for flake8 which uses pydocstyle to check docstrings"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8_docstrings-1.7.0-py2.py3-none-any.whl", hash = "sha256:51f2344026da083fc084166a9353f5082b01f72901df422f74b4d953ae88ac75"},
-    {file = "flake8_docstrings-1.7.0.tar.gz", hash = "sha256:4c8cc748dc16e6869728699e5d0d685da9a10b0ea718e090b1ba088e67a941af"},
-]
-
-[package.dependencies]
-flake8 = ">=3"
-pydocstyle = ">=2.1"
-
-[[package]]
-name = "flake8-eradicate"
-version = "1.4.0"
-description = "Flake8 plugin to find commented out code"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "flake8-eradicate-1.4.0.tar.gz", hash = "sha256:3088cfd6717d1c9c6c3ac45ef2e5f5b6c7267f7504d5a74b781500e95cb9c7e1"},
-    {file = "flake8_eradicate-1.4.0-py3-none-any.whl", hash = "sha256:e3bbd0871be358e908053c1ab728903c114f062ba596b4d40c852fd18f473d56"},
-]
-
-[package.dependencies]
-attrs = "*"
-eradicate = ">=2.0,<3.0"
-flake8 = ">=3.5,<6"
-
-[[package]]
-name = "flake8-isort"
-version = "5.0.3"
-description = "flake8 plugin that integrates isort ."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-isort-5.0.3.tar.gz", hash = "sha256:0951398c343c67f4933407adbbfb495d4df7c038650c5d05753a006efcfeb390"},
-    {file = "flake8_isort-5.0.3-py3-none-any.whl", hash = "sha256:8c4ab431d87780d0c8336e9614e50ef11201bc848ef64ca017532dec39d4bf49"},
-]
-
-[package.dependencies]
-flake8 = "*"
-isort = ">=4.3.5,<6"
-
-[package.extras]
-test = ["pytest"]
-
-[[package]]
-name = "flake8-quotes"
-version = "3.3.2"
-description = "Flake8 lint for quotes."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "flake8-quotes-3.3.2.tar.gz", hash = "sha256:6e26892b632dacba517bf27219c459a8396dcfac0f5e8204904c5a4ba9b480e1"},
-]
-
-[package.dependencies]
-flake8 = "*"
-
-[[package]]
-name = "flake8-rst-docstrings"
-version = "0.3.0"
-description = "Python docstring reStructuredText (RST) validator for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-rst-docstrings-0.3.0.tar.gz", hash = "sha256:d1ce22b4bd37b73cd86b8d980e946ef198cfcc18ed82fedb674ceaa2f8d1afa4"},
-    {file = "flake8_rst_docstrings-0.3.0-py3-none-any.whl", hash = "sha256:f8c3c6892ff402292651c31983a38da082480ad3ba253743de52989bdc84ca1c"},
-]
-
-[package.dependencies]
-flake8 = ">=3"
-pygments = "*"
-restructuredtext-lint = "*"
-
-[package.extras]
-develop = ["build", "twine"]
-
-[[package]]
-name = "flake8-string-format"
-version = "0.3.0"
-description = "string format checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "flake8-string-format-0.3.0.tar.gz", hash = "sha256:65f3da786a1461ef77fca3780b314edb2853c377f2e35069723348c8917deaa2"},
-    {file = "flake8_string_format-0.3.0-py2.py3-none-any.whl", hash = "sha256:812ff431f10576a74c89be4e85b8e075a705be39bc40c4b4278b5b13e2afa9af"},
-]
-
-[package.dependencies]
-flake8 = "*"
-
-[[package]]
-name = "gitdb"
-version = "4.0.10"
-description = "Git Object Database"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "gitdb-4.0.10-py3-none-any.whl", hash = "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"},
-    {file = "gitdb-4.0.10.tar.gz", hash = "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a"},
-]
-
-[package.dependencies]
-smmap = ">=3.0.1,<6"
-
-[[package]]
-name = "gitpython"
-version = "3.1.30"
-description = "GitPython is a python library used to interact with Git repositories"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "GitPython-3.1.30-py3-none-any.whl", hash = "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"},
-    {file = "GitPython-3.1.30.tar.gz", hash = "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8"},
-]
-
-[package.dependencies]
-gitdb = ">=4.0.1,<5"
-
-[[package]]
 name = "identify"
-version = "2.5.17"
+version = "2.5.18"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.17-py2.py3-none-any.whl", hash = "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed"},
-    {file = "identify-2.5.17.tar.gz", hash = "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"},
+    {file = "identify-2.5.18-py2.py3-none-any.whl", hash = "sha256:93aac7ecf2f6abf879b8f29a8002d3c6de7086b8c28d88e1ad15045a15ab63f9"},
+    {file = "identify-2.5.18.tar.gz", hash = "sha256:89e144fa560cc4cffb6ef2ab5e9fb18ed9f9b3cb054384bab4b95c12f6c309fe"},
 ]
 
 [package.extras]
@@ -1195,18 +892,6 @@ rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
@@ -1322,21 +1007,6 @@ files = [
 ]
 
 [[package]]
-name = "pep8-naming"
-version = "0.13.3"
-description = "Check PEP-8 naming conventions, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pep8-naming-0.13.3.tar.gz", hash = "sha256:1705f046dfcd851378aac3be1cd1551c7c1e5ff363bacad707d43007877fa971"},
-    {file = "pep8_naming-0.13.3-py3-none-any.whl", hash = "sha256:1a86b8c71a03337c97181917e2b472f0f5e4ccb06844a0d6f0a33522549e7a80"},
-]
-
-[package.dependencies]
-flake8 = ">=5.0.0"
-
-[[package]]
 name = "pkginfo"
 version = "1.9.6"
 description = "Query metadata from sdists / bdists / installed packages."
@@ -1445,18 +1115,6 @@ files = [
 test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
-name = "pycodestyle"
-version = "2.9.1"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
-    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1466,36 +1124,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
-]
-
-[[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-snowballstemmer = ">=2.2.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.3)"]
-
-[[package]]
-name = "pyflakes"
-version = "2.5.0"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
-    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
 
 [[package]]
@@ -1666,7 +1294,7 @@ files = [
 cffi = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5)", "sphinx_rtd_theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
@@ -1695,14 +1323,14 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.
 
 [[package]]
 name = "python-json-logger"
-version = "2.0.5"
+version = "2.0.6"
 description = "A python library adding a json log formatter"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "python-json-logger-2.0.5.tar.gz", hash = "sha256:3853e0b73e6c1ba4b1f2543066b24950bf1c21ed104f297a7bff8c74532a6ab2"},
-    {file = "python_json_logger-2.0.5-py3-none-any.whl", hash = "sha256:f389ccb0a8fd26f84c294dc627a999daf58f759b457ee022f698098f6547288d"},
+    {file = "python-json-logger-2.0.6.tar.gz", hash = "sha256:ed33182c2b438a366775c25c1219ebbd5bd7f71694c644d6b3b3861e19565ae3"},
+    {file = "python_json_logger-2.0.6-py3-none-any.whl", hash = "sha256:3af8e5b907b4a5b53cae249205ee3a3d3472bd7ad9ddfaec136eec2f2faf4995"},
 ]
 
 [[package]]
@@ -1837,20 +1465,6 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "restructuredtext-lint"
-version = "1.4.0"
-description = "reStructuredText linter"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "restructuredtext_lint-1.4.0.tar.gz", hash = "sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"},
-]
-
-[package.dependencies]
-docutils = ">=0.11,<1.0"
-
-[[package]]
 name = "rfc3986"
 version = "2.0.0"
 description = "Validating URI References per RFC 3986"
@@ -1884,6 +1498,32 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "ruff"
+version = "0.0.246"
+description = "An extremely fast Python linter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.246-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:2474a805c4244cfaf0390a745a0c5ea9e5452f52fbce0be74930fece8bd40b90"},
+    {file = "ruff-0.0.246-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:5839a213a90220845693c95d7e6a19ab26751b9e37047ef8f4a58dc49230c817"},
+    {file = "ruff-0.0.246-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:589aff453085cad28b8d1f517161a6b37a6d359cda419f64c009e0f7ff424d72"},
+    {file = "ruff-0.0.246-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:529a7d72f48331b97367cd6d42273f3cafa764d9373e74b75561367135958546"},
+    {file = "ruff-0.0.246-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca7d1ee44144460ae119a6212aaff77a671a5729d543b981c786c052011cdfe3"},
+    {file = "ruff-0.0.246-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ebe6052bc87ee51d84af231ccd27e5338fdc30d8bf49e51bdcfceb44c51c5625"},
+    {file = "ruff-0.0.246-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8173a00766b88b47431e8e744f577d06c6c52c0e18181ac29a701a9d5c035b39"},
+    {file = "ruff-0.0.246-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:45cde6f9df94fb393ffeeada2daca279569b9d53d1d95d49b9b5b418fe70bd23"},
+    {file = "ruff-0.0.246-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:468f282e26d1845f4a06dcd76fdc355f4288208e6b97f061951a7ffd6725102e"},
+    {file = "ruff-0.0.246-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:67d5fa9abdcb764a7cee242fb65e303662c9cb80104a2dd0657e96fca8a7c6d8"},
+    {file = "ruff-0.0.246-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:64af553f8ff4d1f51a24104ac8f81b5ce6df9c230d776fa4dd22db96699efdb0"},
+    {file = "ruff-0.0.246-py3-none-musllinux_1_2_i686.whl", hash = "sha256:734ff8fef2e7105cf6946e525b3e8cbed035edc9d58c4f47aac7205dbd1e55c0"},
+    {file = "ruff-0.0.246-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:449e6632c13902df06ac14ccfc7bad71841ab90bfa64e8cb3f1a2ea91e647df0"},
+    {file = "ruff-0.0.246-py3-none-win32.whl", hash = "sha256:f6004332134580f0ede29d86a9a16102ba07c25799e0ab9683359216a419366b"},
+    {file = "ruff-0.0.246-py3-none-win_amd64.whl", hash = "sha256:dd4f58b9295615ebb01563a38a5594fcb4664bb6106b2ccd00b90c0f1d14cf8c"},
+    {file = "ruff-0.0.246.tar.gz", hash = "sha256:f8403e31e64b15c9b3e2745b0400e2f43eea81493ae0fa85e275ed0800a89c19"},
+]
 
 [[package]]
 name = "secretstorage"
@@ -1943,14 +1583,14 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "setuptools"
-version = "67.2.0"
+version = "67.3.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.2.0-py3-none-any.whl", hash = "sha256:16ccf598aab3b506593c17378473978908a2734d7336755a8769b480906bec1c"},
-    {file = "setuptools-67.2.0.tar.gz", hash = "sha256:b440ee5f7e607bb8c9de15259dba2583dd41a38879a7abc1d43a71c59524da48"},
+    {file = "setuptools-67.3.1-py3-none-any.whl", hash = "sha256:23c86b4e44432bfd8899384afc08872ec166a24f48a3f99f293b0a557e6a6b5d"},
+    {file = "setuptools-67.3.1.tar.gz", hash = "sha256:daec07fd848d80676694d6bf69c009d28910aeece68a38dbe88b7e1bb6dba12e"},
 ]
 
 [package.extras]
@@ -1968,30 +1608,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
-
-[[package]]
-name = "smmap"
-version = "5.0.0"
-description = "A pure Python implementation of a sliding window memory map manager"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
-    {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
-]
-
-[[package]]
-name = "snowballstemmer"
-version = "2.2.0"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
-    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 
 [[package]]
@@ -2058,14 +1674,14 @@ urllib3 = ">=1.26.0"
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 
 [[package]]
@@ -2155,43 +1771,6 @@ files = [
 ]
 
 [[package]]
-name = "wemake-python-styleguide"
-version = "0.17.0"
-description = "The strictest and most opinionated python linter ever"
-category = "dev"
-optional = false
-python-versions = "^3.7"
-files = []
-develop = false
-
-[package.dependencies]
-astor = "^0.8"
-attrs = "*"
-darglint = "^1.2"
-flake8 = "^5.0"
-flake8-bandit = "^4.1"
-flake8-broken-line = "^0.6"
-flake8-bugbear = "^22.9"
-flake8-commas = "^2.0"
-flake8-comprehensions = "^3.1"
-flake8-debugger = "^4.0"
-flake8-docstrings = "^1.3"
-flake8-eradicate = "^1.0"
-flake8-isort = ">=4,<6"
-flake8-quotes = "^3.0"
-flake8-rst-docstrings = ">=0.2,<0.4"
-flake8-string-format = "^0.3"
-pep8-naming = "^0.13"
-pygments = "^2.4"
-typing_extensions = ">=4.0,<5.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/wemake-services/wemake-python-styleguide"
-reference = "HEAD"
-resolved_reference = "f23a4b6e10a7a14bf265fd8c0eb430906bbc4a60"
-
-[[package]]
 name = "zipp"
 version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -2210,4 +1789,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "acb1f39a3b750c9a3b25f2399f2c13a71fb7bd1fac8328c0e3f3f949e315df60"
+content-hash = "9c5adc438599c039ddd9f6280cbd1cf6a5a3e2e387384b519e6b35c797fbdbcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ target-version = ["py38"]
 profile = "black"
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py38"
 line-length = 88
 select = [
     "A",      # flake8-builtins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ sentry-sdk = "^1.3.1"
 edx-opaque-keys = "2.3.0"
 celery = ">=4.4.7"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "*"
 isort = "*"
 pre-commit = "^2.18.0"
 pytest = "^7.0.0"
 twine = "^4.0.0"
-wemake-python-styleguide = {git = "https://github.com/wemake-services/wemake-python-styleguide"}
+ruff = "^0.0.246"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -31,3 +31,92 @@ target-version = ["py38"]
 
 [tool.isort]
 profile = "black"
+
+[tool.ruff]
+target-version = "py39"
+line-length = 88
+select = [
+    "A",      # flake8-builtins
+    # "ARG",  # flake8-unused-arguments
+    # "ANN",  # flake8-annotations
+    "B",      # flake8-bugbear
+    # "BLE",  # flake8-blind-except
+    # "C4",   # flake8-comprehensions
+    # "COM",  # flake8-commas
+    "DTZ",    # flake8-datetimez
+    "D",      # pydocstyle
+    "E",      # pydocstyle
+    "ERA",  # eradicate
+    # "EM",   # flake8-errmsg
+    "EXE",    # flake8-executable
+    "F",      # flake8
+    "G",      # flake8-logging-format
+    "ICN",    # flake8-import-conventions
+    # "INP",    # flake8-no-pep420
+    "ISC",    # flake8-implicit-str-concat
+    "N",      # pep8-naming
+    # "PD",   # pandas-vet
+    "PIE",    # flake8-pie
+    # "PGH",  # pygrep-hooks                [Enable]
+    # "PT",   # flake8-pytest-style         [Enable]
+    "PTH",  # flake8-use-pathlib
+    "PLR",    # Refactor
+    "Q",      # flake8-quotes
+    "RET",    # flake8-return
+    "S",      # flake8-bandit
+    "SIM",    # flake8-simplify
+    "T10",    # flake8-debugger
+    "T20",    # flake8-print
+    "TCH",  # flake8-type-checking
+    "TID",    # flake8-tidy-imports
+    "UP",     # pyupgrade
+    "W",      # pydocstyle
+    "YTT",     # flake8-2020
+    "RUF"
+]
+ignore = [
+    "A003",
+    "B008",
+    "B905",
+    "D104",
+    "D200",
+    "D202",
+    "D205",
+    "D301",
+    "D400",
+    "ERA001",
+    "ISC001",
+    "N801",
+    "N802",
+    "N803",
+    "N806",
+    "N813",
+    "N815",
+    "N816",
+    "PIE804",
+    "PLR2004",
+    "PTH123",
+    "RET504",
+    "RET505",
+    "RET506",
+    "RET507",
+    "RET508",
+    "S101",
+    "T201",
+    "TCH001",
+    "TCH002",
+    "TCH003",
+    "UP007"
+
+]
+typing-modules = ["colour.hints"]
+fixable = ["I", "D", "B", "E", "F", "UP", "C4", "Q", "RET", "PIE", "SIM","UP", "W", "RUF"]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.flake8-quotes]
+inline-quotes = "double"
+
+[tool.ruff.per-file-ignores]
+"test_*.py" = ["S101"]

--- a/src/ol_openedx_canvas_integration/__init__.py
+++ b/src/ol_openedx_canvas_integration/__init__.py
@@ -4,4 +4,4 @@ This is an integration of canvas with edX.
 
 __version__ = "0.0.1"
 
-default_app_config = "ol_openedx_canvas_integration.app.CanvasIntegrationConfig"  # pylint: disable=invalid-name
+default_app_config = "ol_openedx_canvas_integration.app.CanvasIntegrationConfig"  # pylint: disable=invalid-name  # noqa: E501

--- a/src/ol_openedx_canvas_integration/api.py
+++ b/src/ol_openedx_canvas_integration/api.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 
 def first_or_none(iterable):
-    """Returns the first item in the given iterable, or None if the iterable is empty"""
+    """Returns the first item in the given iterable, or None if the iterable is empty"""  # noqa: D401, E501
     return next((x for x in iterable), None)
 
 
@@ -36,7 +36,7 @@ def course_graded_items(course):
 def get_enrolled_non_staff_users(course):
     """
     Returns an iterable of non-staff enrolled users for a given course
-    """
+    """  # noqa: D401
     return [
         user
         for user in CourseEnrollment.objects.users_enrolled_in(course.id)
@@ -48,7 +48,7 @@ def enroll_emails_in_course(emails, course_key):
     """
     Attempts to enroll all provided emails in a course. Emails without a corresponding
     user have a CourseEnrollmentAllowed object created for the course.
-    """
+    """  # noqa: D401
     results = {}
     for email in emails:
         user = User.objects.filter(email=email).first()
@@ -90,14 +90,14 @@ def get_subsection_user_grades(course):
                     <User object for student 2>: <grades.subsection_grade.CreateSubsectionGrade object>,
                 }
             }
-    """
+    """  # noqa: D401, E501
     enrolled_students = CourseEnrollment.objects.users_enrolled_in(course.id)
     subsection_grade_dict = defaultdict(dict)
-    for student, course_grade, error in CourseGradeFactory().iter(
+    for student, course_grade, _error in CourseGradeFactory().iter(
         users=enrolled_students, course=course
     ):
         for (
-            graded_item_type,
+            _graded_item_type,
             subsection_dict,
         ) in course_grade.graded_subsections_by_format().items():
             for subsection_block_locator, subsection_grade in subsection_dict.items():
@@ -127,7 +127,7 @@ def get_subsection_block_user_grades(course):
                     <User object for student 2>: <grades.subsection_grade.CreateSubsectionGrade object>,
                 }
             }
-    """
+    """  # noqa: D401, E501
     subsection_user_grades = get_subsection_user_grades(course)
     graded_subsection_blocks = [
         graded_item.get("subsection_block")
@@ -141,7 +141,7 @@ def get_subsection_block_user_grades(course):
             for block in graded_subsection_blocks
             if block.location == block_locator
         )
-        for block_locator in subsection_user_grades.keys()
+        for block_locator in subsection_user_grades
     }
     return {
         block: subsection_user_grades[block_locator]
@@ -199,7 +199,7 @@ def push_edx_grades_to_canvas(course):
 
     Returns:
         dict: A dictionary with some information about the success/failure of the updates
-    """
+    """  # noqa: E501
     canvas_course_id = course.canvas_course_id
     client = CanvasClient(canvas_course_id=canvas_course_id)
     existing_assignment_dict = client.get_assignments_by_int_id()
@@ -208,7 +208,7 @@ def push_edx_grades_to_canvas(course):
     # Populate missing assignments
     new_assignment_blocks = (
         subsection_block
-        for subsection_block in subsection_block_user_grades.keys()
+        for subsection_block in subsection_block_user_grades
         if str(subsection_block.location) not in existing_assignment_dict
     )
     created_assignments = {

--- a/src/ol_openedx_canvas_integration/app.py
+++ b/src/ol_openedx_canvas_integration/app.py
@@ -34,7 +34,7 @@ class CanvasIntegrationConfig(AppConfig):
         },
         PluginContexts.CONFIG: {
             ProjectType.LMS: {
-                INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME: "ol_openedx_canvas_integration.context_api.plugin_context"
+                INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME: "ol_openedx_canvas_integration.context_api.plugin_context"  # noqa: E501
             }
         },
     }

--- a/src/ol_openedx_canvas_integration/client.py
+++ b/src/ol_openedx_canvas_integration/client.py
@@ -72,7 +72,7 @@ class CanvasClient:
 
         Returns:
             dict: Email addresses mapped to canvas user ids for all enrolled users
-        """
+        """  # noqa: E501
         url = urljoin(
             settings.CANVAS_BASE_URL,
             f"/api/v1/courses/{self.canvas_course_id}/enrollments",
@@ -175,7 +175,7 @@ def create_assignment_payload(subsection_block):
     Returns:
         dict:
             Assignment payload to be sent to Canvas to create or update the assignment
-    """
+    """  # noqa: E501
     return {
         "assignment": {
             "name": subsection_block.display_name,
@@ -185,8 +185,8 @@ def create_assignment_payload(subsection_block):
             "due_at": (
                 None
                 if not subsection_block.fields.get("due")
-                # The internal API gives us a TZ-naive datetime for the due date, but Studio indicates that
-                # the user should enter a UTC datetime for the due date. Coerce this to UTC before creating the
+                # The internal API gives us a TZ-naive datetime for the due date, but Studio indicates that  # noqa: E501
+                # the user should enter a UTC datetime for the due date. Coerce this to UTC before creating the  # noqa: E501
                 # string representation.
                 else subsection_block.fields["due"].astimezone(pytz.UTC).isoformat()
             ),
@@ -206,5 +206,5 @@ def update_grade_payload_kv(user_id, grade_percent):
 
     Returns:
         (tuple): A key/value pair that will be used in the body of a bulk grade update request
-    """
+    """  # noqa: D401, E501
     return (f"grade_data[{user_id}][posted_grade]", f"{grade_percent * 100}%")

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -16,20 +16,20 @@ def get_resource_bytes(path):
 
     Returns:
         unicode: The unicode contents of the resource at the given path
-    """
+    """  # noqa: D401
     resource_contents = pkg_resources.resource_string(__name__, path)
     return resource_contents.decode("utf-8")
 
 
 def plugin_context(context):
-    """Provide context based data for Canvas Integration plugin (For Instructor Dashboard)"""
+    """Provide context based data for Canvas Integration plugin (For Instructor Dashboard)"""  # noqa: E501
 
     course = context.get("course")
 
     # Don't add Canvas tab is the Instructor Dashboard if it doesn't have any associated
     # canvas_course_id set from Canvas Service
     if not course.canvas_course_id:
-        return
+        return None
 
     fragment = Fragment()
     # Adding JS as bytes (Inspired by what we are doing with Rapid Response xBlock)

--- a/src/ol_openedx_canvas_integration/settings/common.py
+++ b/src/ol_openedx_canvas_integration/settings/common.py
@@ -2,6 +2,6 @@
 
 
 def plugin_settings(settings):
-    """Settings for the canvas integration plugin."""
+    """Settings for the canvas integration plugin."""  # noqa: D401
     settings.CANVAS_ACCESS_TOKEN = None
     settings.CANVAS_BASE_URL = None

--- a/src/ol_openedx_canvas_integration/settings/production.py
+++ b/src/ol_openedx_canvas_integration/settings/production.py
@@ -7,7 +7,7 @@ PLUGIN_TEMPLATES_ROOT = path(__file__).abspath().dirname().dirname()
 
 
 def plugin_settings(settings):
-    """Settings for the canvas integration plugin."""
+    """Settings for the canvas integration plugin."""  # noqa: D401
     settings.CANVAS_ACCESS_TOKEN = settings.AUTH_TOKENS.get(
         "CANVAS_ACCESS_TOKEN", settings.CANVAS_ACCESS_TOKEN
     )

--- a/src/ol_openedx_canvas_integration/tasks.py
+++ b/src/ol_openedx_canvas_integration/tasks.py
@@ -30,7 +30,7 @@ def run_sync_canvas_enrollments(
         "canvas_course_id": canvas_course_id,
         "unenroll_current": unenroll_current,
     }
-    task_key = hashlib.md5(course_key.encode("utf8")).hexdigest()
+    task_key = hashlib.md5(course_key.encode("utf8")).hexdigest()  # noqa: S324
     TASK_LOG.debug("Submitting task to sync canvas enrollments")
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
@@ -53,11 +53,11 @@ def run_push_edx_grades_to_canvas(request, course_id):
     task_type = TASK_TYPE_PUSH_EDX_GRADES_TO_CANVAS
     task_class = push_edx_grades_to_canvas_task
     task_input = {
-        # course_key is already passed into the task, but we need to put it in task_input as well
-        # so the instructor task status can be properly calculated instead of being marked incomplete
+        # course_key is already passed into the task, but we need to put it in task_input as well  # noqa: E501
+        # so the instructor task status can be properly calculated instead of being marked incomplete  # noqa: E501
         "course_key": str(course_id)
     }
-    task_key = hashlib.md5(course_id.encode("utf8")).hexdigest()
+    task_key = hashlib.md5(course_id.encode("utf8")).hexdigest()  # noqa: S324
     TASK_LOG.debug("Submitting task to push edX grades to Canvas")
     return submit_task(request, task_type, task_class, course_id, task_input, task_key)
 

--- a/src/ol_openedx_canvas_integration/test_settings.py
+++ b/src/ol_openedx_canvas_integration/test_settings.py
@@ -11,7 +11,7 @@ def root(*args):
     """
     Get the absolute path of the given path relative to the project root.
     """
-    return join(abspath(dirname(__file__)), *args)
+    return join(abspath(dirname(__file__)), *args)  # noqa: PTH100, PTH120, PTH118
 
 
 DATABASES = {
@@ -40,7 +40,7 @@ LOCALE_PATHS = [
 
 ROOT_URLCONF = "ol_openedx_canvas_integration.urls"
 
-SECRET_KEY = "insecure-secret-key"  # pragma: allowlist secret
+SECRET_KEY = "insecure-secret-key"  # pragma: allowlist secret  # noqa: S105
 
 MIDDLEWARE = (
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/src/ol_openedx_canvas_integration/views.py
+++ b/src/ol_openedx_canvas_integration/views.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 def _get_edx_enrollment_data(email, course_key):
-    """Helper function to look up some info regarding whether a user with a email address is enrolled in edx"""
+    """Helper function to look up some info regarding whether a user with a email address is enrolled in edx"""  # noqa: D401, E501
     user = User.objects.filter(email=email).first()
     allowed = CourseEnrollmentAllowed.objects.filter(
         email=email, course_id=course_key
@@ -68,7 +68,7 @@ def list_canvas_enrollments(request, course_id):
 def add_canvas_enrollments(request, course_id):
     """
     Fetches enrollees for a course in canvas and enrolls those emails in the course in edX
-    """
+    """  # noqa: D401, E501
     unenroll_current = request.POST.get("unenroll_current", "").lower() == "true"
     course_key = CourseLocator.from_string(course_id)
     course = get_course_by_id(course_key)

--- a/src/ol_openedx_checkout_external/__init__.py
+++ b/src/ol_openedx_checkout_external/__init__.py
@@ -4,4 +4,4 @@ This is an integration external checkout API.
 
 __version__ = "0.1.0"
 
-default_app_config = "ol_openedx_checkout_external.app.ExternalCheckoutConfig"  # pylint: disable=invalid-name
+default_app_config = "ol_openedx_checkout_external.app.ExternalCheckoutConfig"  # pylint: disable=invalid-name  # noqa: E501

--- a/src/ol_openedx_checkout_external/settings/common.py
+++ b/src/ol_openedx_checkout_external/settings/common.py
@@ -2,5 +2,5 @@
 
 
 def plugin_settings(settings):
-    """Settings for the external checkout plugin."""
+    """Settings for the external checkout plugin."""  # noqa: D401
     settings.MARKETING_SITE_CHECKOUT_URL = None

--- a/src/ol_openedx_checkout_external/settings/production.py
+++ b/src/ol_openedx_checkout_external/settings/production.py
@@ -2,7 +2,7 @@
 
 
 def plugin_settings(settings):
-    """Settings for the external checkout plugin."""
+    """Settings for the external checkout plugin."""  # noqa: D401
     settings.MARKETING_SITE_CHECKOUT_URL = settings.ENV_TOKENS.get(
         "MARKETING_SITE_CHECKOUT_URL", settings.MARKETING_SITE_CHECKOUT_URL
     )

--- a/src/ol_openedx_checkout_external/views.py
+++ b/src/ol_openedx_checkout_external/views.py
@@ -32,7 +32,7 @@ def external_checkout(request):
     A 404 would be returned in case there is no sku matching products
 
     A 500 would be returned if there are any configuration errors
-    """
+    """  # noqa: D401, E501
 
     if request.method != "GET":
         raise NotImplementedError("API only supports GET requests")
@@ -51,17 +51,17 @@ def external_checkout(request):
     course_modes = CourseMode.objects.filter(sku=product_sku)
     if not course_modes:
         log.error(
-            f"No CourseMode was found against the given product SKU ({product_sku})"
+            f"No CourseMode was found against the given product SKU ({product_sku})"  # noqa: E501, G004
         )
         raise Http404
 
-    # Because there is no unique constraint on SKU, so there could be multiple CourseModes with same SKU
+    # Because there is no unique constraint on SKU, so there could be multiple CourseModes with same SKU  # noqa: E501
     if len(course_modes) > 1:
         raise ExternalCheckoutError(
             f"Found multiple CourseModes for the same SKU ({product_sku})"
         )
 
-    #  Generate a URL to redirect to marketing site based on its checkout URL with and added
+    #  Generate a URL to redirect to marketing site based on its checkout URL with and added  # noqa: E501
     #  course ID query param)
     course_id = quote(str(course_modes.first().course.id))
     redirect_url = f"{settings.MARKETING_SITE_CHECKOUT_URL}?course_id={course_id}"

--- a/src/ol_openedx_course_export/s3_client.py
+++ b/src/ol_openedx_course_export/s3_client.py
@@ -24,7 +24,7 @@ class S3Client:
         )
 
     def get_bucket_url(self):
-        """Returns a URL for the bucket, which is then used to add in the API response"""
+        """Returns a URL for the bucket, which is then used to add in the API response"""  # noqa: D401, E501
         return self.client.get_bucket_location(
             Bucket=settings.COURSE_IMPORT_EXPORT_BUCKET
         )

--- a/src/ol_openedx_course_export/settings/common.py
+++ b/src/ol_openedx_course_export/settings/common.py
@@ -2,4 +2,4 @@
 
 
 def plugin_settings(settings):
-    """Settings for the course export s3 location plugin."""
+    """Settings for the course export s3 location plugin."""  # noqa: D401

--- a/src/ol_openedx_course_export/settings/production.py
+++ b/src/ol_openedx_course_export/settings/production.py
@@ -2,4 +2,4 @@
 
 
 def plugin_settings(settings):
-    """Settings for the course export plugin."""
+    """Settings for the course export plugin."""  # noqa: D401

--- a/src/ol_openedx_course_export/tasks.py
+++ b/src/ol_openedx_course_export/tasks.py
@@ -29,7 +29,7 @@ def task_upload_course_s3(self, user_id, course_key_string):
 
     Returns:
         task_id, Just starts a task and returns it's id as part of Celery's base implementation. Used for status updates
-    """
+    """  # noqa: D401, E501
     try:
         self.status.set_state(UserTaskStatus.IN_PROGRESS)
         s3_client = S3Client()
@@ -43,7 +43,7 @@ def task_upload_course_s3(self, user_id, course_key_string):
         self.status.set_state(UserTaskStatus.SUCCEEDED)
     except ClientError as ex:
         log.exception(
-            f"Course export {course_key_string}: A ClientError in course export:"
+            f"Course export {course_key_string}: A ClientError in course export:"  # noqa: E501, G004
         )
         if self.status.state != UserTaskStatus.FAILED:
             self.status.fail({"raw_error_msg": str(ex)})

--- a/src/ol_openedx_course_export/utils.py
+++ b/src/ol_openedx_course_export/utils.py
@@ -33,4 +33,4 @@ def get_aws_file_url(course_id):
         str: Returns the S3 specific access URL for the file
     """
 
-    return f"https://{settings.COURSE_IMPORT_EXPORT_BUCKET}.{AWS_S3_DEFAULT_URL_PREFIX}/{get_file_name_with_extension(course_id)}"
+    return f"https://{settings.COURSE_IMPORT_EXPORT_BUCKET}.{AWS_S3_DEFAULT_URL_PREFIX}/{get_file_name_with_extension(course_id)}"  # noqa: E501

--- a/src/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/views.py
@@ -94,7 +94,7 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
         }
 
 
-    """
+    """  # noqa: E501
 
     http_method_names = ["get", "post"]
     permission_classes = [
@@ -104,11 +104,11 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
     def post(self, request):
         """
         This will take list of course id as param and will export them to S3
-        """
+        """  # noqa: D401
         if not is_bucket_configuration_valid():
             raise self.api_error(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                developer_message="COURSE_IMPORT_EXPORT_BUCKET value is not configured properly",
+                developer_message="COURSE_IMPORT_EXPORT_BUCKET value is not configured properly",  # noqa: E501
                 error_code="internal_error",
             )
 
@@ -130,7 +130,9 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
                 course_upload_urls[course_id] = get_aws_file_url(course_id)
                 upload_task_ids[course_id] = task_detail.task_id
             except Exception as e:
-                log.exception(f"Course export {course_id}: An error has occurred:")
+                log.exception(
+                    f"Course export {course_id}: An error has occurred:"  # noqa: G004
+                )  # noqa: G004, RUF100
                 failed_course_uploads[course_id] = str(e)
 
         response_data = {
@@ -158,7 +160,7 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
             return Response({"state": task_status.state})
         except Exception as e:
             log.exception(str(e))
-            raise self.api_error(
+            raise self.api_error(  # noqa: B904
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 developer_message=str(e),
                 error_code="internal_error",

--- a/src/ol_openedx_git_auto_export/app.py
+++ b/src/ol_openedx_git_auto_export/app.py
@@ -28,8 +28,8 @@ class GitAutoExportConfig(AppConfig):
                 PluginSignals.RECEIVERS: [
                     {
                         PluginSignals.RECEIVER_FUNC_NAME: "listen_for_course_publish",
-                        PluginSignals.SIGNAL_PATH: "xmodule.modulestore.django.COURSE_PUBLISHED",
-                        PluginSignals.DISPATCH_UID: "ol_openedx_git_auto_export.signals.listen_for_course_publish",
+                        PluginSignals.SIGNAL_PATH: "xmodule.modulestore.django.COURSE_PUBLISHED",  # noqa: E501
+                        PluginSignals.DISPATCH_UID: "ol_openedx_git_auto_export.signals.listen_for_course_publish",  # noqa: E501
                     }
                 ],
             },

--- a/src/ol_openedx_git_auto_export/settings/common.py
+++ b/src/ol_openedx_git_auto_export/settings/common.py
@@ -4,6 +4,6 @@ from ol_openedx_git_auto_export.constants import ENABLE_GIT_AUTO_EXPORT
 
 
 def plugin_settings(settings):
-    """Settings for the git auto export plugin."""
+    """Settings for the git auto export plugin."""  # noqa: D401
     settings.GIT_REPO_EXPORT_DIR = "/edx/var/edxapp/export_course_repos"
     settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = True

--- a/src/ol_openedx_git_auto_export/settings/production.py
+++ b/src/ol_openedx_git_auto_export/settings/production.py
@@ -4,6 +4,6 @@ from ol_openedx_git_auto_export.constants import ENABLE_GIT_AUTO_EXPORT
 
 
 def plugin_settings(settings):
-    """Settings for the git auto export plugin."""
+    """Settings for the git auto export plugin."""  # noqa: D401
     settings.GIT_REPO_EXPORT_DIR = "/edx/var/edxapp/export_course_repos"
     settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = True

--- a/src/ol_openedx_git_auto_export/signals.py
+++ b/src/ol_openedx_git_auto_export/signals.py
@@ -21,19 +21,19 @@ def listen_for_course_publish(
     git_repo_export_dir = getattr(
         settings, "GIT_REPO_EXPORT_DIR", "/edx/var/edxapp/export_course_repos"
     )
-    if not os.path.exists(git_repo_export_dir):
-        # for development/docker/vagrant if GIT_REPO_EXPORT_DIR folder does not exist then create it
+    if not os.path.exists(git_repo_export_dir):  # noqa: PTH110
+        # for development/docker/vagrant if GIT_REPO_EXPORT_DIR folder does not exist then create it  # noqa: E501
         log.error(
             "GIT_REPO_EXPORT_DIR is not available in settings, please create it first"
         )
-        os.makedirs(git_repo_export_dir, 0o755)
+        os.makedirs(git_repo_export_dir, 0o755)  # noqa: PTH103
 
     if settings.FEATURES.get("ENABLE_EXPORT_GIT") and settings.FEATURES.get(
         ENABLE_GIT_AUTO_EXPORT
     ):
         # If the Git auto-export is enabled, push the course changes to Git
         log.info(
-            "Course published with auto-export enabled. Starting export... (course id: %s)",
+            "Course published with auto-export enabled. Starting export... (course id: %s)",  # noqa: E501
             course_key,
         )
         async_export_to_git.delay(str(course_key))

--- a/src/ol_openedx_git_auto_export/tasks.py
+++ b/src/ol_openedx_git_auto_export/tasks.py
@@ -11,7 +11,7 @@ LOGGER = get_task_logger(__name__)
 def async_export_to_git(course_key_string, user=None):
     """
     Exports a course to Git.
-    """
+    """  # noqa: D401
     course_key = CourseKey.from_string(course_key_string)
     course_module = modulestore().get_course(course_key)
 
@@ -29,7 +29,7 @@ def async_export_to_git(course_key_string, user=None):
         )
     except Exception as ex:  # pylint: disable=broad-except
         LOGGER.error(
-            "Unknown error occured during async course content export to git (course id: %s): %s",
+            "Unknown error occured during async course content export to git (course id: %s): %s",  # noqa: E501
             course_module.id,
             ex,
         )

--- a/src/ol_openedx_git_auto_export/test_settings.py
+++ b/src/ol_openedx_git_auto_export/test_settings.py
@@ -11,7 +11,7 @@ def root(*args):
     """
     Get the absolute path of the given path relative to the project root.
     """
-    return join(abspath(dirname(__file__)), *args)
+    return join(abspath(dirname(__file__)), *args)  # noqa: PTH100, PTH120, PTH118
 
 
 DATABASES = {
@@ -40,7 +40,7 @@ LOCALE_PATHS = [
 
 ROOT_URLCONF = "ol_openedx_git_auto_export.urls"
 
-SECRET_KEY = "insecure-secret-key"  # pragma: allowlist secret
+SECRET_KEY = "insecure-secret-key"  # pragma: allowlist secret  # noqa: S105
 
 MIDDLEWARE = (
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/src/ol_openedx_rapid_response_reports/__init__.py
+++ b/src/ol_openedx_rapid_response_reports/__init__.py
@@ -4,4 +4,4 @@ A plugin to add support for rapid response reports in Instructor Dashboard.
 
 __version__ = "0.1.0"
 
-default_app_config = "ol_openedx_rapid_response_reports.app.RapidResponsePluginConfig"  # pylint: disable=invalid-name
+default_app_config = "ol_openedx_rapid_response_reports.app.RapidResponsePluginConfig"  # pylint: disable=invalid-name  # noqa: E501

--- a/src/ol_openedx_rapid_response_reports/app.py
+++ b/src/ol_openedx_rapid_response_reports/app.py
@@ -33,7 +33,7 @@ class RapidResponsePluginConfig(AppConfig):
         },
         PluginContexts.CONFIG: {
             ProjectType.LMS: {
-                INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME: "ol_openedx_rapid_response_reports.context_api.plugin_context"
+                INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME: "ol_openedx_rapid_response_reports.context_api.plugin_context"  # noqa: E501
             }
         },
     }

--- a/src/ol_openedx_rapid_response_reports/docs/conf.py
+++ b/src/ol_openedx_rapid_response_reports/docs/conf.py
@@ -25,15 +25,19 @@ def get_version(*file_paths):
     """
     Extract the version string from the file at the given relative path fragments.
     """
-    filename = os.path.join(os.path.dirname(__file__), *file_paths)
-    version_file = open(filename, encoding="utf8").read()
+    filename = os.path.join(  # noqa: PTH118
+        os.path.dirname(__file__), *file_paths  # noqa: PTH120
+    )  # noqa: PTH118, PTH120, RUF100
+    version_file = open(filename, encoding="utf8").read()  # noqa: SIM115
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+REPO_ROOT = os.path.dirname(  # noqa: PTH120
+    os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
+)  # noqa: PTH100, PTH120, RUF100
 sys.path.append(REPO_ROOT)
 
 VERSION = get_version(
@@ -94,7 +98,7 @@ top_level_doc = "index"
 
 # General information about the project.
 project = "ol_openedx_rapid_response_reports"
-copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin
+copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin  # noqa: A001
 author = edx_theme.AUTHOR
 project_title = "ol_openedx_rapid_response_reports"
 documentation_title = f"{project_title}"
@@ -488,20 +492,26 @@ def on_init(app):  # pylint: disable=unused-argument
     Read the Docs won't run tox or custom shell commands, so we need this to
     avoid checking in the generated reStructuredText files.
     """
-    docs_path = os.path.abspath(os.path.dirname(__file__))
-    root_path = os.path.abspath(os.path.join(docs_path, ".."))
+    docs_path = os.path.abspath(os.path.dirname(__file__))  # noqa: PTH100, PTH120
+    root_path = os.path.abspath(os.path.join(docs_path, ".."))  # noqa: PTH100, PTH118
     apidoc_path = "sphinx-apidoc"
     if hasattr(sys, "real_prefix"):  # Check to see if we are in a virtualenv
         # If we are, assemble the path manually
-        bin_path = os.path.abspath(os.path.join(sys.prefix, "bin"))
-        apidoc_path = os.path.join(bin_path, apidoc_path)
+        bin_path = os.path.abspath(  # noqa: PTH100
+            os.path.join(sys.prefix, "bin")  # noqa: PTH118
+        )  # noqa: PTH100, PTH118, RUF100
+        apidoc_path = os.path.join(bin_path, apidoc_path)  # noqa: PTH118
     check_call(
         [
             apidoc_path,
             "-o",
             docs_path,
-            os.path.join(root_path, "ol_openedx_rapid_response_reports"),
-            os.path.join(root_path, "ol_openedx_rapid_response_reports/migrations"),
+            os.path.join(  # noqa: PTH118
+                root_path, "ol_openedx_rapid_response_reports"
+            ),  # noqa: PTH118, RUF100
+            os.path.join(  # noqa: PTH118
+                root_path, "ol_openedx_rapid_response_reports/migrations"
+            ),  # noqa: PTH118, RUF100
         ]
     )
 

--- a/src/ol_openedx_rapid_response_reports/settings/production.py
+++ b/src/ol_openedx_rapid_response_reports/settings/production.py
@@ -6,7 +6,7 @@ PLUGIN_TEMPLATES_ROOT = path(__file__).abspath().dirname().dirname()
 
 
 def plugin_settings(settings):
-    """Settings for the rapid response plugin."""
+    """Settings for the rapid response plugin."""  # noqa: D401
     settings.TEMPLATES = settings.ENV_TOKENS.get("TEMPLATES", settings.TEMPLATES)
 
     for template_engine in settings.TEMPLATES:

--- a/src/ol_openedx_rapid_response_reports/utils.py
+++ b/src/ol_openedx_rapid_response_reports/utils.py
@@ -5,7 +5,7 @@ def get_display_name_from_usage_key(key, course):
         key (UsageKey) : Usage key of block
     Returns:
         String : Returns the display name of block if exists else 'Deleted'.
-    """
+    """  # noqa: D401
     block = course.get_child(key)
     if block:
         return block.display_name


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
N/A

#### What's this PR do?
Changes pre-commit linting and autofixes from Flake8 and wemake-python-styleguide to use Ruff since it is much faster and more actively maintained

#### How should this be manually tested?
Run `pre-commit run --all-files`

#### Where should the reviewer start?
pyproject.toml and pre-commit-config.yaml

#### Any background context you want to provide?
wemake-python-styleguide appears to have stopped having active maintenance done on it so we need a more stable linting setup.
