### PR TITLE
feat: update drawer payload

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.2.8",
+        version="0.3.0",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -37,7 +37,8 @@ Add the following configuration values to the config file in Open edX. For any r
 .. code-block::
 
     MIT_LEARN_AI_API_URL: <MIT_LEARN_AI_API_URL>
-    MIT_LEARN_API_URL: <MIT_LEARN_API_URL>
+    MIT_LEARN_API_BASE_URL: <MIT_LEARN_API_BASE_URL>
+    MIT_LEARN_SUMMARY_FLASHCARD_URL: <MIT_LEARN_SUMMARY_FLASHCARD_URL>
 
 
 2. Add database record

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -36,7 +36,8 @@ Add the following configuration values to the config file in Open edX. For any r
 
 .. code-block::
 
-    LEARN_AI_API_URL: <LEARN_AI_API_URL>
+    MIT_LEARN_AI_API_URL: <MIT_LEARN_AI_API_URL>
+    MIT_LEARN_API_URL: <MIT_LEARN_API_URL>
 
 
 2. Add database record

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -56,7 +56,7 @@ This will generate a bundle for the remoteAiChatDrawer. This bundle will be used
 
 .. code-block:: sh
 
-   npm pack @mitodl/smoot-design@^3.4.0
+   npm pack @mitodl/smoot-design@^5.0.0
    tar -xvzf mitodl-smoot-design*.tgz
    mv package mitodl-smoot-design
 
@@ -68,9 +68,9 @@ The Unit is rendered inside an Iframe and we use postMessage to communicate betw
 
    import { getConfig } from '@edx/frontend-platform';
 
-   import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js";
+   import * as remoteTutorDrawer from "./mitodl-smoot-design/dist/bundles/remoteTutorDrawer.umd.js";
 
