### PR TITLE
feat: pass block type to chat drawer

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.2.6",
+        version="0.2.7",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -117,6 +117,7 @@ class OLChatAside(XBlockAside):
             "ask_tim_drawer_title": f"about {block.display_name}",
             "user_id": self.runtime.user_id,
             "block_id": block_id,
+            "block_type": block_type,
             "edx_module_id": block_usage_key,
             "chat_api_url": f"{settings.LEARN_AI_API_URL}/{MIT_AI_CHAT_URL_PATHS[block_type]}",  # noqa: E501
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -12,6 +12,7 @@
       $(`#chat-button-${init_args.block_id}`).on("click", {
         askTimTitle: init_args.ask_tim_drawer_title,
         blockId: init_args.block_id,
+        blockType: init_args.block_type,
         edxModuleId: init_args.edx_module_id,
         requestBody: init_args.request_body,
         apiURL: init_args.chat_api_url
@@ -22,6 +23,7 @@
             type: "smoot-design::chat-open",
             payload: {
               chatId: event.data.blockId,
+              blockType: event.data.blockType,
               edxModuleId: event.data.edxModuleId,
               askTimTitle: event.data.askTimTitle,
               apiUrl: event.data.apiURL,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Passes block type to the AI Chat drawer.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup by following the [Readme](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat).
- You can add console log in ai_chat.js to see what is available in event.data.blockType.