### PR TITLE
fix(git-auto-export): Start export only if GIT_URL exists in the course settings

### DIFF
--- a/src/ol_openedx_git_auto_export/BUILD
+++ b/src/ol_openedx_git_auto_export/BUILD
@@ -12,7 +12,7 @@ python_distribution(
     dependencies=[":git_auto_export"],
     provides=setup_py(
         name="ol-openedx-git-auto-export",
-        version="0.3.1",
+        version="0.3.2",
         license="BSD-3-Clause",
         description="A plugin that auto saves the course OLX to git when an author publishes it",
         entry_points={

--- a/src/ol_openedx_git_auto_export/settings/common.py
+++ b/src/ol_openedx_git_auto_export/settings/common.py
@@ -5,5 +5,5 @@ from ol_openedx_git_auto_export.constants import ENABLE_GIT_AUTO_EXPORT
 
 def plugin_settings(settings):
     """Settings for the git auto export plugin."""  # noqa: D401
-    settings.GIT_REPO_EXPORT_DIR = "/edx/var/edxapp/export_course_repos"
+    settings.GIT_REPO_EXPORT_DIR = "/openedx/export_course_repos"
     settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = True

--- a/src/ol_openedx_git_auto_export/settings/production.py
+++ b/src/ol_openedx_git_auto_export/settings/production.py
@@ -5,5 +5,5 @@ from ol_openedx_git_auto_export.constants import ENABLE_GIT_AUTO_EXPORT
 
 def plugin_settings(settings):
     """Settings for the git auto export plugin."""  # noqa: D401
-    settings.GIT_REPO_EXPORT_DIR = "/edx/var/edxapp/export_course_repos"
+    settings.GIT_REPO_EXPORT_DIR = "/openedx/export_course_repos"
     settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = True

--- a/src/ol_openedx_git_auto_export/tasks.py
+++ b/src/ol_openedx_git_auto_export/tasks.py
@@ -15,13 +15,6 @@ def async_export_to_git(course_key_string, user=None):
     course_key = CourseKey.from_string(course_key_string)
     course_module = modulestore().get_course(course_key)
 
-    if course_module.giturl is None:
-        LOGGER.debug(
-            "Course %s does not have a giturl, skipping export.",
-            course_module.id,
-        )
-        return
-
     try:
         LOGGER.debug(
             "Starting async course content export to git (course id: %s)",

--- a/src/ol_openedx_git_auto_export/tasks.py
+++ b/src/ol_openedx_git_auto_export/tasks.py
@@ -15,6 +15,13 @@ def async_export_to_git(course_key_string, user=None):
     course_key = CourseKey.from_string(course_key_string)
     course_module = modulestore().get_course(course_key)
 
+    if course_module.giturl is None:
+        LOGGER.debug(
+            "Course %s does not have a giturl, skipping export.",
+            course_module.id,
+        )
+        return
+
     try:
         LOGGER.debug(
             "Starting async course content export to git (course id: %s)",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6803

### Description (What does it do?)
This PR:
1. Start course export on publish only when giturl exists

### How can this be tested?
1. Checkout to this branch
2. Create installable package by following the instructions in [Readme file](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_git_auto_export)
3. Install the package in edX.
4. Create a course in studio and make sure giturl value is set to empty or null in course advance settings
5. Publish the course
6. Keep an eye on logs -- you should see `Course {course_key} does not have a giturl, skipping export.` instead of error saying `'NoneType' object has no attribute 'endswith'`