### PR TITLE
build: Replace paver command for master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
         - 3.11
         edx_branch:
         - master
-        - open-release/quince.master
         - open-release/redwood.master
+        - open-release/sumac.master
           # Add more branches as needed
 
     steps:
@@ -31,13 +31,13 @@ jobs:
 
     - name: Install tutor
       run: |
-        if [[ "${{ matrix.edx_branch }}" == "open-release/quince.master" ]]; then
-          pip install tutor==17.0.6
+        if [[ "${{ matrix.edx_branch }}" == "open-release/redwood.master" ]]; then
+          pip install tutor==18.2.2
         elif [[ "${{ matrix.edx_branch }}" == "master" ]]; then
           git clone --branch=main https://github.com/overhangio/tutor.git
           pip install -e "./tutor"
         else
-          pip install tutor==18.0.0
+          pip install tutor==19.0.0
         fi
 
     - name: Set up tutor with edx-platform
@@ -60,7 +60,7 @@ jobs:
           DIRECTORY="tutor"
           DEV="tutor_dev"
         fi
-        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/$DIRECTORY/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD/../open-edx-plugins:/open-edx-plugins lms /open-edx-plugins/run_devstack_integration_tests.sh
+        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/$DIRECTORY/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD/../open-edx-plugins:/open-edx-plugins lms /open-edx-plugins/run_devstack_integration_tests.sh "${{ matrix.edx_branch }}"
 
     - name: Upload coverage to CodeCov
       uses: codecov/codecov-action@v4

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -8,15 +8,22 @@ pwd
 mkdir -p reports
 
 pip install -r ./requirements/edx/testing.txt
-pip install -r ./requirements/edx/paver.txt
+if [ "$1" != "master" ]; then
+    pip install -r ./requirements/edx/paver.txt
+fi
 
 # Installing edx-platform
 pip install -e .
 
 mkdir -p test_root  # for edx
-paver update_assets lms --settings=test_static_optimized
+if [ "$1" == "master" ]; then
+    npm run build && ./manage.py lms collectstatic --noinput && ./manage.py cms collectstatic
+    cp /openedx/staticfiles/webpack-stats.json test_root/staticfiles/webpack-stats.json
+else
+    paver update_assets lms --settings=test_static_optimized
+    cp test_root/staticfiles/lms/webpack-stats.json test_root/staticfiles/webpack-stats.json
+fi
 
-cp test_root/staticfiles/lms/webpack-stats.json test_root/staticfiles/webpack-stats.json
 cd /open-edx-plugins
 
 # Installing test dependencies


### PR DESCRIPTION
Paver is removed in master branch https://github.com/openedx/edx-platform/pull/36046

### What are the relevant tickets?
https://github.com/openedx/edx-platform/pull/36046

### Description (What does it do?)
This PR replaces Paver usage for master branch testing
