### PR TITLE
docs: typo fix on individual plugin docs

### DIFF
--- a/src/edx_username_changer/README.rst
+++ b/src/edx_username_changer/README.rst
@@ -11,7 +11,7 @@ It only supports koa and latest releases of Open edX.
 Installing The Plugin
 ---------------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -48,7 +48,7 @@ Use ``0.1.1`` version of this plugin
 Installation
 ------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -12,7 +12,7 @@ MIT's AI chatbot for Open edX
 Setup
 =====
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_openedx_checkout_external/README.rst
+++ b/src/ol_openedx_checkout_external/README.rst
@@ -8,7 +8,7 @@ The plugin redirects the user the desired external ecommerce service upon clicki
 Installation
 ------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_openedx_course_export/README.rst
+++ b/src/ol_openedx_course_export/README.rst
@@ -7,7 +7,7 @@ A django app plugin to add a new API to Open edX to export courses to S3 buckets
 Installation
 ------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_openedx_course_structure_api/README.rst
+++ b/src/ol_openedx_course_structure_api/README.rst
@@ -7,7 +7,7 @@ A django app plugin to add a new API to Open edX to retrieve the JSON representa
 Installation
 ------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_openedx_otel_monitoring/README.rst
+++ b/src/ol_openedx_otel_monitoring/README.rst
@@ -7,7 +7,7 @@ This Django plugin integrates Open Telemetry, offering both tracing and metric f
 Installation
 ------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_openedx_rapid_response_reports/README.rst
+++ b/src/ol_openedx_rapid_response_reports/README.rst
@@ -23,7 +23,7 @@ This plugin generates reports for `Rapid Response xBlock <https://github.com/mit
 Installation
 ------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/ol_social_auth/README.rst
+++ b/src/ol_social_auth/README.rst
@@ -11,7 +11,7 @@ Compatible with all edx releases
 Installing The Plugin
 ---------------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/openedx_companion_auth/README.rst
+++ b/src/openedx_companion_auth/README.rst
@@ -11,7 +11,7 @@ Compatible with the Nutmeg release of the Open edX and onwards. May work with pr
 Installing The Plugin
 ---------------------
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 

--- a/src/rapid_response_xblock/README.rst
+++ b/src/rapid_response_xblock/README.rst
@@ -12,7 +12,7 @@ Setup
 In production, the current practice as of 01/2021 is to add this
 dependency via Salt.
 
-For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.``
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
 
 Installation required in:
 


### PR DESCRIPTION
### What are the relevant tickets?
#22 
### Description (What does it do?)
This PR fixes a typography error made in #435 . Key changes include:
1. Updates child README.rst files to remove `` at the end of this line `For detailed installation instructions, please refer to the plugin installation guide.`

### How can this be tested?
- Navigate to any plugin in the src directory
- Verify that no `` are present after this line `For detailed installation instructions, please refer to the plugin installation guide.`
- Verify that the relative link to central installation guide works