### PR TITLE
feat: change backend name of social auth

### DIFF
--- a/src/ol_social_auth/README.rst
+++ b/src/ol_social_auth/README.rst
@@ -39,9 +39,8 @@ Configurations
 --------------
 This section outlines the steps for integrating your application with ol-social-auth for various deployment scenarios. Please refer to the corresponding documentation for detailed instructions.
 
-* **MITxPRO:** To configure ol-social-auth with MITxPRO, follow the comprehensive guide available `here <https://github.com/mitodl/mitxpro/blob/master/docs/configure_open_edx.md>`_
-* **MITxOnline:** For integration with MITxOnline, detailed instructions can be found in the official documentation `here <https://github.com/mitodl/mitxonline/blob/main/docs/source/configuration/open_edx.rst>`_
-* **MITxOnline with Tutor:** If you're using MITxOnline with Tutor for development purposes, specific configuration steps are outlined in the `documentation <https://github.com/mitodl/mitxonline/blob/main/docs/source/configuration/tutor.rst>`_
+* **Devstack:** To configure ol-social-auth with an edx-platform instance provisioned using devstack, follow the instructions `here <https://mitodl.github.io/handbook/openedx/MITx-edx-integration-devstack.html>`_
+* **Tutor:** To configure ol-social-auth with an edx-platform instance provisioned using tutor, follow the instructions `here https://mitodl.github.io/handbook/openedx/MITx-edx-integration-tutor.html`_
 
 
 How to use

--- a/src/ol_social_auth/backends.py
+++ b/src/ol_social_auth/backends.py
@@ -1,10 +1,10 @@
-"""MIT xPro social auth backend"""
+"""Open Learning social auth backend"""
 
 from social_core.backends.oauth import BaseOAuth2
 
 
 class OLOAuth2(BaseOAuth2):
-    """MIT xPro social auth backend"""
+    """Open Learning social auth backend"""
 
     name = "ol-oauth2"
 
@@ -49,7 +49,7 @@ class OLOAuth2(BaseOAuth2):
         return f"{self.api_root()}{path}"
 
     def get_user_details(self, response):
-        """Return user details from xPro account"""
+        """Return user details from MIT application account"""
         return {
             "username": response.get("username"),
             "email": response.get("email", ""),
@@ -57,7 +57,7 @@ class OLOAuth2(BaseOAuth2):
         }
 
     def user_data(self, access_token, *args, **kwargs):  # noqa: ARG002
-        """Loads user data from xpro"""  # noqa: D401
+        """Loads user data from MIT application"""  # noqa: D401
         url = self.api_url("api/users/me")
         headers = {"Authorization": f"Bearer {access_token}"}
         return self.get_json(url, headers=headers)

--- a/src/ol_social_auth/backends.py
+++ b/src/ol_social_auth/backends.py
@@ -3,10 +3,10 @@
 from social_core.backends.oauth import BaseOAuth2
 
 
-class MITxProOAuth2(BaseOAuth2):
+class OLOAuth2(BaseOAuth2):
     """MIT xPro social auth backend"""
 
-    name = "mitxpro-oauth2"
+    name = "ol-oauth2"
 
     ID_KEY = "username"
     REQUIRES_EMAIL_VALIDATION = False

--- a/src/ol_social_auth/tests/backends_test.py
+++ b/src/ol_social_auth/tests/backends_test.py
@@ -3,7 +3,6 @@
 from urllib.parse import urljoin
 
 import pytest
-
 from ol_social_auth.backends import OLOAuth2
 
 # pylint: disable=redefined-outer-name

--- a/src/ol_social_auth/tests/backends_test.py
+++ b/src/ol_social_auth/tests/backends_test.py
@@ -3,7 +3,8 @@
 from urllib.parse import urljoin
 
 import pytest
-from ol_social_auth.backends import MITxProOAuth2
+
+from ol_social_auth.backends import OLOAuth2
 
 # pylint: disable=redefined-outer-name
 
@@ -16,8 +17,8 @@ def strategy(mocker):
 
 @pytest.fixture()
 def backend(strategy):
-    """MITxProOAuth2 backend fixture"""
-    return MITxProOAuth2(strategy)
+    """OLOAuth2 backend fixture"""
+    return OLOAuth2(strategy)
 
 
 @pytest.mark.parametrize(

--- a/src/openedx_companion_auth/settings/common.py
+++ b/src/openedx_companion_auth/settings/common.py
@@ -6,7 +6,7 @@ Settings for openedx-companion-auth
 def plugin_settings(settings):
     """Apply default settings for this plugin"""
     settings.MITX_REDIRECT_ENABLED = True
-    settings.MITX_REDIRECT_LOGIN_URL = "/auth/login/mitxpro-oauth2/?auth_entry=login"
+    settings.MITX_REDIRECT_LOGIN_URL = "/auth/login/ol-oauth2/?auth_entry=login"
     settings.MITX_REDIRECT_ALLOW_RE_LIST = [
         r"^/(admin|auth|login|logout|register|api|oauth2|user_api)"
     ]

--- a/src/openedx_companion_auth/settings/test.py
+++ b/src/openedx_companion_auth/settings/test.py
@@ -16,7 +16,7 @@ def plugin_settings(  # type: ignore[no-redef]
     Configure the plugin for tests
     """
     settings.MITX_REDIRECT_ENABLED = True
-    settings.MITX_REDIRECT_LOGIN_URL = "/auth/login/mitxpro-oauth2/?auth_entry=login"
+    settings.MITX_REDIRECT_LOGIN_URL = "/auth/login/ol-oauth2/?auth_entry=login"
     settings.MITX_REDIRECT_ALLOW_RE_LIST = [
         r"^/(admin|auth|login|logout|register|api|oauth2|user_api)"
     ]

--- a/src/openedx_companion_auth/tests/middleware_test.py
+++ b/src/openedx_companion_auth/tests/middleware_test.py
@@ -36,7 +36,7 @@ def test_redirect_middleware(  # noqa: PLR0913
     should_redirect,
 ):  # pylint: disable=too-many-arguments
     """Test that the middleware redirects correctly"""
-    settings.MITX_REDIRECT_LOGIN_URL = "/mitxpro-oauth2/?auth_entry=login"
+    settings.MITX_REDIRECT_LOGIN_URL = "/ol-oauth2/?auth_entry=login"
     settings.MITX_REDIRECT_ENABLED = is_enabled
     settings.MITX_REDIRECT_ALLOW_RE_LIST = allowed_regexes
     settings.MITX_REDIRECT_DENY_RE_LIST = denied_regexes


### PR DESCRIPTION
### What are the relevant tickets?
First step of https://github.com/mitodl/hq/issues/5726#issuecomment-2416510876

### Description (What does it do?)
This PR updates the backend class name in `ol-social-auth` plugin to `OLOAuth2` and backend name to `ol-oauth2`. Additionally, it also updates `MITX_REDIRECT_LOGIN_URL` in openedx-companion-auth

### How can this be tested?
Follow the steps in https://github.com/mitodl/hq/issues/5726#issuecomment-2416510876 for local setup

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
