### PR TITLE
fix: implement create_user_task workaround

### DIFF
--- a/src/ol_openedx_course_export/app.py
+++ b/src/ol_openedx_course_export/app.py
@@ -31,3 +31,9 @@ class CourseExportConfig(AppConfig):
             }
         },
     }
+
+    def ready(self):
+        """
+        Import signals to enable celery task protocol workaround
+        """
+        import ol_openedx_course_export.signals

--- a/src/ol_openedx_course_export/signals.py
+++ b/src/ol_openedx_course_export/signals.py
@@ -1,0 +1,63 @@
+"""
+Signal handlers for the ol_openedx_course_export app.
+
+This module implements a workaround for a compatibility issue between django-user-tasks
+and Celery's protocol version 2. The create_user_task signal handler expects protocol
+version 1 format but receives version 2, causing TypeError exceptions in the logs.
+
+This fix wraps the original handler, converts protocol v2 messages to v1 format, and
+ensures UserTask-based tasks work properly without generating errors.
+"""
+
+from celery import signals, chain
+from user_tasks.signals import create_user_task
+from cms.celery import APP
+
+signals.before_task_publish.disconnect(create_user_task)
+
+
+def create_user_task_wrapper(sender=None, body=None, **kwargs):
+
+    return create_user_task(
+        sender,
+        body
+        if APP.conf.task_protocol == 1
+        else proto2_to_proto1(body, kwargs.get("headers", {})),
+    )
+
+
+signals.before_task_publish.connect(create_user_task_wrapper)
+
+
+def proto2_to_proto1(body, headers):
+    args, kwargs, embed = body
+    embedded = _extract_proto2_embed(**embed)
+    chained = embedded.pop("chain")
+    new_body = dict(
+        _extract_proto2_headers(**headers), args=args, kwargs=kwargs, **embedded
+    )
+    if chained:
+        new_body["callbacks"].append(chain(chained))
+    return new_body
+
+
+def _extract_proto2_headers(id, retries, eta, expires, group, timelimit, task, **_):
+    return {
+        "id": id,
+        "task": task,
+        "retries": retries,
+        "eta": eta,
+        "expires": expires,
+        "utc": True,
+        "taskset": group,
+        "timelimit": timelimit,
+    }
+
+
+def _extract_proto2_embed(callbacks, errbacks, chain, chord, **_):
+    return {
+        "callbacks": callbacks or [],
+        "errbacks": errbacks,
+        "chain": chain,
+        "chord": chord,
+    }


### PR DESCRIPTION
### What are the relevant tickets?
[#6807](https://github.com/mitodl/hq/issues/6807)

### Description (What does it do?)
This PR implements a workaround for an issue in the django-user-tasks library where the [create_user_task](https://github.com/openedx/django-user-tasks/blob/master/user_tasks/signals.py#L24) signal handler fails with TypeError('tuple indices must be integers or slices, not str') when processing Celery tasks with protocol version 2 (the default in recent Celery versions). This occurs when processing our [task_upload_course_s3](https://github.com/mitodl/open-edx-plugins/blob/main/src/ol_openedx_course_export/tasks.py#L19) task.

The django-user-tasks library was designed for Celery's protocol version 1, but our application uses protocol version 2. This causes errors in logs when tasks are published, though the tasks themselves still execute.

Changes:

- Disconnect the original signal handler
- Connect a wrapper function that detects the protocol version
- For protocol v2 messages, convert them to protocol v1 format before passing to the original handler
- For protocol v1 messages, pass them through unchanged