### PR TITLE
chore: run CI for teak branch and remove redwood

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,11 @@ jobs:
     - name: Run tests on tutor
       run: |
         if [[ "${{ matrix.edx_branch }}" == "master" ]]; then
-          DIRECTORY="tutor-main"
           DEV="tutor_main_dev"
         else
-          DIRECTORY="tutor"
           DEV="tutor_dev"
         fi
-        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/tutor/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD/../open-edx-plugins:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh
+        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/tutor/env/local/docker-compose.yml -f /home/runner/.local/share/tutor/env/dev/docker-compose.yml --project-name $DEV run -v $PWD/../open-edx-plugins:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh
 
     - name: Upload coverage to CodeCov
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
### What are the relevant tickets?
None, Mainy, created this PR to run CI on Teak (The most recent edX release)

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Teak release has been cut by Open edX last month, and we should run our CI against that branch as well. Based on my analysis of [version_matrix](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/settings/openedx/version_matrix.py) in infrastructure, we are not running anything on redwood, so it's safe to remove.
- This PR also fixes how we set up the Tutor to run our tests, Fixes failing CI e.g., https://github.com/mitodl/open-edx-plugins/actions/runs/15921432982/job/44908904746
- Also fixes codecov warnings similar to https://github.com/mitodl/mitxpro/pull/3551


### How can this be tested?
- CI should pass for all the branches
- No CI for `redwood` branch
- Tests run on `Teak` branch as well
- No Codecov warning or errors
