### PR TITLE
chore(edx-sysadmin): Improve logging when incoming branch conflicts with setting branch

### DIFF
--- a/src/edx_sysadmin/BUILD
+++ b/src/edx_sysadmin/BUILD
@@ -21,7 +21,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="edx-sysadmin",
-        version="0.3.0",
+        version="0.3.1",
         description="An Open edX plugin to enable SysAdmin panel",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/edx_sysadmin/api/views.py
+++ b/src/edx_sysadmin/api/views.py
@@ -105,7 +105,7 @@ class GitReloadAPIView(APIView):
         if status_code == status.HTTP_200_OK:
             logger.info(f"{self.__class__.__name__}:: {msg}")  # noqa: G004
         else:
-            logger.debug(f"{self.__class__.__name__}:: {msg}")  # noqa: G004
+            logger.info(f"{self.__class__.__name__}:: {msg}")  # noqa: G004
 
         return Response(
             {"message": msg},

--- a/src/edx_sysadmin/api/views.py
+++ b/src/edx_sysadmin/api/views.py
@@ -58,7 +58,7 @@ class GitReloadAPIView(APIView):
                 err_msg = _("SYSADMIN_DEFAULT_BRANCH is not configured in settings")
             elif clean_pushed_branch != settings.SYSADMIN_DEFAULT_BRANCH:
                 err_msg = _(
-                    "Couldn't entertain reload request for the branch ({}), expected branch is ({}) "  # noqa: E501
+                    "Couldn't reload course from the branch ({}), expected branch was ({}) "  # noqa: E501
                 ).format(clean_pushed_branch, settings.SYSADMIN_DEFAULT_BRANCH)
             else:
                 repo = get_local_course_repo(repo_name)
@@ -93,8 +93,9 @@ class GitReloadAPIView(APIView):
                         return self.get_reload_response(
                             msg=msg, status_code=status.HTTP_200_OK
                         )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             err_msg = str(e)
+            logger.exception(f"{self.__class__.__name__}:: {err_msg}")  # noqa: G004
 
         return self.get_reload_response(
             msg=err_msg, status_code=status.HTTP_400_BAD_REQUEST
@@ -104,7 +105,7 @@ class GitReloadAPIView(APIView):
         if status_code == status.HTTP_200_OK:
             logger.info(f"{self.__class__.__name__}:: {msg}")  # noqa: G004
         else:
-            logger.exception(f"{self.__class__.__name__}:: {msg}")  # noqa: G004
+            logger.debug(f"{self.__class__.__name__}:: {msg}")  # noqa: G004
 
         return Response(
             {"message": msg},


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/2891#issuecomment-2855121735

### Description (What does it do?)
This PR:
1. Logs exception only when necessary

### How can this be tested?
1. Checkout to this branch
2. Create installable package by following the instructions in [Readme file](https://github.com/mitodl/open-edx-plugins/tree/main/src/edx_sysadmin)
3. Install the package in edX
4. Make sure you have setup the hook for course auto reload
5. Change the default branch setting for this plugin to something different. For example: `dummy`
6. Publish any course from studio without any change which will invoke the hook for edx_sysadmin > gitreload OR directly push changes to github repo whose hook is configured
7. Verify that there are debug logs like `Couldn't reload course for the branch` instead of exception