-   remoteAiChatDrawer.init({
+   remoteTutorDrawer.init({
        messageOrigin: getConfig().LMS_BASE_URL,
        transformBody: messages => ({ message: messages[messages.length - 1].content }),
    })

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import quote as urlquote  # pylint: disable=ungrouped-imports
+from urllib.parse import quote as urlquote
 
 import pkg_resources
 from django.conf import settings

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import quote as urlquote  # pylint: disable=ungrouped-imports
 
 import pkg_resources
 from django.conf import settings
@@ -22,11 +23,6 @@ from webob.response import Response
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import Boolean, Scope
 from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
-
-try:
-    from django.utils.http import urlquote
-except ImportError:
-    from urllib.parse import quote as urlquote  # pylint: disable=ungrouped-imports
 
 log = logging.getLogger(__name__)
 
@@ -150,7 +146,7 @@ class OLChatAside(XBlockAside):
             url_quoted_transcript_id = urlquote(
                 str(request_body["transcript_asset_id"])
             )
-            content_url = f"{settings.MIT_LEARN_API_URL}/api/v1/contentfiles/?edx_module_id={url_quoted_transcript_id}"  # noqa: E501
+            content_url = f"{settings.MIT_LEARN_SUMMARY_FLASHCARD_URL}?edx_module_id={url_quoted_transcript_id}"  # noqa: E501
             extra_context["drawer_payload"].update(
                 {
                     "summary": {

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -129,9 +129,9 @@ class OLChatAside(XBlockAside):
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "drawer_payload": {
                 "blockType": block_type,
+                "title": f"about {block.display_name}",
                 "chat": {
                     "chatId": block_id,
-                    "askTimTitle": f"about {block.display_name}",
                     "initialMessages": TUTOR_INITIAL_MESSAGES,
                     "apiUrl": f"{settings.MIT_LEARN_AI_API_URL}/{MIT_AI_CHAT_URL_PATHS[block_type]}",  # noqa: E501
                     "requestBody": request_body,

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -150,7 +150,7 @@ class OLChatAside(XBlockAside):
             extra_context["drawer_payload"].update(
                 {
                     "summary": {
-                        "contentUrl": content_url,
+                        "apiUrl": content_url,
                     }
                 }
             )

--- a/src/ol_openedx_chat/constants.py
+++ b/src/ol_openedx_chat/constants.py
@@ -19,3 +19,10 @@ BLOCK_TYPE_TO_SETTINGS = {
 CHAT_APPLICABLE_BLOCKS = [PROBLEM_BLOCK_CATEGORY, VIDEO_BLOCK_CATEGORY]
 
 ENGLISH_LANGUAGE_TRANSCRIPT = "en"
+
+TUTOR_INITIAL_MESSAGES = [
+    {
+        "content": "Hi! Do you need any help?",
+        "role": "assistant",
+    },
+]

--- a/src/ol_openedx_chat/settings/common.py
+++ b/src/ol_openedx_chat/settings/common.py
@@ -8,4 +8,5 @@ def plugin_settings(settings):
     Populate common settings
     """
     env_tokens = getattr(settings, "ENV_TOKENS", {})
-    settings.LEARN_AI_API_URL = env_tokens.get("LEARN_AI_API_URL", "")
+    settings.MIT_LEARN_AI_API_URL = env_tokens.get("MIT_LEARN_AI_API_URL", "")
+    settings.MIT_LEARN_API_URL = env_tokens.get("MIT_LEARN_API_URL", "")

--- a/src/ol_openedx_chat/settings/common.py
+++ b/src/ol_openedx_chat/settings/common.py
@@ -9,4 +9,7 @@ def plugin_settings(settings):
     """
     env_tokens = getattr(settings, "ENV_TOKENS", {})
     settings.MIT_LEARN_AI_API_URL = env_tokens.get("MIT_LEARN_AI_API_URL", "")
-    settings.MIT_LEARN_API_URL = env_tokens.get("MIT_LEARN_API_URL", "")
+    settings.MIT_LEARN_API_BASE_URL = env_tokens.get("MIT_LEARN_API_BASE_URL", "")
+    settings.MIT_LEARN_SUMMARY_FLASHCARD_URL = env_tokens.get(
+        "MIT_LEARN_SUMMARY_FLASHCARD_URL", ""
+    )

--- a/src/ol_openedx_chat/settings/devstack.py
+++ b/src/ol_openedx_chat/settings/devstack.py
@@ -8,4 +8,5 @@ def plugin_settings(settings):
     Populate devstack settings
     """
     env_tokens = getattr(settings, "ENV_TOKENS", {})
-    settings.LEARN_AI_API_URL = env_tokens.get("LEARN_AI_API_URL", "")
+    settings.MIT_LEARN_AI_API_URL = env_tokens.get("MIT_LEARN_AI_API_URL", "")
+    settings.MIT_LEARN_API_URL = env_tokens.get("MIT_LEARN_API_URL", "")

--- a/src/ol_openedx_chat/settings/devstack.py
+++ b/src/ol_openedx_chat/settings/devstack.py
@@ -9,4 +9,7 @@ def plugin_settings(settings):
     """
     env_tokens = getattr(settings, "ENV_TOKENS", {})
     settings.MIT_LEARN_AI_API_URL = env_tokens.get("MIT_LEARN_AI_API_URL", "")
-    settings.MIT_LEARN_API_URL = env_tokens.get("MIT_LEARN_API_URL", "")
+    settings.MIT_LEARN_API_BASE_URL = env_tokens.get("MIT_LEARN_API_BASE_URL", "")
+    settings.MIT_LEARN_SUMMARY_FLASHCARD_URL = env_tokens.get(
+        "MIT_LEARN_SUMMARY_FLASHCARD_URL", ""
+    )

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -2,34 +2,14 @@
   function AiChatAsideView(runtime, element, block_element, init_args) {
     $(function ($) {
 
-      const INITIAL_MESSAGES = [
-        {
-          content: "Hi! Do you need any help?",
-          role: "assistant",
-        },
-      ];
-
       $(`#chat-button-${init_args.block_id}`).on("click", {
-        askTimTitle: init_args.ask_tim_drawer_title,
-        blockId: init_args.block_id,
-        blockType: init_args.block_type,
-        edxModuleId: init_args.edx_module_id,
-        requestBody: init_args.request_body,
-        apiURL: init_args.chat_api_url
+        payload: init_args.drawer_payload,
       }, function (event) {
 
         window.parent.postMessage(
           {
-            type: "smoot-design::chat-open",
-            payload: {
-              chatId: event.data.blockId,
-              blockType: event.data.blockType,
-              edxModuleId: event.data.edxModuleId,
-              askTimTitle: event.data.askTimTitle,
-              apiUrl: event.data.apiURL,
-              initialMessages: INITIAL_MESSAGES,
-              requestBody: event.data.requestBody,
-            },
+            type: "smoot-design::tutor-drawer-open",
+            payload: event.data.payload
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin
         );


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
A part of https://github.com/mitodl/hq/issues/6985

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Updates the drawer payload structure as per the drawer requirements.
- Adds a new setting MIT_LEARN_API_BASE_URL and renames `LEARN_AI_API_URL` to `MIT_ LEARN_AI_API_URL`.
- Also, add another setting for the video summary and flashcards to point to the API URL named `MIT_LEARN_SUMMARY_FLASHCARD_URL`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Follow the [updated readme](https://github.com/mitodl/open-edx-plugins/blob/4e66a20aaef5eceb710e0d0daf52ebc47c8a3e88/src/ol_openedx_chat/README.rst) from this PR to setup ol_openedx_chat.
- You can add a console log statement in ai_chat.js to see the payload.
- Verify that the drawer is working when enabled.
- Verify that chatting with a Problem block sends the expected request body by monitoring the network. It should have block_siblings.
- Verify that chatting with a Video block sends the expected request body by monitoring the network. It should have transcript_asset_id if transcript is available.
- Verify that the payload structure is as per the requirement in the issue. It should have a chat key for both Problem and Videos. Also, an extra summary key for the Videos.
