### PR TITLE
Allowed urls updated to bypass asset routes

### DIFF
--- a/src/openedx_companion_auth/BUILD
+++ b/src/openedx_companion_auth/BUILD
@@ -12,7 +12,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="openedx-companion-auth",
-        version="1.1.0",
+        version="1.1.1",
         description="A package to add login redirection from Open edX to MIT applications",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/openedx_companion_auth/settings/common.py
+++ b/src/openedx_companion_auth/settings/common.py
@@ -8,7 +8,7 @@ def plugin_settings(settings):
     settings.MITX_REDIRECT_ENABLED = True
     settings.MITX_REDIRECT_LOGIN_URL = "/auth/login/ol-oauth2/?auth_entry=login"
     settings.MITX_REDIRECT_ALLOW_RE_LIST = [
-        r"^/(admin|auth|login|logout|register|api|oauth2|user_api)"
+        r"^/(admin|auth|login|logout|register|api|oauth2|user_api|c4x|asset-v1:|assets/courseware/)"
     ]
     settings.MITX_REDIRECT_DENY_RE_LIST = []
 

--- a/src/openedx_companion_auth/settings/test.py
+++ b/src/openedx_companion_auth/settings/test.py
@@ -18,7 +18,7 @@ def plugin_settings(  # type: ignore[no-redef]
     settings.MITX_REDIRECT_ENABLED = True
     settings.MITX_REDIRECT_LOGIN_URL = "/auth/login/ol-oauth2/?auth_entry=login"
     settings.MITX_REDIRECT_ALLOW_RE_LIST = [
-        r"^/(admin|auth|login|logout|register|api|oauth2|user_api)"
+        r"^/(admin|auth|login|logout|register|api|oauth2|user_api|c4x|asset-v1:|assets/courseware/)"
     ]
     settings.MITX_REDIRECT_DENY_RE_LIST = []
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6479#issuecomment-2606061294

### Description (What does it do?)
This PR adds [new routes](https://github.com/openedx/edx-platform/blob/open-release/sumac.master/openedx/core/djangoapps/contentserver/urls.py) added for contentserver after [this implementation](https://github.com/openedx/edx-platform/issues/34702)

### How can this be tested?
1. Add Course assets from studio
2. Copy the web url
3. Open it in a new tab/incognito tab without login
4. It should be accessible if the asset is unlocked/public

### Additional Context
If the course asset is locked, it shouldn't be accessible
