### PR TITLE
feat: enable unit publish when ai chat is enabled/disabled

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.2.3",
+        version="0.2.4",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/static/css/studio.css
+++ b/src/ol_openedx_chat/static/css/studio.css
@@ -1,59 +1,20 @@
-.form-container {
-    margin: 20px auto;
-    padding: 20px;
-    background-color: #f9f9f9;
-}
-.form-container label {
-    display: block;
-    margin: 18px 0 8px;
-    font-weight: 400;
-    font-size: 14px;
-    font-style: normal;
-}
-.form-container input,
-.form-container select,
-.form-container textarea {
-    width: 100%;
-    min-height: 96px;
-    font-style: normal;
-    font-size: 16px;
-    font-weight: 400;
-}
-.form-container button {
-    width: 100%;
-    padding: 8px;
-    margin-bottom: 10px;
-}
-
-.checkbox-container {
+.enable-ai-assistant-container {
     display: flex;
     align-items: center;
     padding: 16px 0;
-}
-.enabled-check {
-    min-height: 16px !important;
-    width: auto !important;
-    margin-right: 8px;
-}
-.enabled-label {
-    margin: 0 !important;
-}
+    margin-left: 20px;
 
-.sub-label {
-    font-size: 12px !important;
-    font-weight: 400 !important;
-    margin: 2px 0 8px !important;
+    .enabled-check {
+        min-height: 16px !important;
+        width: auto !important;
+        margin-right: 8px;
+    }
 
-}
-
-.llm-dropdown {
-    height: 48px !important;
-    min-height: 48px !important;
-}
-.enabled-checkbox {
-    min-height: auto !important;
-}
-
-#ask-tim-drawer-title {
-    min-height: unset;
+    .enabled-label {
+        margin: 0 !important;
+        display: block;
+        font-weight: 400;
+        font-size: 14px;
+        font-style: normal;
+    }
 }

--- a/src/ol_openedx_chat/static/html/studio_view.html
+++ b/src/ol_openedx_chat/static/html/studio_view.html
@@ -1,12 +1,4 @@
-<div class="form-container">
-    <form id="ol-chat-form" data-block-id="{{ block_id }}">
-        <!-- Checkbox -->
-        <div class="checkbox-container">
-            <input class="enabled-check" type="checkbox" id="is-enabled-{{ block_id }}" name="is-enabled" {% if is_enabled %} checked {% endif %}/>
-            <label class="enabled-label" for="is-enabled-{{ block_id }}">Enable AI Chat Assistant</label>
-        </div>
-
-        <!-- Save Button -->
-        <button type="submit" id="save-chat-config">Save</button>
-    </form>
+<div class="enable-ai-assistant-container">
+  <input class="enabled-check" type="checkbox" id="is-enabled-{{ block_id }}" name="is-enabled" {% if is_enabled %} checked {% endif %}/>
+  <label class="enabled-label" for="is-enabled-{{ block_id }}">Enable AI Chat Assistant</label>
 </div>

--- a/src/ol_openedx_chat/static/js/studio.js
+++ b/src/ol_openedx_chat/static/js/studio.js
@@ -2,35 +2,40 @@
     'use strict';
 
     function OpenLearningChatView(runtime, element) {
-        // Sometimes the element is a jQuery object instead of a DOM object which leads to the broken chat form reference
-        if (element instanceof jQuery){
-            element = element[0]
-        }
-        const chatForm = element.querySelector("#ol-chat-form")
-        chatForm.addEventListener("submit", function(event) {
-            event.preventDefault();
-            var studioRuntime = new window.StudioRuntime.v1();
-            const enabledCheck = element.querySelector("#is-enabled-"+chatForm.dataset.blockId);
+        var $element = $(element);
+        var AIChatConfigUpdateInProgress = false;
+        // we need studio runtime to get handler capable of saving xblock data
+        var studioRuntime = new window.StudioRuntime.v1();
 
-            // Get the handler URL
-            const handlerUrl = studioRuntime.handlerUrl(element, 'update_chat_config');
-            var dataToPost = {"is_enabled": enabledCheck.checked};
+        $($element).find('.enabled-check').change(function(e) {
+            var dataToPost = {"is_enabled": this.checked};
+            if (!AIChatConfigUpdateInProgress) {
+                AIChatConfigUpdateInProgress = true;
 
-            $.ajax({
-                url: handlerUrl,
-                method: 'POST',
-                data: JSON.stringify(dataToPost),
-                contentType: 'application/json; charset=utf-8',
-                success: function (response) {
-                    alert("Saved successfully!");
-                },
-                error: function (xhr, status, error) {
-                    alert("There was an error saving the details. Please try again");
-                }
-            });
+                e.preventDefault();
+                runtime.notify('save', {
+                    state: 'start',
+                    element: element,
+                    message: gettext('Updating Chat Config')
+                });
 
+                $.ajax({
+                    type: 'POST',
+                    url: studioRuntime.handlerUrl(element, 'update_chat_config'),
+                    data: JSON.stringify(dataToPost),
+                    dataType: 'json',
+                    contentType: 'application/json; charset=utf-8'
+                }).always(function() {
+                    runtime.notify('save', {
+                        state: 'end',
+                        element: element
+                    });
+                    AIChatConfigUpdateInProgress = false;
+                });
+            }
         });
     }
+
     function initializeOLChat(runtime, element) {
         return new OpenLearningChatView(runtime, element);
     }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6814

### Description (What does it do?)
<!--- Describe your changes in detail -->
Enables Unit publish when AI Chat is enabled or disabled. Also, removes the save button and relies on the checkbox to enable/disable.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
https://github.com/user-attachments/assets/b3878677-5037-4961-a03d-80e22c25a42b

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Generate package by checking out this branch and running `pants package :: .`
- Enable xBlock configurations in CMS <STUDIO_URL>/admin/xblock_config/studioconfig/
- Enable xBlock asides in LMS <LMS_URL>/admin/lms_xblock/xblockasidesconfig/
- Install the ol-openedx-chat in LMS and CMS, Reload them
  - make sure to install the latest version 0.2.4
- In frontend-app-learning:
  - Create env.config.jsx and add the below code:
```
import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js"

remoteAiChatDrawer.init({
  messageOrigin: "http://local.openedx.io:8000",
  transformBody: messages => ({ message: messages[messages.length - 1].content }),
})

const config = {
  ...process.env,
};

export default config;
```
- Now run the below in the shell inside the learning MFE folder:
- `npm pack @mitodl/smoot-design@3.4.0`
- `tar -xvzf mitodl-smoot-design-3.4.0.tgz`
- `mv package mitodl-smoot-design`
- Now start learning MFE by `npm run dev`
- Now enable the `ol_openedx_chat.ol_openedx_chat_enabled` waffle flag for a course at <LMS_URL>/admin/waffle_utils/waffleflagcourseoverridemodel/
- AI Assistant will be enabled for this course.
- Visit the CMS.
- Now you will see a single checkbox to enable the AI Chat, enabling/disabling should also enable the Unit Publish button.