### PR TITLE
chore: update companion-auth version

### DIFF
--- a/src/openedx_companion_auth/BUILD
+++ b/src/openedx_companion_auth/BUILD
@@ -12,7 +12,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="openedx-companion-auth",
-        version="1.0.0",
+        version="1.1.0",
         description="A package to add login redirection from Open edX to MIT applications",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
https://github.com/mitodl/open-edx-plugins/commit/0fd7824c306b5a654003ca9721a08d39b699920a has been merged recently but the openedx-companion-auth version was not updated. This PR updates the openedx-companion-auth version to `1.1.0`

### How can this be tested?
- Run `pants package ::` and verify that the package is created with version `1.1.0`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
