### PR TITLE
chore: support django 4.x

### DIFF
--- a/src/edx_sysadmin/BUILD
+++ b/src/edx_sysadmin/BUILD
@@ -21,7 +21,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="edx-sysadmin",
-        version="0.2.3",
+        version="0.3.0",
         description="An Open edX plugin to enable SysAdmin panel",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/edx_sysadmin/api/urls.py
+++ b/src/edx_sysadmin/api/urls.py
@@ -1,7 +1,7 @@
 """
 URLs for edx_sysadmin.
 """
-from django.conf.urls import url
+from django.urls import re_path
 from edx_sysadmin.api.views import (
     GitCourseDetailsAPIView,
     GitReloadAPIView,
@@ -10,8 +10,8 @@ from edx_sysadmin.api.views import (
 app_name = "api"
 
 urlpatterns = [
-    url("^gitreload/$", GitReloadAPIView.as_view(), name="git-reload"),
-    url(
+    re_path("^gitreload/$", GitReloadAPIView.as_view(), name="git-reload"),
+    re_path(
         "^gitcoursedetails/$",
         GitCourseDetailsAPIView.as_view(),
         name="git-course-details",

--- a/src/edx_sysadmin/urls.py
+++ b/src/edx_sysadmin/urls.py
@@ -1,7 +1,7 @@
 """
 URLs for edx_sysadmin.
 """
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from edx_sysadmin.views import (
     CoursesPanel,
     GitImport,
@@ -14,11 +14,11 @@ app_name = "sysadmin"
 
 
 urlpatterns = [
-    url("^$", SysadminDashboardRedirectionView.as_view(), name="sysadmin"),
-    url(r"^courses/?$", CoursesPanel.as_view(), name="courses"),
-    url(r"^gitimport/$", GitImport.as_view(), name="gitimport"),
-    url(r"^gitlogs/?$", GitLogs.as_view(), name="gitlogs"),
-    url(r"^gitlogs/(?P<course_id>.+)$", GitLogs.as_view(), name="gitlogs_detail"),
-    url(r"^users/$", UsersPanel.as_view(), name="users"),
-    url(r"^api/", include("edx_sysadmin.api.urls", namespace="api")),
+    re_path("^$", SysadminDashboardRedirectionView.as_view(), name="sysadmin"),
+    re_path(r"^courses/?$", CoursesPanel.as_view(), name="courses"),
+    re_path(r"^gitimport/$", GitImport.as_view(), name="gitimport"),
+    re_path(r"^gitlogs/?$", GitLogs.as_view(), name="gitlogs"),
+    re_path(r"^gitlogs/(?P<course_id>.+)$", GitLogs.as_view(), name="gitlogs_detail"),
+    re_path(r"^users/$", UsersPanel.as_view(), name="users"),
+    re_path(r"^api/", include("edx_sysadmin.api.urls", namespace="api")),
 ]

--- a/src/ol_openedx_canvas_integration/BUILD
+++ b/src/ol_openedx_canvas_integration/BUILD
@@ -12,7 +12,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-canvas-integration",
-        version="0.2.6",
+        version="0.3.0",
         description="An Open edX plugin to add canvas integration support",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -3,7 +3,7 @@ The initialization of the context for the Canvas Integration Plugin
 """
 import pkg_resources
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from web_fragments.fragment import Fragment
 
 

--- a/src/ol_openedx_canvas_integration/templates/canvas_integration.html
+++ b/src/ol_openedx_canvas_integration/templates/canvas_integration.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='../../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <section>

--- a/src/ol_openedx_canvas_integration/urls.py
+++ b/src/ol_openedx_canvas_integration/urls.py
@@ -2,25 +2,25 @@
 Canvas Integration API endpoint urls.
 """
 
-from django.conf.urls import url
+from django.urls import re_path
 from ol_openedx_canvas_integration import views
 
 urlpatterns = [
-    url(
+    re_path(
         r"^add_canvas_enrollments$",
         views.add_canvas_enrollments,
         name="add_canvas_enrollments",
     ),
-    url(
+    re_path(
         r"^list_canvas_enrollments$",
         views.list_canvas_enrollments,
         name="list_canvas_enrollments",
     ),
-    url(
+    re_path(
         r"^list_canvas_assignments$",
         views.list_canvas_assignments,
         name="list_canvas_assignments",
     ),
-    url(r"^list_canvas_grades$", views.list_canvas_grades, name="list_canvas_grades"),
-    url(r"^push_edx_grades$", views.push_edx_grades, name="push_edx_grades"),
+    re_path(r"^list_canvas_grades$", views.list_canvas_grades, name="list_canvas_grades"),
+    re_path(r"^push_edx_grades$", views.push_edx_grades, name="push_edx_grades"),
 ]

--- a/src/ol_openedx_canvas_integration/urls.py
+++ b/src/ol_openedx_canvas_integration/urls.py
@@ -21,6 +21,8 @@ urlpatterns = [
         views.list_canvas_assignments,
         name="list_canvas_assignments",
     ),
-    re_path(r"^list_canvas_grades$", views.list_canvas_grades, name="list_canvas_grades"),
+    re_path(
+        r"^list_canvas_grades$", views.list_canvas_grades, name="list_canvas_grades"
+    ),
     re_path(r"^push_edx_grades$", views.push_edx_grades, name="push_edx_grades"),
 ]

--- a/src/ol_openedx_canvas_integration/views.py
+++ b/src/ol_openedx_canvas_integration/views.py
@@ -5,7 +5,7 @@ from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentA
 from common.djangoapps.util.json_request import JsonResponse
 from django.contrib.auth.models import User
 from django.db import transaction
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST

--- a/src/ol_openedx_rapid_response_reports/BUILD
+++ b/src/ol_openedx_rapid_response_reports/BUILD
@@ -13,7 +13,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-rapid-response-reports",
-        version="0.2.2",
+        version="0.3.0",
         description="An Open edX plugin to add rapid response reports support",
         license="BSD-3-Clause",
         entry_points={

--- a/src/ol_openedx_rapid_response_reports/context_api.py
+++ b/src/ol_openedx_rapid_response_reports/context_api.py
@@ -2,7 +2,7 @@
 ol_openedx_rapid_response_reports Django application plugin context initialization.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from rapid_response_xblock.utils import get_run_data_for_course
 from web_fragments.fragment import Fragment
 

--- a/src/ol_openedx_rapid_response_reports/templates/rapid_response.html
+++ b/src/ol_openedx_rapid_response_reports/templates/rapid_response.html
@@ -2,7 +2,7 @@
 <%!
 from itertools import groupby
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 
 from lms.djangoapps.courseware.courses import get_course_by_id

--- a/src/ol_openedx_rapid_response_reports/urls.py
+++ b/src/ol_openedx_rapid_response_reports/urls.py
@@ -1,12 +1,12 @@
 """
 URLs for ol_openedx_rapid_response_reports.
 """
-from django.conf.urls import url
+from django.urls import re_path
 from ol_openedx_rapid_response_reports.api import get_rapid_response_report
 
 urlpatterns = [
     # rapid response downloads
-    url(
+    re_path(
         r"rapid_response_report/(?P<run_id>[^/]*)$",
         get_rapid_response_report,
         name="get_rapid_response_report",


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/open-edx-plugins/issues/230

# Description (What does it do?)
- Removes deprecated/removed functionality from old Django 3.x
- Support for 4.x

# How can this be tested?
-  Package geenration should be successful
- Everything should work with Quince release of edX
