### PR TITLE
fix: recreate course key during course import

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.3.2",
+        version="0.3.3",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -13,9 +13,9 @@ from ol_openedx_chat.constants import (
     TUTOR_INITIAL_MESSAGES,
     VIDEO_BLOCK_CATEGORY,
 )
-from ol_openedx_chat.tests.utils import OLChatTestCase
 from opaque_keys.edx.asides import AsideUsageKeyV2
 from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lms
+from tests.utils import OLChatTestCase
 from xblock.core import XBlockAside
 from xmodule.modulestore import ModuleStoreEnum
 

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -1,7 +1,6 @@
 """Tests for the OLChatAside"""
 
 import json
-from datetime import datetime
 from unittest.mock import Mock, patch
 
 from ddt import data, ddt, unpack
@@ -14,88 +13,16 @@ from ol_openedx_chat.constants import (
     TUTOR_INITIAL_MESSAGES,
     VIDEO_BLOCK_CATEGORY,
 )
+from ol_openedx_chat.tests.utils import OLChatTestCase
 from opaque_keys.edx.asides import AsideUsageKeyV2
 from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lms
-from pytz import UTC
 from xblock.core import XBlockAside
-from xblock.runtime import DictKeyValueStore, KvsFieldData
-from xblock.test.tools import TestRuntime
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 
 @ddt
-class OLChatAsideTests(ModuleStoreTestCase):
+class OLChatAsideTests(OLChatTestCase):
     """Tests for OLChatAside logic"""
