### PR TITLE
feat: add OL_OPENEDX_CHAT_ENABLED flag

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.2.0",
+        version="0.2.1",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -10,7 +10,7 @@ from xblock.core import XBlock, XBlockAside
 from xblock.fields import Boolean, Scope, String
 from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
 
-from .compat import get_enable_ol_openedx_chat_flag
+from .compat import get_ol_openedx_chat_enabled_flag
 
 
 def get_resource_bytes(path):
@@ -152,7 +152,7 @@ class OLChatAside(XBlockAside):
         instances, the problem type of the given block needs to be retrieved in
         different ways.
         """  # noqa: D401
-        return get_enable_ol_openedx_chat_flag().is_enabled(
+        return get_ol_openedx_chat_enabled_flag().is_enabled(
             block.scope_ids.usage_id.context_key
         ) and is_aside_applicable_to_block(block=block)
 

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -10,6 +10,8 @@ from xblock.core import XBlock, XBlockAside
 from xblock.fields import Boolean, Scope, String
 from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
 
+from .compat import get_enable_ol_openedx_chat_flag
+
 
 def get_resource_bytes(path):
     """
@@ -150,7 +152,9 @@ class OLChatAside(XBlockAside):
         instances, the problem type of the given block needs to be retrieved in
         different ways.
         """  # noqa: D401
-        return is_aside_applicable_to_block(block=block)
+        return get_enable_ol_openedx_chat_flag().is_enabled(
+            block.scope_ids.usage_id.context_key
+        ) and is_aside_applicable_to_block(block=block)
 
     @XBlock.handler
     def update_chat_config(self, request, suffix=""):  # noqa: ARG002

--- a/src/ol_openedx_chat/compat.py
+++ b/src/ol_openedx_chat/compat.py
@@ -12,7 +12,7 @@ WAFFLE_FLAG_NAMESPACE = "ol_openedx_chat"
 # .. toggle_creation_date: 2025-02-26
 # .. toggle_tickets: None
 # .. toggle_warning: None.
-ENABLE_OL_OPENEDX_CHAT = "enable_ol_openedx_chat"
+OL_OPENEDX_CHAT_ENABLED = "enable_ol_openedx_chat"
 
 
 def get_enable_ol_openedx_chat_flag():
@@ -21,4 +21,6 @@ def get_enable_ol_openedx_chat_flag():
     """
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
-    return CourseWaffleFlag(f"{WAFFLE_FLAG_NAMESPACE}.enable_ol_openedx_chat", __name__)
+    return CourseWaffleFlag(
+        f"{WAFFLE_FLAG_NAMESPACE}.{OL_OPENEDX_CHAT_ENABLED}", __name__
+    )

--- a/src/ol_openedx_chat/compat.py
+++ b/src/ol_openedx_chat/compat.py
@@ -1,0 +1,24 @@
+"""
+Compatibility layer to isolate core-platform method calls from implementation.
+"""
+
+WAFFLE_FLAG_NAMESPACE = "ol_openedx_chat"
+
+# .. toggle_name: ol_openedx_chat.enable_ol_openedx_chat
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables ol_openedx_chat plugin for a course.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2025-02-26
+# .. toggle_tickets: None
+# .. toggle_warning: None.
+ENABLE_OL_OPENEDX_CHAT = "enable_ol_openedx_chat"
+
+
+def get_enable_ol_openedx_chat_flag():
+    """
+    Import and return Waffle flag for enabling ol_openedx_chat.
+    """
+    from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+    return CourseWaffleFlag(f"{WAFFLE_FLAG_NAMESPACE}.enable_ol_openedx_chat", __name__)

--- a/src/ol_openedx_chat/compat.py
+++ b/src/ol_openedx_chat/compat.py
@@ -12,10 +12,10 @@ WAFFLE_FLAG_NAMESPACE = "ol_openedx_chat"
 # .. toggle_creation_date: 2025-02-26
 # .. toggle_tickets: None
 # .. toggle_warning: None.
-OL_OPENEDX_CHAT_ENABLED = "enable_ol_openedx_chat"
+OL_OPENEDX_CHAT_ENABLED = "ol_openedx_chat_enabled"
 
 
-def get_enable_ol_openedx_chat_flag():
+def get_ol_openedx_chat_enabled_flag():
     """
     Import and return Waffle flag for enabling ol_openedx_chat.
     """

--- a/src/ol_openedx_chat/compat.py
+++ b/src/ol_openedx_chat/compat.py
@@ -4,7 +4,7 @@ Compatibility layer to isolate core-platform method calls from implementation.
 
 WAFFLE_FLAG_NAMESPACE = "ol_openedx_chat"
 
-# .. toggle_name: ol_openedx_chat.enable_ol_openedx_chat
+# .. toggle_name: ol_openedx_chat.ol_openedx_chat_enabled
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Enables ol_openedx_chat plugin for a course.


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6825

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a waffle flag ol_openedx_chat.ol_openedx_chat_enabled to enable ol_openedx_chat for a single course.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
When the waffle flag is enabled for a course:
<img width="1735" alt="Screenshot 2025-02-26 at 6 10 51 PM" src="https://github.com/user-attachments/assets/fcc291eb-e574-4f43-8830-fcd574131ae0" />

When the waffle flag is not enabled for the course:
<img width="1735" alt="Screenshot 2025-02-26 at 6 10 59 PM" src="https://github.com/user-attachments/assets/974887f1-4af6-4d23-826e-8951d69fda08" />

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Generate package by checking out this branch and running `pants package :: .`
- Enable xBlock configurations in CMS <STUDIO_URL>/admin/xblock_config/studioconfig/
- Enable xBlock asides in LMS <LMS_URL>/admin/lms_xblock/xblockasidesconfig/
- Install the ol-openedx-chat in LMS and CMS, Reload them
- In frontend-app-learning:
  - Create env.config.jsx and add the below code:
```
import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js"

remoteAiChatDrawer.init({
  messageOrigin: "http://local.openedx.io:8000",
  transformBody: messages => ({ message: messages[messages.length - 1].content }),
})

const config = {
  ...process.env,
};

export default config;
```
- Now run the below in the shell inside the learning MFE folder:
- `npm pack @mitodl/smoot-design@3.4.0`
- `tar -xvzf mitodl-smoot-design-3.4.0.tgz`
- `mv package mitodl-smoot-design`
- Now start learning MFE by `npm run dev`
- Now enable the `ol_openedx_chat.ol_openedx_chat_enabled` waffle flag for a course at <LMS_URL>/admin/waffle_utils/waffleflagcourseoverridemodel/
- Verify that the chat options are only enabled for this course and are disabled for all others.
- Visit the CMS and enable the chat for a few problem and video blocks.
- Visit LMS and you should see the button for AI Chat drawer and clicking on the button should open a drawer.
- To communicate with the LEARN AI backend, you can add the API URL in LMS private.py: `LEARN_AI_API_URL = "http://ai.open.odl.local:8002/http/recommendation_agent/"`
