### PR TITLE
fix ImportError on dump_block for olive release 

### DIFF
--- a/src/ol_openedx_course_structure_api/BUILD
+++ b/src/ol_openedx_course_structure_api/BUILD
@@ -8,7 +8,7 @@ python_distribution(
     dependencies=[":course_structure_api"],
     provides=setup_py(
         name="ol-openedx-course-structure-api",
-        version="0.1.1",
+        version="0.1.2",
         description="An Open edX plugin to add API for course structure",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_course_structure_api/__init__.py
+++ b/src/ol_openedx_course_structure_api/__init__.py
@@ -2,6 +2,6 @@
 ol_openedx_course_structure_api
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 default_app_config = "ol_openedx_course_structure_api.app.CourseStructureAPIConfig"

--- a/src/ol_openedx_course_structure_api/views.py
+++ b/src/ol_openedx_course_structure_api/views.py
@@ -2,9 +2,6 @@
 
 import logging
 
-from lms.djangoapps.courseware.management.commands.dump_course_structure import (
-    dump_block,
-)
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.api.view_utils import (
@@ -85,6 +82,21 @@ class CourseStructureView(DeveloperErrorViewMixin, GenericAPIView):
         # Precompute inherited metadata at the course level
         if inherited_metadata:
             compute_inherited_metadata(course)
+
+        # dump_block is renamed from dump_module in release-2023-03-08-14.35
+        # For backward compatibility, try import the new name and then old name
+        try:
+            from lms.djangoapps.courseware.management.commands.dump_course_structure import (  # noqa: E501
+                dump_block,
+            )
+        except ImportError:
+            try:
+                from lms.djangoapps.courseware.management.commands.dump_course_structure import (  # noqa: E501
+                    dump_module as dump_block,
+                )
+            except ImportError as exc:
+                msg = "Couldn't import dump_block or dump_module"
+                raise ImportError(msg) from exc
 
         # Convert course data to dictionary and dump it as JSON
         json_data = dump_block(

--- a/src/ol_openedx_course_structure_api/views.py
+++ b/src/ol_openedx_course_structure_api/views.py
@@ -2,6 +2,21 @@
 
 import logging
 
+# dump_block is renamed from dump_module in release-2023-03-08-14.35
+# For backward compatibility, try import the new name and then old name
+try:
+    from lms.djangoapps.courseware.management.commands.dump_course_structure import (
+        dump_block,
+    )
+except ImportError:
+    try:
+        from lms.djangoapps.courseware.management.commands.dump_course_structure import (  # noqa: E501
+            dump_module as dump_block,
+        )
+    except ImportError as exc:
+        msg = "Couldn't import dump_block or dump_module"
+        raise ImportError(msg) from exc
+
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.api.view_utils import (
@@ -82,21 +97,6 @@ class CourseStructureView(DeveloperErrorViewMixin, GenericAPIView):
         # Precompute inherited metadata at the course level
         if inherited_metadata:
             compute_inherited_metadata(course)
-
-        # dump_block is renamed from dump_module in release-2023-03-08-14.35
-        # For backward compatibility, try import the new name and then old name
-        try:
-            from lms.djangoapps.courseware.management.commands.dump_course_structure import (  # noqa: E501
-                dump_block,
-            )
-        except ImportError:
-            try:
-                from lms.djangoapps.courseware.management.commands.dump_course_structure import (  # noqa: E501
-                    dump_module as dump_block,
-                )
-            except ImportError as exc:
-                msg = "Couldn't import dump_block or dump_module"
-                raise ImportError(msg) from exc
 
         # Convert course data to dictionary and dump it as JSON
         json_data = dump_block(


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/open-edx-plugins/issues/110

# Description (What does it do?)
<!--- Describe your changes in detail -->
This PR fixes ImportError for `olive` open edx instance (e.g. xpro) https://mit-office-of-digital-learning.sentry.io/issues/?project=1730882&referrer=sidebar
```
cannot import name 'dump_block' from 'lms.djangoapps.courseware.management.commands.dump_course_structure' (/openedx/edx-platform/./lms/djangoapps/courseware/management/commands/dump_course_structure.py
```


In older versions of open edx like `olive` it still uses the old function name `dump_module` in [this file](https://github.com/openedx/edx-platform/blob/open-release/olive.master/lms/djangoapps/courseware/management/commands/dump_course_structure.py#L81). But `dump_module` has renamed to `dump_block` in [release-2023-03-08-14.35](https://github.com/openedx/edx-platform/releases/tag/release-2023-03-08-14.35). For backward compatibility, this PR handles ImportError to import either `dump_module` or `dump_block` 

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Follow the step in [README](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_course_structure_api#installation) 

then I modified Dockerfile in tutor/env/build/openedx/ to point to https://github.com/openedx/edx-platform/tree/open-release/olive.master.
```
FROM minimal as code
ARG EDX_PLATFORM_REPOSITORY=https://github.com/openedx/edx-platform.git
ARG EDX_PLATFORM_VERSION=open-release/olive.master
```
Ran `tutor images build openedx`
Ran `tutor local run lms ./manage.py lms print_setting INSTALLED_APPS` to make sure no ImportError

To test palm, I changed Dockerfile back to what was before (latest release)
```
FROM minimal as code
ARG EDX_PLATFORM_REPOSITORY=https://github.com/openedx/edx-platform.git
ARG EDX_PLATFORM_VERSION=open-release/palm.2
```
Ran the same steps to make sure no error

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
