### PR TITLE
fix: removed redwood from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
         devstack_branch:
         - master
         - open-release/quince.master
-        - open-release/redwood.master
           # Add more branches as needed
 
     steps:

--- a/src/ol_openedx_course_export/README.rst
+++ b/src/ol_openedx_course_export/README.rst
@@ -59,6 +59,11 @@ To call the API, Send a POST request to `<STUDIO_BASE>/api/courses/v0/export/` w
     }
 
 
+.. note::
+
+The API requires JWT authentication. Follow the instructions at `this link <https://docs.openedx.org/projects/edx-platform/en/latest/how-tos/use_the_api.html>`_ to generate a JWT token and use it in the request headers.
+
+
 The successful response would look like:
 
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/open-edx-plugins/issues/334

### Description (What does it do?)
Temporarily removes redwood from CI

### How can this be tested?
See the CI logs
