### PR TITLE
display title in v6 smoot-design drawer

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.3.1",
+        version="0.3.2",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -57,7 +57,7 @@ This will generate a bundle for the remoteAiChatDrawer. This bundle will be used
 
 .. code-block:: sh
 
-   npm pack @mitodl/smoot-design@^5.0.0
+   npm pack @mitodl/smoot-design@^6.0.0
    tar -xvzf mitodl-smoot-design*.tgz
    mv package mitodl-smoot-design
 

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -141,7 +141,8 @@ class OLChatAside(XBlockAside):
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "drawer_payload": {
                 "blockType": block_type,
-                "title": f"about {block.display_name}",
+                # Frontend will style AskTIM slightly
+                "title": f"AskTIM about {block.display_name}",
                 "chat": {
                     "chatId": block_id,
                     "initialMessages": TUTOR_INITIAL_MESSAGES,


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/6985

### Description (What does it do?)
This updates the plugin to send `AskTIM` in the title, which is what v6 of smoot-design wants.

### Screenshots (if appropriate):
<img width="1400" alt="Screenshot 2025-03-28 at 11 45 34 AM" src="https://github.com/user-attachments/assets/af774ccb-84e2-4a25-97dc-5fcd09e77bd3" />

<img width="1411" alt="Screenshot 2025-03-28 at 11 25 53 AM" src="https://github.com/user-attachments/assets/9ada3989-0ff6-4006-a591-73e662115265" />


### How can this be tested?
1. Run the plugin locally, following directions in `src/ol_openedx_chat/README.rst` In particular, use v6 of smoot-design
2. View a problem and video with tutor enabled. Observe that the title shows up correctly on all video tabs and in the tutor drawer.
- **NOTE:** If you actually want to see content in the drawer for the video, probably the easiest thing is to change the `content_url` value in `block.py` to be a static value like `"https://api.rc.learn.mit.edu/learn/api/v1/contentfiles/?edx_module_id=asset-v1%3AMITxT%2B3.012Sx%2B3T2024%2Btype%40asset%2Bblock%400cc53e11-1f91-4ed8-8bab-0d873db8cb90-en.srt"`