-
-    def setUp(self):
-        super().setUp()
-
-        key_store = DictKeyValueStore()
-        field_data = KvsFieldData(key_store)
-        self.runtime = TestRuntime(services={"field-data": field_data})
-
-        course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
-        self.course = BlockFactory.create(
-            parent_location=course.location,
-            category="course",
-            display_name="Test course",
-        )
-        self.chapter = BlockFactory.create(
-            parent_location=self.course.location,
-            category="chapter",
-            display_name="Week 1",
-            publish_item=True,
-            start=datetime(2015, 3, 1, tzinfo=UTC),
-        )
-        self.sequential = BlockFactory.create(
-            parent_location=self.chapter.location,
-            category="sequential",
-            display_name="Lesson 1",
-            publish_item=True,
-            start=datetime(2015, 3, 1, tzinfo=UTC),
-        )
-        self.vertical = BlockFactory.create(
-            parent_location=self.sequential.location,
-            category="vertical",
-            display_name="Subsection 1",
-            publish_item=True,
-            start=datetime(2015, 4, 1, tzinfo=UTC),
-        )
-
-        self.problem_block = BlockFactory.create(
-            category="problem",
-            parent_location=self.vertical.location,
-            display_name="A Problem Block",
-            weight=1,
-            user_id=self.user.id,
-            publish_item=False,
-        )
-        self.video_block = BlockFactory.create(
-            parent_location=self.vertical.location,
-            category="video",
-            display_name="My Video",
-            user_id=self.user.id,
-        )
-
-        self.aside_name = "ol_openedx_chat"
-        self.problem_aside_instance = self.create_aside(PROBLEM_BLOCK_CATEGORY)
-        self.video_aside_instance = self.create_aside(VIDEO_BLOCK_CATEGORY)
-        self.video_block.get_transcripts_info = Mock(
-            return_value={"transcripts": {"en": "video-transcript-en.srt"}}
-        )
-
-    def create_aside(self, block_type):
-        """
-        Create an aside instance.
-        """
-        def_id = self.runtime.id_generator.create_definition(block_type)
-        usage_id = self.runtime.id_generator.create_usage(def_id)
-        _, aside_id = self.runtime.id_generator.create_aside(
-            def_id, usage_id, self.aside_name
-        )
-        return self.runtime.get_aside(aside_id)
 
     @data(
         *[

--- a/src/ol_openedx_chat/tests/test_utils.py
+++ b/src/ol_openedx_chat/tests/test_utils.py
@@ -8,29 +8,33 @@ from ol_openedx_chat.utils import (
     is_aside_applicable_to_block,
     is_ol_chat_enabled_for_course,
 )
+from opaque_keys.edx.locator import CourseLocator
 
 
 @ddt
 class OLChatUtilTests(OLChatTestCase):
     @data(
         *[
-            ("problem", True, True, True),
-            ("problem", True, False, False),
-            ("problem", False, True, True),
-            ("problem", False, False, False),
-            ("video", True, True, True),
-            ("video", True, False, True),
-            ("video", False, True, False),
-            ("video", False, False, False),
+            ("problem", True, True, True, True),
+            ("problem", True, True, True, False),
+            ("problem", True, False, False, False),
+            ("problem", False, True, True, False),
+            ("problem", False, False, False, False),
+            ("video", True, True, True, True),
+            ("video", True, True, True, False),
+            ("video", True, False, True, False),
+            ("video", False, True, False, False),
+            ("video", False, False, False, False),
         ]
     )
     @unpack
-    def test_is_ol_chat_enabled_for_course(
+    def test_is_ol_chat_enabled_for_course(  # noqa: PLR0913
         self,
         block_category,
         video_block_setting,
         problem_block_setting,
         expected_is_enabled,
+        is_course_key_deprecated,
     ):
         """
         Test the is_ol_chat_enabled_for_course function
@@ -46,6 +50,13 @@ class OLChatUtilTests(OLChatTestCase):
             block = (
                 self.problem_block if block_category == "problem" else self.video_block
             )
+            if is_course_key_deprecated:
+                block.usage_key.course_key.deprecated = True
+                block.usage_key.course_key = CourseLocator(
+                    block.usage_key.course_key.org,
+                    block.usage_key.course_key.course,
+                    block.usage_key.course_key.run,
+                )
             assert is_ol_chat_enabled_for_course(block) == expected_is_enabled
 
     @data(

--- a/src/ol_openedx_chat/tests/test_utils.py
+++ b/src/ol_openedx_chat/tests/test_utils.py
@@ -1,60 +1,62 @@
 """Tests for the util methods"""
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-import pytest
+from ddt import data, ddt, unpack
+from ol_openedx_chat.tests.utils import OLChatTestCase
 from ol_openedx_chat.utils import (
     is_aside_applicable_to_block,
     is_ol_chat_enabled_for_course,
 )
 
 
-@pytest.mark.parametrize(
-    ("block_category", "is_aside_applicable"),
-    [
-        ("problem", True),
-        ("video", True),
-        ("html", False),
-    ],
-)
-def test_is_aside_applicable_to_block(block_category, is_aside_applicable):
-    """Tests that `is_aside_applicable_to_block` returns the expected value"""
-    assert (
-        is_aside_applicable_to_block(Mock(category=block_category))
-        == is_aside_applicable
+@ddt
+class OLChatUtilTests(OLChatTestCase):
+    @data(
+        *[
+            ("problem", True, True, True),
+            ("problem", True, False, False),
+            ("problem", False, True, True),
+            ("problem", False, False, False),
+            ("video", True, True, True),
+            ("video", True, False, True),
+            ("video", False, True, False),
+            ("video", False, False, False),
+        ]
     )
+    @unpack
+    def test_is_ol_chat_enabled_for_course(
+        self,
+        block_category,
+        video_block_setting,
+        problem_block_setting,
+        expected_is_enabled,
+    ):
+        """
+        Test the is_ol_chat_enabled_for_course function
+        """
+        """Tests that `is_ol_chat_enabled_for_course` returns the expected value"""
+        with patch(
+            "ol_openedx_chat.utils.get_course_by_id", new=self.course
+        ) as mock_get_course_by_id:
+            mock_get_course_by_id.return_value.other_course_settings = {
+                "OL_OPENEDX_CHAT_VIDEO_BLOCK_ENABLED": video_block_setting,
+                "OL_OPENEDX_CHAT_PROBLEM_BLOCK_ENABLED": problem_block_setting,
+            }
+            block = (
+                self.problem_block if block_category == "problem" else self.video_block
+            )
+            assert is_ol_chat_enabled_for_course(block) == expected_is_enabled
 
-
-@pytest.mark.parametrize(
-    (
-        "block_category",
-        "video_block_setting",
-        "problem_block_setting",
-        "expected_is_enabled",
-    ),
-    [
-        ("problem", True, True, True),
-        ("problem", True, False, False),
-        ("problem", False, True, True),
-        ("problem", False, False, False),
-        ("video", True, True, True),
-        ("video", True, False, True),
-        ("video", False, True, False),
-        ("video", False, False, False),
-    ],
-)
-def test_is_ol_chat_enabled_for_course(
-    block_category, video_block_setting, problem_block_setting, expected_is_enabled
-):
-    """Tests that `is_ol_chat_enabled_for_course` returns the expected value"""
-    with patch(
-        "ol_openedx_chat.utils.get_course_by_id", new=Mock()
-    ) as mock_get_course_by_id:
-        mock_get_course_by_id.return_value.other_course_settings = {
-            "OL_OPENEDX_CHAT_VIDEO_BLOCK_ENABLED": video_block_setting,
-            "OL_OPENEDX_CHAT_PROBLEM_BLOCK_ENABLED": problem_block_setting,
-        }
-        assert (
-            is_ol_chat_enabled_for_course(Mock(category=block_category))
-            == expected_is_enabled
-        )
+    @data(
+        *[
+            ("problem", True),
+            ("video", True),
+            ("html", False),
+        ]
+    )
+    @unpack
+    def test_is_aside_applicable_to_block(self, block_category, is_aside_applicable):
+        """Tests that `is_aside_applicable_to_block` returns the expected value"""
+        block = self.problem_block if block_category == "problem" else self.video_block
+        assert is_aside_applicable_to_block(block) == is_aside_applicable

--- a/src/ol_openedx_chat/tests/utils.py
+++ b/src/ol_openedx_chat/tests/utils.py
@@ -63,6 +63,12 @@ class OLChatTestCase(ModuleStoreTestCase):
             display_name="My Video",
             user_id=self.user.id,
         )
+        self.html_block = BlockFactory.create(
+            category="html",
+            parent_location=self.vertical.location,
+            display_name="An HTML Block",
+            user_id=self.user.id,
+        )
 
         self.aside_name = "ol_openedx_chat"
         self.problem_aside_instance = self.create_aside(PROBLEM_BLOCK_CATEGORY)

--- a/src/ol_openedx_chat/tests/utils.py
+++ b/src/ol_openedx_chat/tests/utils.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from unittest.mock import Mock
+
+from ol_openedx_chat.constants import (
+    PROBLEM_BLOCK_CATEGORY,
+    VIDEO_BLOCK_CATEGORY,
+)
+from pytz import UTC
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+from xblock.test.tools import TestRuntime
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
+
+
+class OLChatTestCase(ModuleStoreTestCase):
+    def setUp(self):
+        super().setUp()
+
+        key_store = DictKeyValueStore()
+        field_data = KvsFieldData(key_store)
+        self.runtime = TestRuntime(services={"field-data": field_data})
+
+        course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
+        self.course = BlockFactory.create(
+            parent_location=course.location,
+            category="course",
+            display_name="Test course",
+        )
+        self.chapter = BlockFactory.create(
+            parent_location=self.course.location,
+            category="chapter",
+            display_name="Week 1",
+            publish_item=True,
+            start=datetime(2015, 3, 1, tzinfo=UTC),
+        )
+        self.sequential = BlockFactory.create(
+            parent_location=self.chapter.location,
+            category="sequential",
+            display_name="Lesson 1",
+            publish_item=True,
+            start=datetime(2015, 3, 1, tzinfo=UTC),
+        )
+        self.vertical = BlockFactory.create(
+            parent_location=self.sequential.location,
+            category="vertical",
+            display_name="Subsection 1",
+            publish_item=True,
+            start=datetime(2015, 4, 1, tzinfo=UTC),
+        )
+
+        self.problem_block = BlockFactory.create(
+            category="problem",
+            parent_location=self.vertical.location,
+            display_name="A Problem Block",
+            weight=1,
+            user_id=self.user.id,
+            publish_item=False,
+        )
+        self.video_block = BlockFactory.create(
+            parent_location=self.vertical.location,
+            category="video",
+            display_name="My Video",
+            user_id=self.user.id,
+        )
+
+        self.aside_name = "ol_openedx_chat"
+        self.problem_aside_instance = self.create_aside(PROBLEM_BLOCK_CATEGORY)
+        self.video_aside_instance = self.create_aside(VIDEO_BLOCK_CATEGORY)
+        self.video_block.get_transcripts_info = Mock(
+            return_value={"transcripts": {"en": "video-transcript-en.srt"}}
+        )
+
+    def create_aside(self, block_type):
+        """
+        Create an aside instance.
+        """
+        def_id = self.runtime.id_generator.create_definition(block_type)
+        usage_id = self.runtime.id_generator.create_usage(def_id)
+        _, aside_id = self.runtime.id_generator.create_aside(
+            def_id, usage_id, self.aside_name
+        )
+        return self.runtime.get_aside(aside_id)

--- a/src/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/utils.py
@@ -21,15 +21,12 @@ def is_ol_chat_enabled_for_course(block):
     Returns:
         bool: True if OL Chat is enabled, False otherwise
     """
-    # This is kind of a hack for course import. During course import, the course_key
-    # string is in the format `{org}/{course_code}/{run_code}` and not in the format
-    # `course-v1:{org}+{course_code}+{run_code}`. This results in no course found.
-    if "/" in str(block.usage_key.course_key):
-        course_id = str(block.usage_key.course_key)
-        course_id = course_id.replace("/", "+")
-        course_id = CourseLocator.from_string(f"course-v1:{course_id}")
-    else:
-        course_id = block.usage_key.course_key
+    # During course import, the course_key uses older format `{org}/{course}/{run}`
+    # as explained in `edx-platform/xmodule/modulestore/xml.py:XMLModuleStore.get_id`.
+    # It results in no course found. We convert it to latest course key.
+    course_id = block.usage_key.course_key
+    if course_id.deprecated:
+        course_id = CourseLocator(course_id.org, course_id.course, course_id.run)
 
     course = get_course_by_id(course_id)
     other_course_settings = course.other_course_settings

--- a/src/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/utils.py
@@ -22,7 +22,7 @@ def is_ol_chat_enabled_for_course(block):
         bool: True if OL Chat is enabled, False otherwise
     """
     # During course import, the course_key uses older format `{org}/{course}/{run}`
-    # as explained in `https://github.com/open-craft/edx-platform/blob/8ad4d081fbdc024ed08cd1477380b395d78bb051/common/lib/xmodule/xmodule/modulestore/xml.py#L573`.
+    # as explained in `https://github.com/openedx/edx-platform/blob/8ad4d081fbdc024ed08cd1477380b395d78bb051/common/lib/xmodule/xmodule/modulestore/xml.py#L573`.
     # We convert it to the latest course key if course_id is deprecated/old format.
     course_id = block.usage_key.course_key
     if course_id.deprecated:

--- a/src/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/utils.py
@@ -22,8 +22,8 @@ def is_ol_chat_enabled_for_course(block):
         bool: True if OL Chat is enabled, False otherwise
     """
     # During course import, the course_key uses older format `{org}/{course}/{run}`
-    # as explained in `edx-platform/xmodule/modulestore/xml.py:XMLModuleStore.get_id`.
-    # It results in no course found. We convert it to latest course key.
+    # as explained in `https://github.com/open-craft/edx-platform/blob/8ad4d081fbdc024ed08cd1477380b395d78bb051/common/lib/xmodule/xmodule/modulestore/xml.py#L573`.
+    # We convert it to the latest course key if course_id is deprecated/old format.
     course_id = block.usage_key.course_key
     if course_id.deprecated:
         course_id = CourseLocator(course_id.org, course_id.course, course_id.run)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
A part of https://github.com/mitodl/hq/issues/4987#issuecomment-2775751816

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes an issue with the course import, during course import the course key is in the format `{org}/{course_code}/{run_code}`. This results in no course found when we get the course from modulestore to check the advanced settings.

Course import generates the old format key explicitly as explained in [get_id](https://github.com/openedx/edx-platform/blob/master/xmodule/modulestore/xml.py#L597) docs and comment.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout main branch Install the ol_openedx_chat plugin by following the [ReadME](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat). Install the latest 0.3.2 version.
- Now create a course with a few videos, and different problem types. Also, enable `Enable AI Chat Assistant` for a few videos and a few problems and keep it disabled for a few.
- Now export this course and import it in a new course.
- Course import will succeed but it won't import the problem and video blocks.
- Now, checkout this branch
- Build the package and install 0.3.3 version.
- Now, repeat the above steps.
- Videos and Problems should be imported. The state for `Enable AI Chat Assistant` should persist for the Problems. It won't persist for the videos.
- We are debugging the issue with the videos import.
