### PR TITLE
feat: add course-structure-api plugin

### DIFF
--- a/src/ol_openedx_course_structure_api/.coveragerc
+++ b/src/ol_openedx_course_structure_api/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+data_file = .coverage
+source=ol_openedx_course_structure_api
+omit =
+    test_settings.py
+    */migrations/*
+    *admin.py
+    */static/*
+    */templates/*

--- a/src/ol_openedx_course_structure_api/BUILD
+++ b/src/ol_openedx_course_structure_api/BUILD
@@ -1,0 +1,21 @@
+python_sources(
+    name="course_structure_api",
+    dependencies=["src/ol_openedx_course_structure_api/settings:course_structure_api_settings"],
+)
+
+python_distribution(
+    name="course_structure_api_package",
+    dependencies=[":course_structure_api"],
+    provides=setup_py(
+        name="ol-openedx-course-structure-api",
+        version="0.1.0",
+        description="An Open edX plugin to add API for course structure",
+        license="BSD-3-Clause",
+        entry_points={
+            "lms.djangoapp": [
+                 "ol_openedx_course_structure_api = ol_openedx_course_structure_api.app.CourseStructureAPIConfig"
+            ],
+            "cms.djangoapp": [],
+        },
+    ),
+)

--- a/src/ol_openedx_course_structure_api/CHANGELOG.rst
+++ b/src/ol_openedx_course_structure_api/CHANGELOG.rst
@@ -1,0 +1,12 @@
+Change Log
+##########
+
+..
+   All enhancements and patches to ol_openedx_course_structure_api will be documented
+   in this file.  It adheres to the structure of https://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+
+   This project adheres to Semantic Versioning (https://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.

--- a/src/ol_openedx_course_structure_api/LICENSE.txt
+++ b/src/ol_openedx_course_structure_api/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (C) 2023  MIT Open Learning
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/ol_openedx_course_structure_api/MANIFEST.in
+++ b/src/ol_openedx_course_structure_api/MANIFEST.in
@@ -1,0 +1,4 @@
+include CHANGELOG.rst
+include LICENSE.txt
+include README.rst
+recursive-include ol_openedx_course_structure_api *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg *.py

--- a/src/ol_openedx_course_structure_api/README.rst
+++ b/src/ol_openedx_course_structure_api/README.rst
@@ -1,0 +1,101 @@
+Course Structure API Plugin
+=============================
+
+A django app plugin to add a new API to Open edX to retrieve the JSON representation of course structure
+
+
+Installation
+------------
+
+You can install this plugin into any Open edX instance by using any of the following methods:
+
+
+**Option 1: Install from PyPI**
+
+.. code-block::
+
+    # If running devstack in docker, first open a shell in CMS (make studio-shell)
+
+    pip install ol-openedx-course-structure-api
+
+
+**Option 2: Build the package locally and install it**
+
+Follow these steps in a terminal on your machine:
+
+1. Navigate to ``open-edx-plugins`` directory
+2. If you haven't done so already, run ``./pants build``
+3. Run ``./pants package ::``. This will create a "dist" directory inside "open-edx-plugins" directory with ".whl" & ".tar.gz" format packages for all the "ol_openedx_*" plugins in "open-edx-plugins/src")
+4. Move/copy any of the ".whl" or ".tar.gz" files for this plugin that were generated in the above step to the machine/container running Open edX (NOTE: If running devstack via Docker, you can use ``docker cp`` to copy these files into your CMS container)
+5. Run a shell in the machine/container running Open edX, and install this plugin using pip
+
+
+How To Use
+----------
+The API supports a GET API call with two optional query parameters
+ - ``inherited_metadata`` : include inherited metadata at course level (default to false)
+ - ``inherited_metadata_default``: include default values of inherited metadata (default to false)
+
+To call the API, send a GET request to ``<LMS_BASE>/api/courses/v0/<course_id>/``:
+
+The successful response for ``http://localhost:18000/api/course-structure/v0/course-v1:edX+DemoX+Demo_Course/`` would look like:
+
+.. code-block::
+
+     {
+            "block-v1:edX+DemoX+Demo_Course+type@chapter+block@1414ffd5143b4b5": {
+                "category": "chapter"
+                "children": [
+                             "block-v1:edX+DemoX+Demo_Course+type@chapter+block@d8a6192ade314473a78242dfeedfbf5b",
+                             "block-v1:edX+DemoX+Demo_Course+type@chapter+block@interactive_demonstrations",
+                             "block-v1:edX+DemoX+Demo_Course+type@chapter+block@graded_interactions"
+                            ]
+                 "metadata": {"display_name":"Example Week 1: Getting Started"}
+           },
+            "block-v1:edX+DemoX+Demo_Course+type@chapter+block@d8a6192ade314473a": {
+                "category": "chapter"
+                "children": ["block-v1:edX+DemoX+Demo_Course+type@sequential+block@edx_introduction"]
+                "metadata": {"display_name":"Example Week 2: Get Interactive"}
+           },
+    }
+
+
+The successful response for ``http://localhost:18000/api/course-structure/v0/course-v1:edX+DemoX+Demo_Course/?inherited_metadata=true&inherited_metadata_default=true`` would look like:
+.. code-block::
+
+     {
+            "block-v1:edX+DemoX+Demo_Course+type@chapter+block@1414ffd5143b4b5": {
+                "category": "chapter"
+                "children": [
+                             "block-v1:edX+DemoX+Demo_Course+type@chapter+block@d8a6192ade314473a78242dfeedfbf5b",
+                             "block-v1:edX+DemoX+Demo_Course+type@chapter+block@interactive_demonstrations",
+                             "block-v1:edX+DemoX+Demo_Course+type@chapter+block@graded_interactions"
+                             ]
+                 "inherited_metadata": {
+                           "name":null,
+                           "course_edit_method":"Studio",
+                           "graceperiod":"18000 seconds",
+                           "graded": false,
+                            ----
+                           "self_paced":false,
+                           "start":"2013-02-05T05:00:00Z",
+                           "xqa_key":"qaijS3UatK020Wc0sfCtFe0V6jpB4d64"
+                           }
+                 "metadata": {"display_name":"Example Week 1: Getting Started"}
+             },
+            "block-v1:edX+DemoX+Demo_Course+type@chapter+block@d8a6192ade314473a": {
+                "category": "chapter"
+                "children": ["block-v1:edX+DemoX+Demo_Course+type@sequential+block@edx_introduction"]
+                "inherited_metadata": {
+                           "name":null,
+                           "course_edit_method":"Studio",
+                           "graceperiod":"18000 seconds",
+                           "graded": false,
+                            ----
+                           "self_paced":false,
+                           "start":"2013-02-05T05:00:00Z",
+                            "xqa_key":"qaijS3UatK020Wc0sfCtFe0V6jpB4d64"
+                           }
+                "metadata": {"display_name":"Example Week 2: Get Interactive"}
+           },
+     }

--- a/src/ol_openedx_course_structure_api/__init__.py
+++ b/src/ol_openedx_course_structure_api/__init__.py
@@ -1,0 +1,7 @@
+"""
+ol_openedx_course_structure_api
+"""
+
+__version__ = "0.1.0"
+
+default_app_config = "ol_openedx_course_structure_api.app.CourseStructureAPIConfig"

--- a/src/ol_openedx_course_structure_api/app.py
+++ b/src/ol_openedx_course_structure_api/app.py
@@ -1,0 +1,33 @@
+"""
+Course Structure API Application Configuration
+"""
+
+from django.apps import AppConfig
+from edx_django_utils.plugins import PluginSettings, PluginURLs
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
+
+
+class CourseStructureAPIConfig(AppConfig):
+    """
+    Configuration class for Course Structure API
+    """
+
+    name = "ol_openedx_course_structure_api"
+
+    plugin_app = {
+        PluginURLs.CONFIG: {
+            ProjectType.LMS: {
+                PluginURLs.NAMESPACE: "",
+                PluginURLs.REGEX: "^api/course-structure/v0/",
+                PluginURLs.RELATIVE_PATH: "urls",
+            }
+        },
+        PluginSettings.CONFIG: {
+            ProjectType.LMS: {
+                SettingsType.PRODUCTION: {
+                    PluginSettings.RELATIVE_PATH: "settings.production"
+                },
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
+            }
+        },
+    }

--- a/src/ol_openedx_course_structure_api/settings/BUILD
+++ b/src/ol_openedx_course_structure_api/settings/BUILD
@@ -1,0 +1,1 @@
+python_sources(name="course_structure_api_settings")

--- a/src/ol_openedx_course_structure_api/settings/common.py
+++ b/src/ol_openedx_course_structure_api/settings/common.py
@@ -1,0 +1,5 @@
+"""Common settings unique to the course structure API plugin."""
+
+
+def plugin_settings(settings):  # noqa: ARG001
+    """Settings for the course structure API plugin"""  # noqa: D401

--- a/src/ol_openedx_course_structure_api/settings/production.py
+++ b/src/ol_openedx_course_structure_api/settings/production.py
@@ -1,0 +1,5 @@
+"""Production settings unique to the course structure API."""
+
+
+def plugin_settings(settings):  # noqa: ARG001
+    """Settings for the course structure API."""  # noqa: D401

--- a/src/ol_openedx_course_structure_api/urls.py
+++ b/src/ol_openedx_course_structure_api/urls.py
@@ -1,0 +1,15 @@
+"""
+Course structure endpoint urls.
+"""
+
+from django.conf import settings
+from django.urls import re_path
+from ol_openedx_course_structure_api.views import CourseStructureView
+
+urlpatterns = [
+    re_path(
+        rf"^{settings.COURSE_ID_PATTERN}/$",
+        CourseStructureView.as_view(),
+        name="course_structure_api",
+    ),
+]

--- a/src/ol_openedx_course_structure_api/views.py
+++ b/src/ol_openedx_course_structure_api/views.py
@@ -1,0 +1,96 @@
+"""Views for Course structure API"""
+
+import logging
+
+from lms.djangoapps.courseware.management.commands.dump_course_structure import (
+    dump_block,
+)
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.lib.api.view_utils import (
+    DeveloperErrorViewMixin,
+    verify_course_exists,
+)
+from rest_framework import status
+from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.inheritance import compute_inherited_metadata
+
+log = logging.getLogger(__name__)
+
+
+class CourseStructureView(DeveloperErrorViewMixin, GenericAPIView):
+    """
+    An API View for course structure
+
+    **Example Requests**
+
+    GET api/course-structure/v0/{course_id}/
+    GET api/course-structure/v0/{course_id}/?inherited_metadata=true&inherited_metadata_default=true
+
+    **Example GET Response**
+
+    The API will return 200, 404 response codes
+
+    A 404 would be returned if course ID is invalid or course not found
+    A 200 response would look something like
+    {
+      "$block_url": {
+        "category": "$block_category",
+        "children": [$block_children_urls... ],
+        "metadata": {$block_metadata}
+      },
+      "$block_url": ....
+    }
+
+
+    """  # noqa: E501
+
+    http_method_names = ["get"]
+    permission_classes = [
+        IsAdminUser,
+    ]
+
+    @verify_course_exists()
+    def get(self, request, course_id):
+        """
+        Return the structure of a course as a JSON object
+        """
+        store = modulestore()
+
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            raise DeveloperErrorViewMixin.api_error(  # noqa: B904, TRY200
+                status_code=status.HTTP_404_NOT_FOUND,
+                developer_message="Invalid course_id",
+            )
+
+        course = store.get_course(course_key)
+        if course is None:
+            raise DeveloperErrorViewMixin.api_error(
+                status_code=status.HTTP_404_NOT_FOUND,
+                developer_message="Course not found",
+            )
+
+        # include inherited metadata
+        inherited_metadata = request.GET.get("inherited_metadata", False)
+        # include default values of inherited metadata
+        inherited_metadata_default = request.GET.get(
+            "inherited_metadata_default", False
+        )
+
+        # Precompute inherited metadata at the course level
+        if inherited_metadata:
+            compute_inherited_metadata(course)
+
+        # Convert course data to dictionary and dump it as JSON
+        json_data = dump_block(
+            course,
+            inherited=bool(inherited_metadata),
+            defaults=bool(inherited_metadata_default),
+        )
+
+        return Response(json_data, status=status.HTTP_200_OK)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-edx-plugins/issues/110

#### What's this PR do?
This adds an API in LMS to retrieve the JSON representation of course structure. The management command for this can be found [here](https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/courseware/management/commands/dump_course_structure.py)

endpoint: api/course-structure/v0/<course id>/ (requires admin access)
#### How should this be manually tested?

-  An open edX instance running on local (tutor or devstack)
- Setup a course in Studio (e.g. tutor http://studio.local.overhang.io/course/course-v1:edX+DemoX+Demo_Course )
- Give your account admin access

devstack

-  Generate and install the plugin following [these steps](https://github.com/mitodl/open-edx-plugins/blob/f3c2e99f6828eaaf892e4e7705b17077d5b036c5/src/ol_openedx_course_structure_api/README.rst#installation)

tutor 
(These steps work for me as I haven't had luck getting it work in tutor with the above devstack steps)
- Setup [edx-cookiecutter](https://github.com/openedx/edx-cookiecutters) 
- Run `make cookiecutter-django-app` to create a skeleton for ol_openedx_course_structure_api. The files look something like this ( I named repo_name and app_name the same, but they can be different)
![image](https://github.com/mitodl/open-edx-plugins/assets/3138890/df055263-8576-4004-85c8-a0b271cc82db)

- Copy `urls.py`, `views.py`, `app.py`(or apps.py) and `settings` directory from this branch to `ol_openedx_course_structure_api` app directory highlighted in above screenshot
- Add the following to setup.py file in root repo directory
```
    entry_points={
        "lms.djangoapp": [
            "ol_openedx_course_structure_api = ol_openedx_course_structure_api.apps:CourseStructureAPIConfig"
        ],
        "cms.djangoapp": [],
    },
```
- Move the root directory `ol_openedx_course_structure_api` to `env/build/openedx/requirements` in Tutor
- Create a `env/build/openedx/requirements/private.txt` with the following entry in Tutor
```
-e ./ol_openedx_course_structure_api/
```
- Run `tutor images build openedx`
- Run `tutor local run lms ./manage.py lms print_setting INSTALLED_APPS` to confirm the plugin is installed
- Start tutor `tutor local start`


- Go to http://local.overhang.io/api/course-structure/v0/course-v1:edX+DemoX+Demo_Course/, you should see the course structure in JSON


#### Screenshots (if appropriate)
http://local.overhang.io/api/course-structure/v0/course-v1:edX+DemoX+Demo_Course/ 
![image](https://github.com/mitodl/open-edx-plugins/assets/3138890/29bd70d2-2788-4e3a-939b-a0523f7d4379)

http://local.overhang.io/api/course-structure/v0/course-v1:edX+DemoX+Demo_Course/?inherited_metadata=true&inherited_metadata_default=true (This includes additional `inherit-metadata` object to each block)
![image](https://github.com/mitodl/open-edx-plugins/assets/3138890/77193a02-9f89-44d3-a452-a5b6cf6bfb60)



