### PR TITLE
fix: should apply only checks for block type during course import

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.3.3",
+        version="0.3.4",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -202,8 +202,14 @@ class OLChatAside(XBlockAside):
         instances, the problem type of the given block needs to be retrieved in
         different ways.
         """  # noqa: D401
+        # During the course import, this method is called and the block is not
+        # updated with the course information where it is being imported.
+        # In that case, we cannot check for the course settings and waffle flag.
+        # We only check for the block type. For normal CMS and LMS flows, it will
+        # check for the course settings and waffle flag.
         if isinstance(block.runtime, ImportSystem):
             return is_aside_applicable_to_block(block=block)
+
         return (
             get_ol_openedx_chat_enabled_flag().is_enabled(
                 block.scope_ids.usage_id.context_key

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -22,6 +22,7 @@ from web_fragments.fragment import Fragment
 from webob.response import Response
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import Boolean, Scope
+from xmodule.modulestore.xml import ImportSystem
 from xmodule.video_block.transcripts_utils import (
     Transcript,
     get_available_transcript_languages,
@@ -201,6 +202,8 @@ class OLChatAside(XBlockAside):
         instances, the problem type of the given block needs to be retrieved in
         different ways.
         """  # noqa: D401
+        if isinstance(block.runtime, ImportSystem):
+            return is_aside_applicable_to_block(block=block)
         return (
             get_ol_openedx_chat_enabled_flag().is_enabled(
                 block.scope_ids.usage_id.context_key

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -18,6 +18,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lm
 from tests.utils import OLChatTestCase
 from xblock.core import XBlockAside
 from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.xml import ImportSystem
 
 
 @ddt
@@ -199,22 +200,25 @@ class OLChatAsideTests(OLChatTestCase):
 
     @data(
         *[
-            [PROBLEM_BLOCK_CATEGORY, True, True, True],
-            [PROBLEM_BLOCK_CATEGORY, False, True, False],
-            [PROBLEM_BLOCK_CATEGORY, True, False, False],
-            [PROBLEM_BLOCK_CATEGORY, False, False, False],
-            [VIDEO_BLOCK_CATEGORY, True, True, True],
-            [VIDEO_BLOCK_CATEGORY, False, True, False],
-            [VIDEO_BLOCK_CATEGORY, True, False, False],
-            [VIDEO_BLOCK_CATEGORY, False, False, False],
+            [PROBLEM_BLOCK_CATEGORY, True, True, True, True],
+            [PROBLEM_BLOCK_CATEGORY, False, True, False, False],
+            [PROBLEM_BLOCK_CATEGORY, True, False, False, False],
+            [PROBLEM_BLOCK_CATEGORY, False, False, False, False],
+            [PROBLEM_BLOCK_CATEGORY, False, False, True, True],
+            [VIDEO_BLOCK_CATEGORY, True, True, True, True],
+            [VIDEO_BLOCK_CATEGORY, False, True, False, False],
+            [VIDEO_BLOCK_CATEGORY, True, False, False, False],
+            [VIDEO_BLOCK_CATEGORY, False, False, False, False],
+            [VIDEO_BLOCK_CATEGORY, False, False, True, True],
         ]
     )
     @unpack
-    def test_should_apply_to_block(
+    def test_should_apply_to_block(  # noqa: PLR0913
         self,
         block_category,
         waffle_flag_enabled,
         other_course_setting_enabled,
+        is_import_runtime,
         should_apply,
     ):
         """
@@ -241,6 +245,10 @@ class OLChatAsideTests(OLChatTestCase):
                 if block_category == PROBLEM_BLOCK_CATEGORY
                 else self.video_block
             )
+
+            if is_import_runtime:
+                block.runtime = Mock(spec=ImportSystem)
+
             aside_instance = (
                 self.problem_aside_instance
                 if block_category == PROBLEM_BLOCK_CATEGORY

--- a/src/ol_openedx_chat/tests/test_utils.py
+++ b/src/ol_openedx_chat/tests/test_utils.py
@@ -7,40 +7,34 @@ from ol_openedx_chat.utils import (
     is_aside_applicable_to_block,
     is_ol_chat_enabled_for_course,
 )
-from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from tests.utils import OLChatTestCase
-from xmodule.modulestore.tests.factories import BlockFactory
 
 
 @ddt
 class OLChatUtilTests(OLChatTestCase):
     @data(
         *[
-            ("problem", True, True, True, True),
-            ("problem", True, True, True, False),
-            ("problem", True, False, False, False),
-            ("problem", False, True, True, False),
-            ("problem", False, False, False, False),
-            ("video", True, True, True, True),
-            ("video", True, True, True, False),
-            ("video", True, False, True, False),
-            ("video", False, True, False, False),
-            ("video", False, False, False, False),
+            ("problem", True, True, True),
+            ("problem", True, False, False),
+            ("problem", False, True, True),
+            ("problem", False, False, False),
+            ("video", True, True, True),
+            ("video", True, False, True),
+            ("video", False, True, False),
+            ("video", False, False, False),
         ]
     )
     @unpack
-    def test_is_ol_chat_enabled_for_course(  # noqa: PLR0913
+    def test_is_ol_chat_enabled_for_course(
         self,
         block_category,
         video_block_setting,
         problem_block_setting,
         expected_is_enabled,
-        is_course_key_deprecated,
     ):
         """
         Test the is_ol_chat_enabled_for_course function
         """
-        """Tests that `is_ol_chat_enabled_for_course` returns the expected value"""
         with patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id:
             self.course.other_course_settings = {
                 "OL_OPENEDX_CHAT_VIDEO_BLOCK_ENABLED": video_block_setting,
@@ -50,28 +44,19 @@ class OLChatUtilTests(OLChatTestCase):
             block = (
                 self.problem_block if block_category == "problem" else self.video_block
             )
-            if is_course_key_deprecated:
-                course_key = CourseLocator(
-                    block.usage_key.course_key.org,
-                    block.usage_key.course_key.course,
-                    block.usage_key.course_key.run,
-                    deprecated=True,
-                )
-                usage_key = BlockUsageLocator(
-                    course_key=course_key,
-                    block_type=block_category,
-                    block_id=block_category,
-                )
-                block = BlockFactory.create(
-                    category=block_category,
-                    parent_location=self.vertical.location,
-                    display_name=f"A {block_category} Block",
-                    user_id=self.user.id,
-                    location=usage_key,
-                )
-                assert is_ol_chat_enabled_for_course(block) == expected_is_enabled
-            else:
-                assert is_ol_chat_enabled_for_course(block) == expected_is_enabled
+            assert is_ol_chat_enabled_for_course(block) == expected_is_enabled
+
+    @data("problem", "video")
+    def test_is_ol_chat_enabled_for_course_when_no_course_found(self, block_category):
+        """
+        Test the `is_ol_chat_enabled_for_course` function when `get_course_by_id` fails
+        """
+        with patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id:
+            mock_get_course_by_id.side_effect = Exception()
+            block = (
+                self.problem_block if block_category == "problem" else self.video_block
+            )
+            assert is_ol_chat_enabled_for_course(block)
 
     @data(
         *[

--- a/src/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/utils.py
@@ -28,6 +28,9 @@ def is_ol_chat_enabled_for_course(block):
     if course_id.deprecated:
         course_id = CourseLocator(course_id.org, course_id.course, course_id.run)
 
+    # Sometimes we cannot find a course by the ID i.e. during course import.
+    # We return True in that case to avoid breaking the import process.
+    # This will work fine with LMS and CMS.
     try:
         course = get_course_by_id(course_id)
     except Exception:  # noqa: BLE001

--- a/src/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/utils.py
@@ -28,7 +28,11 @@ def is_ol_chat_enabled_for_course(block):
     if course_id.deprecated:
         course_id = CourseLocator(course_id.org, course_id.course, course_id.run)
 
-    course = get_course_by_id(course_id)
+    try:
+        course = get_course_by_id(course_id)
+    except Exception:  # noqa: BLE001
+        return True
+
     other_course_settings = course.other_course_settings
     block_type = getattr(block, "category", None)
     return other_course_settings.get(BLOCK_TYPE_TO_SETTINGS.get(block_type))


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/7076

### Description (What does it do?)
<!--- Describe your changes in detail -->
Do not check for course settings and waffle flag during XML course import.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup by following the readme
- end-to-end test course import and export.
- Course import and export should import all blocks and should retain the state for `Enable AI Chat Assistant`
- Test for different course run keys.
- Export a course from QA and import locally, it should work.

### Extra Context

For Video Asides, you can checkout the following branch https://github.com/openedx/edx-platform/pull/36500. Otherwise, it won't retain the state for the Video blocks.
