### PR TITLE
feat: remove extra ai assistant config fields

### DIFF
--- a/src/ol_openedx_chat/static/html/studio_view.html
+++ b/src/ol_openedx_chat/static/html/studio_view.html
@@ -1,33 +1,9 @@
 <div class="form-container">
     <form id="ol-chat-form" data-block-id="{{ block_id }}">
-        <!-- Text Fields -->
-        <label for="chat-prompts">Enter Prompts to assist students</label>
-        <textarea id="chat-prompts" name="chat-prompts" placeholder="Where can I find more information on Large Language Models?" required>{{ chat_prompts }}</textarea>
-        <label class="sub-label">Learners will see these prompts when using the chatbot feature</label>
-        <!-- Text Fields -->
-        <label for="ask-tim-drawer-title">Enter the Chat Drawer title</label>
-        <input type="text" id="ask-tim-drawer-title" name="ask-tim-drawer-title" value="{{ ask_tim_drawer_title }}" required>
-        <label class="sub-label">Learners will see this as the title of the Chat Drawer.</label>
-        <!-- Dropdown -->
-        <label for="llm-model-dropdown">Choose the Large Language Model (LLM) to use for this question</label>
-        <select class="llm-dropdown" id="llm-model-dropdown" name="llm-model-dropdown" value="{{ llm_model }}" required>
-            <option>-- Select an LLM Model --</option>
-            {% for llm_model in llm_models_list %}
-                <option {% if selected_llm_model == llm_model %} selected {% endif %}>{{ llm_model }}</option>
-            {% endfor %}
-        </select>
-        <label class="sub-label">Set this so that AI instructions can be more formal, instructive, conversational, technical based on your choice</label>
-
-        <!-- Text Fields -->
-        <label for="additional-solution">Enter the solution</label>
-        <textarea type="text" id="additional-solution" name="additional-solution" placeholder="Add additional solution">{{ additional_solution }}</textarea>
-
-        <label class="sub-label">The more you add here, the more helpful it will be to Learners. We will train our Model to understand the solution, understand potential mistakes learners might make, and assist the Learner without giving direct answers. Links can also be used here to assist Learners find the content from previous course pages or websites. </label>
-
         <!-- Checkbox -->
         <div class="checkbox-container">
             <input class="enabled-check" type="checkbox" id="is-enabled-{{ block_id }}" name="is-enabled" {% if is_enabled %} checked {% endif %}/>
-            <label class="enabled-label" for="is-enabled-{{ block_id }}">Enable</label>
+            <label class="enabled-label" for="is-enabled-{{ block_id }}">Enable AI Chat Assistant</label>
         </div>
 
         <!-- Save Button -->

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -4,7 +4,7 @@
 
       const INITIAL_MESSAGES = [
         {
-          content: "Hi! What are you interested in learning about?",
+          content: "Hi! Do you need any help?",
           role: "assistant",
         },
       ];

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -8,10 +8,8 @@
           role: "assistant",
         },
       ];
-      $(`#chat-button-${init_args.block_usage_key}`).on("click", { starters: init_args.starters, askTimTitle: init_args.ask_tim_drawer_title }, function (event) {
-        const starters = event.data.starters.map(message => ({ content: message }));
+      $(`#chat-button-${init_args.block_usage_key}`).on("click", { askTimTitle: init_args.ask_tim_drawer_title }, function (event) {
         const blockKey = $(this).data("block-key");
-
         window.parent.postMessage(
           {
             type: "smoot-design::chat-open",
@@ -20,7 +18,6 @@
               askTimTitle: event.data.askTimTitle,
               apiUrl: init_args.learn_ai_api_url,
               initialMessages: INITIAL_MESSAGES,
-              conversationStarters: starters,
             },
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin

--- a/src/ol_openedx_chat/static/js/studio.js
+++ b/src/ol_openedx_chat/static/js/studio.js
@@ -10,16 +10,11 @@
         chatForm.addEventListener("submit", function(event) {
             event.preventDefault();
             var studioRuntime = new window.StudioRuntime.v1();
-
-            const chatPromptsField = element.querySelector("#chat-prompts");
-            const askTIMTitleField = element.querySelector("#ask-tim-drawer-title");
-            const llmModelDropdown = element.querySelector("#llm-model-dropdown");
-            const additionalSolutionField = element.querySelector("#additional-solution");
             const enabledCheck = element.querySelector("#is-enabled-"+chatForm.dataset.blockId);
 
             // Get the handler URL
             const handlerUrl = studioRuntime.handlerUrl(element, 'update_chat_config');
-            var dataToPost = {"chat_prompts": chatPromptsField.value, "ask_tim_drawer_title": askTIMTitleField.value, "selected_llm_model": llmModelDropdown.value, "is_enabled": enabledCheck.checked, "additional_solution": additionalSolutionField.value};
+            var dataToPost = {"is_enabled": enabledCheck.checked};
 
             $.ajax({
                 url: handlerUrl,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6838

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removes extra config fields from the CMS for the AI Assistant.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
<img width="1735" alt="Screenshot 2025-02-28 at 7 18 10 PM" src="https://github.com/user-attachments/assets/4cb6b7b0-8be7-4238-ab43-4387a923371a" />
<img width="1735" alt="Screenshot 2025-02-28 at 7 18 19 PM" src="https://github.com/user-attachments/assets/5687fb24-d6d6-40b8-acc7-740cb1bfc5eb" />
<img width="1735" alt="Screenshot 2025-02-28 at 7 18 24 PM" src="https://github.com/user-attachments/assets/0d53264a-0173-495e-98bd-a3a0155de55d" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Generate package by checking out this branch and running `pants package :: .`
- Enable xBlock configurations in CMS <STUDIO_URL>/admin/xblock_config/studioconfig/
- Enable xBlock asides in LMS <LMS_URL>/admin/lms_xblock/xblockasidesconfig/
- Install the ol-openedx-chat in LMS and CMS, Reload them
- In frontend-app-learning:
  - Create env.config.jsx and add the below code:
```
import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js"

remoteAiChatDrawer.init({
  messageOrigin: "http://local.openedx.io:8000",
  transformBody: messages => ({ message: messages[messages.length - 1].content }),
})

const config = {
  ...process.env,
};

export default config;
```
- Now run the below in the shell inside the learning MFE folder:
- `npm pack @mitodl/smoot-design@3.4.0`
- `tar -xvzf mitodl-smoot-design-3.4.0.tgz`
- `mv package mitodl-smoot-design`
- Now start learning MFE by `npm run dev`
- Now enable the `ol_openedx_chat.ol_openedx_chat_enabled` waffle flag for a course at <LMS_URL>/admin/waffle_utils/waffleflagcourseoverridemodel/
- Verify that the chat options are only enabled for this course and are disabled for all others.
- Visit the CMS and enable the chat for a few problem and video blocks.
- You should only see the enable button now.
- Visit LMS and you should see the button for AI Chat drawer and clicking on the button should open a drawer.
- To communicate with the LEARN AI backend, you can add the API URL in LMS private.py: `LEARN_AI_API_URL = "http://ai.open.odl.local:8002/http/recommendation_agent/"`
