### PR TITLE
feat: add block usage key and transcript asset id

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.2.1",
+        version="0.2.2",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -89,8 +89,7 @@ class OLChatAside(XBlockAside):
         fragment.add_css(get_resource_bytes("static/css/ai_chat.css"))
         fragment.add_javascript(get_resource_bytes("static/js/ai_chat.js"))
 
-        request_opts = {
-            "block_id": block_id,
+        request_body = {
             "block_usage_key": block_usage_key,
         }
 
@@ -100,13 +99,13 @@ class OLChatAside(XBlockAside):
                 if transcripts_info.get("transcripts") and transcripts_info[
                     "transcripts"
                 ].get("en"):
-                    request_opts["transcript_asset_id"] = Transcript.asset_location(
+                    request_body["transcript_asset_id"] = Transcript.asset_location(
                         block.location,
                         transcripts_info["transcripts"][ENGLISH_LANGUAGE_TRANSCRIPT],
                     )
 
-            except Exception:
-                log.exception(
+            except Exception:  # noqa: BLE001
+                log.info(
                     "Error while fetching transcripts for block %s",
                     block.location,
                 )
@@ -114,9 +113,10 @@ class OLChatAside(XBlockAside):
         extra_context = {
             "ask_tim_drawer_title": f"about {block.display_name}",
             "user_id": self.runtime.user_id,
+            "block_id": block_id,
             "learn_ai_api_url": settings.LEARN_AI_API_URL,
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
-            "request_opts": request_opts,
+            "request_body": request_body,
         }
 
         fragment.initialize_js("AiChatAsideInit", json_args=extra_context)

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -98,7 +98,7 @@ class OLChatAside(XBlockAside):
                 transcripts_info = block.get_transcripts_info()
                 if transcripts_info.get("transcripts") and transcripts_info[
                     "transcripts"
-                ].get("en"):
+                ].get(ENGLISH_LANGUAGE_TRANSCRIPT):
                     request_body["transcript_asset_id"] = Transcript.asset_location(
                         block.location,
                         transcripts_info["transcripts"][ENGLISH_LANGUAGE_TRANSCRIPT],

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -72,13 +72,17 @@ class OLChatAside(XBlockAside):
         if not self.ol_chat_enabled:
             return fragment
 
+        block_id = self.scope_ids.usage_id.usage_key.block_id
+        block_usage_key = self.scope_ids.usage_id.usage_key
+        block_type = getattr(block, "category", None)
+
         fragment.add_content(
             render_template(
                 "static/html/student_view.html",
                 {
-                    "block_id": self.scope_ids.usage_id.usage_key.block_id,
-                    "block_usage_key": self.scope_ids.usage_id.usage_key,
-                    "block_type": getattr(block, "category", None),
+                    "block_id": block_id,
+                    "block_usage_key": block_usage_key,
+                    "block_type": block_type,
                 },
             )
         )
@@ -86,11 +90,11 @@ class OLChatAside(XBlockAside):
         fragment.add_javascript(get_resource_bytes("static/js/ai_chat.js"))
 
         request_opts = {
-            "block_id": self.scope_ids.usage_id.usage_key.block_id,
-            "block_usage_key": self.scope_ids.usage_id.usage_key,
+            "block_id": block_id,
+            "block_usage_key": block_usage_key,
         }
 
-        if getattr(block, "category", None) == VIDEO_BLOCK_CATEGORY:
+        if block_type == VIDEO_BLOCK_CATEGORY:
             try:
                 transcripts_info = block.get_transcripts_info()
                 if transcripts_info.get("transcripts") and transcripts_info[

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -70,7 +70,8 @@ class OLChatAside(XBlockAside):
             render_template(
                 "static/html/student_view.html",
                 {
-                    "block_key": self.scope_ids.usage_id.usage_key.block_id,
+                    "block_id": self.scope_ids.usage_id.usage_key.block_id,
+                    "block_usage_key": self.scope_ids.usage_id.usage_key,
                     "block_type": getattr(block, "category", None),
                 },
             )
@@ -79,7 +80,8 @@ class OLChatAside(XBlockAside):
         fragment.add_javascript(get_resource_bytes("static/js/ai_chat.js"))
         extra_context = {
             "ask_tim_drawer_title": f"about {block.display_name}",
-            "block_usage_key": self.scope_ids.usage_id.usage_key.block_id,
+            "block_id": self.scope_ids.usage_id.usage_key.block_id,
+            "block_usage_key": self.scope_ids.usage_id.usage_key,
             "user_id": self.runtime.user_id,
             "learn_ai_api_url": settings.LEARN_AI_API_URL,
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,

--- a/src/ol_openedx_chat/constants.py
+++ b/src/ol_openedx_chat/constants.py
@@ -1,3 +1,7 @@
 # The dictionary should contain all the block types for which the chat should be
 # applicable if a block has sub-blocks or sub category, that should be added in the list
-CHAT_APPLICABLE_BLOCKS = ["problem", "video"]
+VIDEO_BLOCK_CATEGORY = "video"
+PROBLEM_BLOCK_CATEGORY = "problem"
+CHAT_APPLICABLE_BLOCKS = [PROBLEM_BLOCK_CATEGORY, VIDEO_BLOCK_CATEGORY]
+
+ENGLISH_LANGUAGE_TRANSCRIPT = "en"

--- a/src/ol_openedx_chat/static/html/student_view.html
+++ b/src/ol_openedx_chat/static/html/student_view.html
@@ -1,5 +1,5 @@
 <div class="{{ block_type }}-block-chat-button-container">
-  <div class="ai-chat-button {{ block_type }}-block-chat-button" id="chat-button-{{ block_key }}" data-block-key="{{ block_key }}">
+  <div class="ai-chat-button {{ block_type }}-block-chat-button" id="chat-button-{{ block_id }}" data-block-id="{{ block_id }}">
     {% if block_type == "problem" %}
       <p>Help me with this problem</p>
     {% elif block_type == "video" %}
@@ -7,5 +7,5 @@
     {% endif %}
     <img src="/static/images/icon.svg" class="chat-icon">
   </div>
-  <div id="app-root-{{ block_key }}"></div>
+  <div id="app-root-{{ block_id }}"></div>
 </div>

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -9,20 +9,21 @@
         },
       ];
 
-      $(`#chat-button-${init_args.request_opts.block_id}`).on("click", {
+      $(`#chat-button-${init_args.block_id}`).on("click", {
         askTimTitle: init_args.ask_tim_drawer_title,
-        requestOpts: init_args.request_opts,
+        blockID: init_args.block_id,
+        requestBody: init_args.request_body,
       }, function (event) {
 
         window.parent.postMessage(
           {
             type: "smoot-design::chat-open",
             payload: {
-              chatId: event.data.requestOpts.block_id,
+              chatId: event.data.blockID,
               askTimTitle: event.data.askTimTitle,
               apiUrl: init_args.learn_ai_api_url,
               initialMessages: INITIAL_MESSAGES,
-              requestOpts: event.data.requestOpts,
+              requestBody: event.data.requestBody,
             },
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -9,24 +9,20 @@
         },
       ];
 
-      $(`#chat-button-${init_args.block_id}`).on("click", {
+      $(`#chat-button-${init_args.request_opts.block_id}`).on("click", {
         askTimTitle: init_args.ask_tim_drawer_title,
-        blockUsageKey: init_args.block_usage_key,
-        blockID: init_args.block_id,
-        transcriptAssetID: init_args.transcript_asset_id
+        requestOpts: init_args.request_opts,
       }, function (event) {
 
         window.parent.postMessage(
           {
             type: "smoot-design::chat-open",
             payload: {
-              chatId: event.data.blockID,
+              chatId: event.data.requestOpts.block_id,
               askTimTitle: event.data.askTimTitle,
               apiUrl: init_args.learn_ai_api_url,
               initialMessages: INITIAL_MESSAGES,
-              blockID: event.data.blockID,
-              blockUsageKey: event.data.blockUsageKey,
-              transcriptAssetID: event.data.transcriptAssetID,
+              requestOpts: event.data.requestOpts,
             },
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -12,7 +12,8 @@
       $(`#chat-button-${init_args.block_id}`).on("click", {
         askTimTitle: init_args.ask_tim_drawer_title,
         blockUsageKey: init_args.block_usage_key,
-        blockID: init_args.block_id
+        blockID: init_args.block_id,
+        transcriptAssetID: init_args.transcript_asset_id
       }, function (event) {
 
         window.parent.postMessage(
@@ -25,6 +26,7 @@
               initialMessages: INITIAL_MESSAGES,
               blockID: event.data.blockID,
               blockUsageKey: event.data.blockUsageKey,
+              transcriptAssetID: event.data.transcriptAssetID,
             },
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -8,20 +8,28 @@
           role: "assistant",
         },
       ];
-      $(`#chat-button-${init_args.block_usage_key}`).on("click", { askTimTitle: init_args.ask_tim_drawer_title }, function (event) {
-        const blockKey = $(this).data("block-key");
+
+      $(`#chat-button-${init_args.block_id}`).on("click", {
+        askTimTitle: init_args.ask_tim_drawer_title,
+        blockUsageKey: init_args.block_usage_key,
+        blockID: init_args.block_id
+      }, function (event) {
+
         window.parent.postMessage(
           {
             type: "smoot-design::chat-open",
             payload: {
-              chatId: blockKey,
+              chatId: event.data.blockID,
               askTimTitle: event.data.askTimTitle,
               apiUrl: init_args.learn_ai_api_url,
               initialMessages: INITIAL_MESSAGES,
+              blockID: event.data.blockID,
+              blockUsageKey: event.data.blockUsageKey,
             },
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin
         );
+
       });
     });
   }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6843

### Description (What does it do?)
<!--- Describe your changes in detail -->
Passes the block usage key and transcripts asset ID.

Here are the example block usage keys:
```
Video: block-v1:testx+test101+2024_T1+type@video+block@d6d49d1d72f942cd9d534a54f99d8a87
Dropdown: block-v1:testx+test101+2024_T1+type@problem+block@a5e043d9325e4ed9b8912d1131051321
MCQ: block-v1:testx+test101+2024_T1+type@problem+block@be69872810904ad195e8ec9241a59e5d
```
Here is an example Asset ID for the video block English transcript:
`asset-v1:testx+test101+2024_T1+type@asset+block@91204cd0-44cb-4b68-9e44-303ff8ffc2e3-en.srt`


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Generate package by checking out this branch and running `pants package :: .`
- Enable xBlock configurations in CMS <STUDIO_URL>/admin/xblock_config/studioconfig/
- Enable xBlock asides in LMS <LMS_URL>/admin/lms_xblock/xblockasidesconfig/
- Install the ol-openedx-chat in LMS and CMS, Reload them
  - make sure to install the latest version 0.2.2
- In frontend-app-learning:
  - Create env.config.jsx and add the below code:
```
import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js"

remoteAiChatDrawer.init({
  messageOrigin: "http://local.openedx.io:8000",
  transformBody: messages => ({ message: messages[messages.length - 1].content }),
})

const config = {
  ...process.env,
};

export default config;
```
- Now run the below in the shell inside the learning MFE folder:
- `npm pack @mitodl/smoot-design@3.4.0`
- `tar -xvzf mitodl-smoot-design-3.4.0.tgz`
- `mv package mitodl-smoot-design`
- Now start learning MFE by `npm run dev`
- Now enable the `ol_openedx_chat.ol_openedx_chat_enabled` waffle flag for a course at <LMS_URL>/admin/waffle_utils/waffleflagcourseoverridemodel/
- Verify that the chat options are only enabled for this course and are disabled for all others.
- Visit the CMS and enable the chat for a few problem and video blocks.
- For the video block:
  - Click on Edit button at the right top of the block in CMS
  <img width="1735" alt="Screenshot 2025-03-03 at 10 02 27 PM" src="https://github.com/user-attachments/assets/9300dee0-c8c8-49b1-8105-f3c7300fa44d" />
  - Click on `import youtube transcript`.
  <img width="1735" alt="Screenshot 2025-03-03 at 10 02 47 PM" src="https://github.com/user-attachments/assets/d99c1217-6542-48f7-9626-c0a0aa935206" />
  - When we fetch transcripts, it returns an empty list. We will have to manually upload transcripts.
  - Click on the `Download Transcript for Editing`
  <img width="1735" alt="Screenshot 2025-03-03 at 10 03 12 PM" src="https://github.com/user-attachments/assets/ae60ecad-228d-4962-88dc-179d8ada705e" />
  - Now upload the downloaded file
  <img width="1735" alt="Screenshot 2025-03-03 at 10 03 43 PM" src="https://github.com/user-attachments/assets/bf7bfd20-6bf9-47ed-a588-6ae2872172fc" />
  - Save the settings, enable the AI Assistant, and Publish the unit.
- Visit LMS and you should see the button for AI Chat drawer and clicking on the button should open a drawer.
- Block usage key and Asset ID are passed to the drawer. You can check by adding a console log in ai_chat.js at line 16
  - `console.log(event.data.requestOpts)`
- To communicate with the LEARN AI backend, you can add the API URL in LMS private.py: `LEARN_AI_API_URL = "http://ai.open.odl.local:8002/http/recommendation_agent/"`