### PR TITLE
feat: add different chat URLs for video and problems

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.2.5",
+        version="0.2.6",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -5,7 +5,11 @@ from django.conf import settings
 from django.template import Context, Template
 from django.utils.translation import gettext_lazy as _
 from ol_openedx_chat.compat import get_ol_openedx_chat_enabled_flag
-from ol_openedx_chat.constants import ENGLISH_LANGUAGE_TRANSCRIPT, VIDEO_BLOCK_CATEGORY
+from ol_openedx_chat.constants import (
+    ENGLISH_LANGUAGE_TRANSCRIPT,
+    LEARN_AI_CHAT_URL_PATH,
+    VIDEO_BLOCK_CATEGORY,
+)
 from ol_openedx_chat.utils import is_aside_applicable_to_block
 from rest_framework import status as api_status
 from web_fragments.fragment import Fragment
@@ -113,7 +117,8 @@ class OLChatAside(XBlockAside):
             "ask_tim_drawer_title": f"about {block.display_name}",
             "user_id": self.runtime.user_id,
             "block_id": block_id,
-            "learn_ai_api_url": settings.LEARN_AI_API_URL,
+            "edx_module_id": block_usage_key,
+            "chat_api_url": f"{settings.LEARN_AI_API_URL}/{LEARN_AI_CHAT_URL_PATH[block_type]}",  # noqa: E501
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "request_body": request_body,
         }

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from ol_openedx_chat.compat import get_ol_openedx_chat_enabled_flag
 from ol_openedx_chat.constants import (
     ENGLISH_LANGUAGE_TRANSCRIPT,
-    LEARN_AI_CHAT_URL_PATH,
+    MIT_AI_CHAT_URL_PATHS,
     VIDEO_BLOCK_CATEGORY,
 )
 from ol_openedx_chat.utils import is_aside_applicable_to_block
@@ -118,7 +118,7 @@ class OLChatAside(XBlockAside):
             "user_id": self.runtime.user_id,
             "block_id": block_id,
             "edx_module_id": block_usage_key,
-            "chat_api_url": f"{settings.LEARN_AI_API_URL}/{LEARN_AI_CHAT_URL_PATH[block_type]}",  # noqa: E501
+            "chat_api_url": f"{settings.LEARN_AI_API_URL}/{MIT_AI_CHAT_URL_PATHS[block_type]}",  # noqa: E501
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "request_body": request_body,
         }

--- a/src/ol_openedx_chat/constants.py
+++ b/src/ol_openedx_chat/constants.py
@@ -2,6 +2,10 @@
 # applicable if a block has sub-blocks or sub category, that should be added in the list
 VIDEO_BLOCK_CATEGORY = "video"
 PROBLEM_BLOCK_CATEGORY = "problem"
+LEARN_AI_CHAT_URL_PATH = {
+    VIDEO_BLOCK_CATEGORY: "http/video_gpt_agent/",
+    PROBLEM_BLOCK_CATEGORY: "http/tutor_agent/",
+}
 CHAT_APPLICABLE_BLOCKS = [PROBLEM_BLOCK_CATEGORY, VIDEO_BLOCK_CATEGORY]
 
 ENGLISH_LANGUAGE_TRANSCRIPT = "en"

--- a/src/ol_openedx_chat/constants.py
+++ b/src/ol_openedx_chat/constants.py
@@ -2,7 +2,11 @@
 # applicable if a block has sub-blocks or sub category, that should be added in the list
 VIDEO_BLOCK_CATEGORY = "video"
 PROBLEM_BLOCK_CATEGORY = "problem"
-LEARN_AI_CHAT_URL_PATH = {
+
+# The actual chat URL is `https://api-learn-ai.ol.mit.edu/http/video_gpt_agent/`
+# for video blocks and`https://api-learn-ai.ol.mit.edu/http/tutor_agent/`
+# for problem blocks.
+MIT_AI_CHAT_URL_PATHS = {
     VIDEO_BLOCK_CATEGORY: "http/video_gpt_agent/",
     PROBLEM_BLOCK_CATEGORY: "http/tutor_agent/",
 }

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -11,17 +11,22 @@
 
       $(`#chat-button-${init_args.block_id}`).on("click", {
         askTimTitle: init_args.ask_tim_drawer_title,
-        blockID: init_args.block_id,
+        blockId: init_args.block_id,
+        edxModuleId: init_args.edx_module_id,
         requestBody: init_args.request_body,
+        apiURL: init_args.chat_api_url
       }, function (event) {
+
+        console.log(event.data)
 
         window.parent.postMessage(
           {
             type: "smoot-design::chat-open",
             payload: {
-              chatId: event.data.blockID,
+              chatId: event.data.blockId,
+              edxModuleId: event.data.edxModuleId,
               askTimTitle: event.data.askTimTitle,
-              apiUrl: init_args.learn_ai_api_url,
+              apiUrl: event.data.apiURL,
               initialMessages: INITIAL_MESSAGES,
               requestBody: event.data.requestBody,
             },

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -17,8 +17,6 @@
         apiURL: init_args.chat_api_url
       }, function (event) {
 
-        console.log(event.data)
-
         window.parent.postMessage(
           {
             type: "smoot-design::chat-open",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds chat API URL based on the block type.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup ol-openedx-chat by following the [readme](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat).
- Now enable AI Chat for a video and problem block.
- Go to the LMS and verify that for video block the chat request is sent to `<LEARN_AI_API_URL>/http/video_gpt_agent/` and for problem block, it is sent to `<LEARN_AI_API_URL>/http/tutor_agent/`