### PR TITLE
POC: add ol-openedx-course-propagator

### DIFF
--- a/src/ol_openedx_course_propagator/BUILD
+++ b/src/ol_openedx_course_propagator/BUILD
@@ -1,0 +1,26 @@
+python_sources(
+    name="ol_openedx_course_propagator_source",
+)
+
+python_distribution(
+    name="ol_openedx_course_propagator_package",
+    dependencies=[":ol_openedx_course_propagator_source"],
+    provides=setup_py(
+        name="ol-openedx-course-propagator",
+        version="0.1.0",
+        description="An edX plugin to propagate changes in a course to its child courses",
+        license="BSD-3-Clause",
+        author="MIT Office of Digital Learning",
+        include_package_data=True,
+        zip_safe=False,
+        keywords="Python edx",
+        entry_points={
+            "lms.djangoapp": [
+                "ol_openedx_course_propagator = ol_openedx_course_propagator.apps:OLOpenEdxCoursePropagatorConfig",
+            ],
+            "cms.djangoapp": [
+                "ol_openedx_course_propagator = ol_openedx_course_propagator.apps:OLOpenEdxCoursePropagatorConfig",
+            ],
+        },
+    ),
+)

--- a/src/ol_openedx_course_propagator/LICENCE.txt
+++ b/src/ol_openedx_course_propagator/LICENCE.txt
@@ -1,0 +1,28 @@
+Copyright (C) 2025  MIT Open Learning
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/ol_openedx_course_propagator/README.rst
+++ b/src/ol_openedx_course_propagator/README.rst
@@ -1,0 +1,18 @@
+edX Username Changer
+=======================
+
+A plugin to enable course updates propagation to the child/rerun courses.
+
+Version Compatibility
+---------------------
+
+It only supports latest releases of Open edX.
+
+Installing The Plugin
+---------------------
+
+For detailed installation instructions, please refer to the `plugin installation guide <../../docs#installation-guide>`_.
+
+Installation required in:
+
+* CMS

--- a/src/ol_openedx_course_propagator/__init__.py
+++ b/src/ol_openedx_course_propagator/__init__.py
@@ -1,0 +1,3 @@
+# pylint: disable=missing-module-docstring
+
+default_app_config = "ol_openedx_course_propagator.apps.OLOpenEdxCoursePropagatorConfig"

--- a/src/ol_openedx_course_propagator/apps.py
+++ b/src/ol_openedx_course_propagator/apps.py
@@ -1,0 +1,10 @@
+"""
+App configuration for ol-openedx-course-propagator plugin
+"""
+
+from django.apps import AppConfig
+
+
+class OLOpenEdxCoursePropagatorConfig(AppConfig):
+    name = "ol_openedx_course_propagator"
+    verbose_name = "Open edX Course Propagator"

--- a/src/ol_openedx_course_propagator/utils.py
+++ b/src/ol_openedx_course_propagator/utils.py
@@ -1,0 +1,30 @@
+"""
+Utility methods for ol-openedx-course-propagator plugin
+"""
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.django import SignalHandler
+from opaque_keys.edx.locator import CourseLocator
+
+def copy_course(user_id, source_course_id, dest_course_id):
+    """
+    Copy course content from source course to destination course.
+    """
+    module_store = modulestore()
+    source_course_key = CourseLocator.from_string(source_course_id)
+    source_course_draft = source_course_key.for_branch("draft-branch")
+    source_course_published = source_course_key.for_branch("published-branch")
+    subtree_list = [module_store.make_course_usage_key(source_course_key)]
+
+    dest_course_key = CourseLocator.from_string(dest_course_id)
+    dest_course_draft = dest_course_key.for_branch("draft-branch")
+    dest_course_published = dest_course_key.for_branch("published-branch")
+
+    source_modulestore = module_store._get_modulestore_for_courselike(source_course_key)
+    # for a temporary period of time, we may want to hardcode dest_modulestore as split if there's a split
+    # to have only course re-runs go to split. This code, however, uses the config'd priority
+    dest_modulestore = module_store._get_modulestore_for_courselike(dest_course_key)
+    if source_modulestore == dest_modulestore:
+        source_modulestore.copy(user_id, source_course_draft, dest_course_draft, subtree_list)
+        source_modulestore.copy(user_id, source_course_published, dest_course_published, subtree_list)
+        SignalHandler.course_published.send(sender=None, course_key=dest_course_key)
+        return


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/7197

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a new plugin to propagate changes from one course to other courses named `ol-openedx-course-propagator`.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Build the package using pants
- Install in the cms and restart the cms
- go to the CMS shell and run the below snippet:
```
from ol_openedx_course_propagator.utils import copy_course
copy_course(<USER_ID>, <SOURCE_COURSE_ID_STR>, <DEST_COURSE_ID_STR>)
```