### PR TITLE
Automatically sync assignments on Open edX to Canvas

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1373,13 +1373,13 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.32.1"
+version = "1.33.0"
 description = "OpenTelemetry Python API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_api-1.32.1-py3-none-any.whl", hash = "sha256:bbd19f14ab9f15f0e85e43e6a958aa4cb1f36870ee62b7fd205783a112012724"},
-    {file = "opentelemetry_api-1.32.1.tar.gz", hash = "sha256:a5be71591694a4d9195caf6776b055aa702e964d961051a0715d05f8632c32fb"},
+    {file = "opentelemetry_api-1.33.0-py3-none-any.whl", hash = "sha256:158df154f628e6615b65fdf6e59f99afabea7213e72c5809dd4adf06c0d997cd"},
+    {file = "opentelemetry_api-1.33.0.tar.gz", hash = "sha256:cc4380fd2e6da7dcb52a828ea81844ed1f4f2eb638ca3c816775109d93d58ced"},
 ]
 
 [package.dependencies]
@@ -1388,139 +1388,139 @@ importlib-metadata = ">=6.0,<8.7.0"
 
 [[package]]
 name = "opentelemetry-distro"
-version = "0.53b1"
+version = "0.54b0"
 description = "OpenTelemetry Python Distro"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_distro-0.53b1-py3-none-any.whl", hash = "sha256:3d24b6fd4b2c45c450c711932e2813dc13dba25772bb7da77cac56454a52a8ea"},
-    {file = "opentelemetry_distro-0.53b1.tar.gz", hash = "sha256:e01466aadfbebf01cb27c571186636f9fe40920740dcccdde9da3093d6b2af2d"},
+    {file = "opentelemetry_distro-0.54b0-py3-none-any.whl", hash = "sha256:8d4a53fe1fd0ab2d727ba5f4ab3f6c9f481ae4f8afa1d47ae19afbcbb95f227e"},
+    {file = "opentelemetry_distro-0.54b0.tar.gz", hash = "sha256:e486fc196a1a2514720a13762566cea8566a9243fdf91ed8539c5f1a7af5a42a"},
 ]
 
 [package.dependencies]
 opentelemetry-api = ">=1.12,<2.0"
-opentelemetry-instrumentation = "0.53b1"
+opentelemetry-instrumentation = "0.54b0"
 opentelemetry-sdk = ">=1.13,<2.0"
 
 [package.extras]
-otlp = ["opentelemetry-exporter-otlp (==1.32.1)"]
+otlp = ["opentelemetry-exporter-otlp (==1.33.0)"]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.32.1"
+version = "1.33.0"
 description = "OpenTelemetry Protobuf encoding"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_exporter_otlp_proto_common-1.32.1-py3-none-any.whl", hash = "sha256:a1e9ad3d0d9a9405c7ff8cdb54ba9b265da16da9844fe36b8c9661114b56c5d9"},
-    {file = "opentelemetry_exporter_otlp_proto_common-1.32.1.tar.gz", hash = "sha256:da4edee4f24aaef109bfe924efad3a98a2e27c91278115505b298ee61da5d68e"},
+    {file = "opentelemetry_exporter_otlp_proto_common-1.33.0-py3-none-any.whl", hash = "sha256:5c282fc752e4ebdf484c6af2f22d0af2048a5685400d59524e8a3dbcee315014"},
+    {file = "opentelemetry_exporter_otlp_proto_common-1.33.0.tar.gz", hash = "sha256:2f43679dab68ce7708db18cb145b59a7e9184d46608ef037c9c22f47c5beb320"},
 ]
 
 [package.dependencies]
-opentelemetry-proto = "1.32.1"
+opentelemetry-proto = "1.33.0"
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.32.1"
+version = "1.33.0"
 description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_exporter_otlp_proto_http-1.32.1-py3-none-any.whl", hash = "sha256:3cc048b0c295aa2cbafb883feaf217c7525b396567eeeabb5459affb08b7fefe"},
-    {file = "opentelemetry_exporter_otlp_proto_http-1.32.1.tar.gz", hash = "sha256:f854a6e7128858213850dbf1929478a802faf50e799ffd2eb4d7424390023828"},
+    {file = "opentelemetry_exporter_otlp_proto_http-1.33.0-py3-none-any.whl", hash = "sha256:5babd7498845c12c2d503d8c185ce345cb35e91805d4e3e5ac32a3abd8f75d64"},
+    {file = "opentelemetry_exporter_otlp_proto_http-1.33.0.tar.gz", hash = "sha256:bf0cf7568432621b903223e5b72aa9f8fe425fcc748e54d0b21ebe99885c12ee"},
 ]
 
 [package.dependencies]
 deprecated = ">=1.2.6"
 googleapis-common-protos = ">=1.52,<2.0"
 opentelemetry-api = ">=1.15,<2.0"
-opentelemetry-exporter-otlp-proto-common = "1.32.1"
-opentelemetry-proto = "1.32.1"
-opentelemetry-sdk = ">=1.32.1,<1.33.0"
+opentelemetry-exporter-otlp-proto-common = "1.33.0"
+opentelemetry-proto = "1.33.0"
+opentelemetry-sdk = ">=1.33.0,<1.34.0"
 requests = ">=2.7,<3.0"
 
 [[package]]
 name = "opentelemetry-exporter-richconsole"
-version = "0.53b1"
+version = "0.54b0"
 description = "Rich Console Exporter for OpenTelemetry"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_exporter_richconsole-0.53b1-py3-none-any.whl", hash = "sha256:1f09b6df99f2639fdc1ee97a1dcb05d213282739a1be6a4bb34efe19b0a2cc91"},
-    {file = "opentelemetry_exporter_richconsole-0.53b1.tar.gz", hash = "sha256:9dba1305d550065871849cb7c94848142b83b5cf73c4e6d5abec750fe2bf5f7c"},
+    {file = "opentelemetry_exporter_richconsole-0.54b0-py3-none-any.whl", hash = "sha256:863fd59721536318c978a63021db4da2eb55a25bbb0b54c218f6a922da597e0e"},
+    {file = "opentelemetry_exporter_richconsole-0.54b0.tar.gz", hash = "sha256:0c6dd06364fb8b5395e2511c7f6c4b55a6a02d335bebf3e0a84d1e2ba78867c6"},
 ]
 
 [package.dependencies]
 opentelemetry-api = ">=1.12,<2.0"
 opentelemetry-sdk = ">=1.12,<2.0"
-opentelemetry-semantic-conventions = "0.53b1"
+opentelemetry-semantic-conventions = "0.54b0"
 rich = ">=10.0.0"
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.53b1"
+version = "0.54b0"
 description = "Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_instrumentation-0.53b1-py3-none-any.whl", hash = "sha256:c07850cecfbc51e8b357f56d5886ae5ccaa828635b220d0f5e78f941ea9a83ca"},
-    {file = "opentelemetry_instrumentation-0.53b1.tar.gz", hash = "sha256:0e69ca2c75727e8a300de671c4a2ec0e86e63a8e906beaa5d6c9f5228e8687e5"},
+    {file = "opentelemetry_instrumentation-0.54b0-py3-none-any.whl", hash = "sha256:1a502238f8af65625ad48800d268d467653e319d959e1732d3b3248916d21327"},
+    {file = "opentelemetry_instrumentation-0.54b0.tar.gz", hash = "sha256:2949d0bbf2316eb5d928a5ef610d0a8a2c261ba80167d878abf6016e1c4ae7bb"},
 ]
 
 [package.dependencies]
 opentelemetry-api = ">=1.4,<2.0"
-opentelemetry-semantic-conventions = "0.53b1"
+opentelemetry-semantic-conventions = "0.54b0"
 packaging = ">=18.0"
 wrapt = ">=1.0.0,<2.0.0"
 
 [[package]]
 name = "opentelemetry-instrumentation-django"
-version = "0.53b1"
+version = "0.54b0"
 description = "OpenTelemetry Instrumentation for Django"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_instrumentation_django-0.53b1-py3-none-any.whl", hash = "sha256:197743e802dc15f6b6d8a6b3af604b743c16ad3b558f710748b0d61728d7015c"},
-    {file = "opentelemetry_instrumentation_django-0.53b1.tar.gz", hash = "sha256:23618516c7cb14893ada25379d1c2eadf1bd0f9bde39a3ef510e8388cd0c4a44"},
+    {file = "opentelemetry_instrumentation_django-0.54b0-py3-none-any.whl", hash = "sha256:af6b33ebf91c9fccba82a9070ed8d884b0d5d4ee9e4f70716672a6641ee005e6"},
+    {file = "opentelemetry_instrumentation_django-0.54b0.tar.gz", hash = "sha256:1df0e7c9f3ab796fbc4579fcc5dae78926b89e7c4c6279fa5355f6630f12f3ce"},
 ]
 
 [package.dependencies]
 opentelemetry-api = ">=1.12,<2.0"
-opentelemetry-instrumentation = "0.53b1"
-opentelemetry-instrumentation-wsgi = "0.53b1"
-opentelemetry-semantic-conventions = "0.53b1"
-opentelemetry-util-http = "0.53b1"
+opentelemetry-instrumentation = "0.54b0"
+opentelemetry-instrumentation-wsgi = "0.54b0"
+opentelemetry-semantic-conventions = "0.54b0"
+opentelemetry-util-http = "0.54b0"
 
 [package.extras]
-asgi = ["opentelemetry-instrumentation-asgi (==0.53b1)"]
+asgi = ["opentelemetry-instrumentation-asgi (==0.54b0)"]
 instruments = ["django (>=1.10)"]
 
 [[package]]
 name = "opentelemetry-instrumentation-wsgi"
-version = "0.53b1"
+version = "0.54b0"
 description = "WSGI Middleware for OpenTelemetry"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_instrumentation_wsgi-0.53b1-py3-none-any.whl", hash = "sha256:84a4f310c7dec66d577c80e594e0e121a6c20ac88bb40e60adc6b5f6c5fbcbad"},
-    {file = "opentelemetry_instrumentation_wsgi-0.53b1.tar.gz", hash = "sha256:762feb948b12dbb1ef71607f93303e3a0e5cb98235528a6e4cc689a736915adb"},
+    {file = "opentelemetry_instrumentation_wsgi-0.54b0-py3-none-any.whl", hash = "sha256:52c58cb532c6ba5641bb5f6188d71d887c1760a4bcabb71f297847df9b95f0f2"},
+    {file = "opentelemetry_instrumentation_wsgi-0.54b0.tar.gz", hash = "sha256:7ecc72b765b032cf04c35dceb117306bbfe37fd54885bd46c8bbaff3f9e88140"},
 ]
 
 [package.dependencies]
 opentelemetry-api = ">=1.12,<2.0"
-opentelemetry-instrumentation = "0.53b1"
-opentelemetry-semantic-conventions = "0.53b1"
-opentelemetry-util-http = "0.53b1"
+opentelemetry-instrumentation = "0.54b0"
+opentelemetry-semantic-conventions = "0.54b0"
+opentelemetry-util-http = "0.54b0"
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.32.1"
+version = "1.33.0"
 description = "OpenTelemetry Python Proto"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_proto-1.32.1-py3-none-any.whl", hash = "sha256:fe56df31033ab0c40af7525f8bf4c487313377bbcfdf94184b701a8ccebc800e"},
-    {file = "opentelemetry_proto-1.32.1.tar.gz", hash = "sha256:bc6385ccf87768f029371535312071a2d09e6c9ebf119ac17dbc825a6a56ba53"},
+    {file = "opentelemetry_proto-1.33.0-py3-none-any.whl", hash = "sha256:84a1d7daacac4aa0f24a5b1190a3e0619011dbff56f945fc2b6fc0a18f48b942"},
+    {file = "opentelemetry_proto-1.33.0.tar.gz", hash = "sha256:ec5aa35486c990207ead2512a8d616d1b324928562c91dbc7e0cb9aa48c60b7b"},
 ]
 
 [package.dependencies]
@@ -1528,44 +1528,44 @@ protobuf = ">=5.0,<6.0"
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.32.1"
+version = "1.33.0"
 description = "OpenTelemetry Python SDK"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_sdk-1.32.1-py3-none-any.whl", hash = "sha256:bba37b70a08038613247bc42beee5a81b0ddca422c7d7f1b097b32bf1c7e2f17"},
-    {file = "opentelemetry_sdk-1.32.1.tar.gz", hash = "sha256:8ef373d490961848f525255a42b193430a0637e064dd132fd2a014d94792a092"},
+    {file = "opentelemetry_sdk-1.33.0-py3-none-any.whl", hash = "sha256:bed376b6d37fbf00688bb65edfee817dd01d48b8559212831437529a6066049a"},
+    {file = "opentelemetry_sdk-1.33.0.tar.gz", hash = "sha256:a7fc56d1e07b218fcc316b24d21b59d3f1967b2ca22c217b05da3a26b797cc68"},
 ]
 
 [package.dependencies]
-opentelemetry-api = "1.32.1"
-opentelemetry-semantic-conventions = "0.53b1"
+opentelemetry-api = "1.33.0"
+opentelemetry-semantic-conventions = "0.54b0"
 typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.53b1"
+version = "0.54b0"
 description = "OpenTelemetry Semantic Conventions"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_semantic_conventions-0.53b1-py3-none-any.whl", hash = "sha256:21df3ed13f035f8f3ea42d07cbebae37020367a53b47f1ebee3b10a381a00208"},
-    {file = "opentelemetry_semantic_conventions-0.53b1.tar.gz", hash = "sha256:4c5a6fede9de61211b2e9fc1e02e8acacce882204cd770177342b6a3be682992"},
+    {file = "opentelemetry_semantic_conventions-0.54b0-py3-none-any.whl", hash = "sha256:fad7c1cf8908fd449eb5cf9fbbeefb301acf4bc995101f85277899cec125d823"},
+    {file = "opentelemetry_semantic_conventions-0.54b0.tar.gz", hash = "sha256:467b739977bdcb079af1af69f73632535cdb51099d5e3c5709a35d10fe02a9c9"},
 ]
 
 [package.dependencies]
 deprecated = ">=1.2.6"
-opentelemetry-api = "1.32.1"
+opentelemetry-api = "1.33.0"
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.53b1"
+version = "0.54b0"
 description = "Web util for OpenTelemetry"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_util_http-0.53b1-py3-none-any.whl", hash = "sha256:ee7ecc1cbe4598535a95eaf7742f80c0c924843bf8f7ef3bab4963a228a94dd0"},
-    {file = "opentelemetry_util_http-0.53b1.tar.gz", hash = "sha256:7b0356584400b3406a643e244d36ff1bbb7c95e3b5ed0509d212e4a11c050a0e"},
+    {file = "opentelemetry_util_http-0.54b0-py3-none-any.whl", hash = "sha256:40598360e08ee7f8ea563f40dee5e30b1c15be54615e11497aaf190930e94250"},
+    {file = "opentelemetry_util_http-0.54b0.tar.gz", hash = "sha256:2b5fe7157928bdbde194d38df7cbd35a679631fe5b6c23b2c4a271229f7e42b5"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2136,29 +2136,29 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
-version = "0.11.8"
+version = "0.11.9"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.11.8-py3-none-linux_armv6l.whl", hash = "sha256:896a37516c594805e34020c4a7546c8f8a234b679a7716a3f08197f38913e1a3"},
-    {file = "ruff-0.11.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ab86d22d3d721a40dd3ecbb5e86ab03b2e053bc93c700dc68d1c3346b36ce835"},
-    {file = "ruff-0.11.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:258f3585057508d317610e8a412788cf726efeefa2fec4dba4001d9e6f90d46c"},
-    {file = "ruff-0.11.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:727d01702f7c30baed3fc3a34901a640001a2828c793525043c29f7614994a8c"},
-    {file = "ruff-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3dca977cc4fc8f66e89900fa415ffe4dbc2e969da9d7a54bfca81a128c5ac219"},
-    {file = "ruff-0.11.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c657fa987d60b104d2be8b052d66da0a2a88f9bd1d66b2254333e84ea2720c7f"},
-    {file = "ruff-0.11.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f2e74b021d0de5eceb8bd32919f6ff8a9b40ee62ed97becd44993ae5b9949474"},
-    {file = "ruff-0.11.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b5ef39820abc0f2c62111f7045009e46b275f5b99d5e59dda113c39b7f4f38"},
-    {file = "ruff-0.11.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c1dba3135ca503727aa4648152c0fa67c3b1385d3dc81c75cd8a229c4b2a1458"},
-    {file = "ruff-0.11.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f024d32e62faad0f76b2d6afd141b8c171515e4fb91ce9fd6464335c81244e5"},
-    {file = "ruff-0.11.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d365618d3ad747432e1ae50d61775b78c055fee5936d77fb4d92c6f559741948"},
-    {file = "ruff-0.11.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4d9aaa91035bdf612c8ee7266153bcf16005c7c7e2f5878406911c92a31633cb"},
-    {file = "ruff-0.11.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0eba551324733efc76116d9f3a0d52946bc2751f0cd30661564117d6fd60897c"},
-    {file = "ruff-0.11.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:161eb4cff5cfefdb6c9b8b3671d09f7def2f960cee33481dd898caf2bcd02304"},
-    {file = "ruff-0.11.8-py3-none-win32.whl", hash = "sha256:5b18caa297a786465cc511d7f8be19226acf9c0a1127e06e736cd4e1878c3ea2"},
-    {file = "ruff-0.11.8-py3-none-win_amd64.whl", hash = "sha256:6e70d11043bef637c5617297bdedec9632af15d53ac1e1ba29c448da9341b0c4"},
-    {file = "ruff-0.11.8-py3-none-win_arm64.whl", hash = "sha256:304432e4c4a792e3da85b7699feb3426a0908ab98bf29df22a31b0cdd098fac2"},
-    {file = "ruff-0.11.8.tar.gz", hash = "sha256:6d742d10626f9004b781f4558154bb226620a7242080e11caeffab1a40e99df8"},
+    {file = "ruff-0.11.9-py3-none-linux_armv6l.whl", hash = "sha256:a31a1d143a5e6f499d1fb480f8e1e780b4dfdd580f86e05e87b835d22c5c6f8c"},
+    {file = "ruff-0.11.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:66bc18ca783b97186a1f3100e91e492615767ae0a3be584e1266aa9051990722"},
+    {file = "ruff-0.11.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bd576cd06962825de8aece49f28707662ada6a1ff2db848d1348e12c580acbf1"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1d18b4be8182cc6fddf859ce432cc9631556e9f371ada52f3eaefc10d878de"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f3f46f759ac623e94824b1e5a687a0df5cd7f5b00718ff9c24f0a894a683be7"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f34847eea11932d97b521450cf3e1d17863cfa5a94f21a056b93fb86f3f3dba2"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f33b15e00435773df97cddcd263578aa83af996b913721d86f47f4e0ee0ff271"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b27613a683b086f2aca8996f63cb3dd7bc49e6eccf590563221f7b43ded3f65"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e0d88756e63e8302e630cee3ce2ffb77859797cc84a830a24473939e6da3ca6"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:537c82c9829d7811e3aa680205f94c81a2958a122ac391c0eb60336ace741a70"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:440ac6a7029f3dee7d46ab7de6f54b19e34c2b090bb4f2480d0a2d635228f381"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:71c539bac63d0788a30227ed4d43b81353c89437d355fdc52e0cda4ce5651787"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c67117bc82457e4501473c5f5217d49d9222a360794bfb63968e09e70f340abd"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e4b78454f97aa454586e8a5557facb40d683e74246c97372af3c2d76901d697b"},
+    {file = "ruff-0.11.9-py3-none-win32.whl", hash = "sha256:7fe1bc950e7d7b42caaee2a8a3bc27410547cc032c9558ee2e0f6d3b209e845a"},
+    {file = "ruff-0.11.9-py3-none-win_amd64.whl", hash = "sha256:52edaa4a6d70f8180343a5b7f030c7edd36ad180c9f4d224959c2d689962d964"},
+    {file = "ruff-0.11.9-py3-none-win_arm64.whl", hash = "sha256:bcf42689c22f2e240f496d0c183ef2c6f7b35e809f12c1db58f75d9aa8d630ca"},
+    {file = "ruff-0.11.9.tar.gz", hash = "sha256:ebd58d4f67a00afb3a30bf7d383e52d0e036e6195143c6db7019604a05335517"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -510,13 +510,13 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.20"
+version = "4.2.21"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Django-4.2.20-py3-none-any.whl", hash = "sha256:213381b6e4405f5c8703fffc29cd719efdf189dec60c67c04f76272b3dc845b9"},
-    {file = "Django-4.2.20.tar.gz", hash = "sha256:92bac5b4432a64532abb73b2ac27203f485e40225d2640a7fbef2b62b876e789"},
+    {file = "django-4.2.21-py3-none-any.whl", hash = "sha256:1d658c7bf5d31c7d0cac1cab58bc1f822df89255080fec81909256c30e6180b3"},
+    {file = "django-4.2.21.tar.gz", hash = "sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ opentelemetry-distro = "*"
 opentelemetry-instrumentation-django = "*"
 opentelemetry-exporter-richconsole = "*"
 opentelemetry-exporter-otlp-proto-http = "*"
+openedx-events = "*"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.0.0"

--- a/src/ol_openedx_canvas_integration/BUILD
+++ b/src/ol_openedx_canvas_integration/BUILD
@@ -19,7 +19,9 @@ python_distribution(
             "lms.djangoapp": [
                 "ol_openedx_canvas_integration = ol_openedx_canvas_integration.app:CanvasIntegrationConfig"
             ],
-            "cms.djangoapp": [],
+            "cms.djangoapp": [
+                "ol_openedx_canvas_integration = ol_openedx_canvas_integration.app:CanvasIntegrationConfig"
+            ],
         },
     ),
 )

--- a/src/ol_openedx_canvas_integration/api.py
+++ b/src/ol_openedx_canvas_integration/api.py
@@ -9,6 +9,8 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.grades.context import grading_context_for_course
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+from opaque_keys.edx.locator import CourseLocator
+
 from ol_openedx_canvas_integration.client import (
     CanvasClient,
     create_assignment_payload,
@@ -16,7 +18,6 @@ from ol_openedx_canvas_integration.client import (
 )
 from ol_openedx_canvas_integration.constants import COURSE_KEY_ID_EMPTY
 from ol_openedx_canvas_integration.utils import get_canvas_course_id
-from opaque_keys.edx.locator import CourseLocator
 
 log = logging.getLogger(__name__)
 

--- a/src/ol_openedx_canvas_integration/app.py
+++ b/src/ol_openedx_canvas_integration/app.py
@@ -30,7 +30,13 @@ class CanvasIntegrationConfig(AppConfig):
                     PluginSettings.RELATIVE_PATH: "settings.production"
                 },
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
-            }
+            },
+            ProjectType.CMS: {
+                SettingsType.PRODUCTION: {
+                    PluginSettings.RELATIVE_PATH: "settings.production"
+                },
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
+            },
         },
         PluginContexts.CONFIG: {
             ProjectType.LMS: {
@@ -38,3 +44,7 @@ class CanvasIntegrationConfig(AppConfig):
             }
         },
     }
+
+    def ready(self):
+        """Perform initialization tasks required for the plugin."""
+        from ol_openedx_canvas_integration import handlers  # noqa: F401

--- a/src/ol_openedx_canvas_integration/client.py
+++ b/src/ol_openedx_canvas_integration/client.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 import pytz
 import requests
 from django.conf import settings
+
 from ol_openedx_canvas_integration.constants import DEFAULT_ASSIGNMENT_POINTS
 
 log = logging.getLogger(__name__)
@@ -144,6 +145,36 @@ class CanvasClient:
                 f"/api/v1/courses/{self.canvas_course_id}/assignments",
             ),
             json=payload,
+        )
+
+    def update_canvas_assignment(self, assignment_id, payload):
+        """
+        Update an assignment with the given ID in Canvas.
+
+        Args:
+            assignment_id (int): ID of the Canvas assignment
+            payload (dict):
+        """
+        return self.session.put(
+            url=urljoin(
+                settings.CANVAS_BASE_URL,
+                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}",
+            ),
+            json=payload,
+        )
+
+    def delete_canvas_assignment(self, assignment_id):
+        """
+        Deletes an assignment with the given ID in Canvas.
+
+        Args:
+            assignment_id (int): ID of the Canvas Assignment
+        """
+        return self.session.delete(
+            url=urljoin(
+                settings.CANVAS_BASE_URL,
+                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}",
+            ),
         )
 
     def update_assignment_grades(self, canvas_assignment_id, payload):

--- a/src/ol_openedx_canvas_integration/cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/cms_tasks.py
@@ -1,0 +1,145 @@
+"""
+Module containing the Celery tasks that are called from the CMS.
+
+This module ideally should be merged with tasks.py. However, tasks.py
+contains references to settings which are not present in the 'cms'.
+Since cms dynamically loads handlers.py via ready() in app config,
+making handler.py depend on tasks.py results in initialization failures.
+So, this module has been added without any dependencies on LMS only
+settings.
+"""
+
+import logging
+
+import requests
+from celery import shared_task
+from lms.djangoapps.courseware.courses import get_course_by_id
+from opaque_keys.edx.locator import CourseLocator
+
+from ol_openedx_canvas_integration.api import course_graded_items
+from ol_openedx_canvas_integration.client import CanvasClient, create_assignment_payload
+from ol_openedx_canvas_integration.utils import get_canvas_course_id
+
+logger = logging.getLogger(__name__)
+
+
+def diff_assignments(openedx_assignments, canvas_assignments_map):
+    """
+    Peform a diff between the assignments in Canvas and Open edX.
+
+    Args:
+        openedx_assignments: List of Subsections
+        canvas_assignments_map: Map of the assignment's Integration ID and Canvas ID
+
+    Returns:
+        The diff between the assignments as a dictionary of the following format:
+
+        {
+            "add": ["JSON Payload of Assignments"],
+            "update": {"Map of Canvas IDs":  "JSON payload of assignments"},
+            "delete": ["Integer IDs of Canvas assignments"]
+        }
+    """
+    diff = {"add": [], "update": {}, "delete": []}
+
+    for subsection in openedx_assignments:
+        payload = create_assignment_payload(subsection)
+        integration_id = str(subsection.location)
+
+        # remove from the map to indicate it's synced
+        if canvas_id := canvas_assignments_map.pop(integration_id, None):
+            diff["update"][canvas_id] = payload
+        else:
+            diff["add"].append(payload)
+
+    # any left over assignments in the map is considered as deleted in Open edX
+    diff["delete"] = list(canvas_assignments_map.values())
+
+    return diff
+
+
+@shared_task
+def sync_course_assignments_with_canvas(course_id):
+    """
+    Syncs the assignments in the course with Canvas if there is a linked Canvas course.
+
+    Args:
+        course_id (str): Open edX Course ID
+    """
+    course_key = CourseLocator.from_string(course_id)
+    course = get_course_by_id(course_key)
+    canvas_course_id = get_canvas_course_id(course)
+
+    if not canvas_course_id:
+        logger.info(
+            "Course %s is not mapped to a Canvas Course. Skipping assignment sync.",
+            course_id,
+        )
+        return
+
+    openedx_assignments = [
+        item["subsection_block"] for _, item, _ in course_graded_items(course)
+    ]
+    canvas = CanvasClient(canvas_course_id=canvas_course_id)
+    canvas_assignments = canvas.get_assignments_by_int_id()
+
+    operations_map = diff_assignments(openedx_assignments, canvas_assignments)
+    logger.info(
+        "Syncing assignments with Canvas. Adding: %d, Updating: %d, Deleting: %d",
+        len(operations_map["add"]),
+        len(operations_map["update"]),
+        len(operations_map["delete"]),
+    )
+
+    succeeded = 0
+    for payload in operations_map["add"]:
+        res = canvas.create_canvas_assignment(payload)
+        try:
+            res.raise_for_status()
+            succeeded += 1
+        except requests.HTTPError as e:
+            logger.warning(
+                "Failed to create new assignment for subsection: %s. Error: %s",
+                payload["assignment"]["integration_id"],
+                str(e),
+            )
+    if operations_map["add"]:
+        logger.info(
+            "%d of %d new assignments were successfully added in Canvas.",
+            succeeded,
+            len(operations_map["add"]),
+        )
+
+    succeeded = 0
+    for canvas_id, payload in operations_map["update"].items():
+        res = canvas.update_canvas_assignment(canvas_id, payload)
+        try:
+            res.raise_for_status()
+            succeeded += 1
+        except requests.HTTPError as e:
+            logger.warning(
+                "Failed to update Canvas Assignment %d. Error: %s", canvas_id, str(e)
+            )
+    if operations_map["update"]:
+        logger.info(
+            "%d of %d assignments were successfully updated in Canvas.",
+            succeeded,
+            len(operations_map["update"]),
+        )
+
+    succeeded = 0
+    for canvas_id in operations_map["delete"]:
+        res = canvas.delete_canvas_assignment(canvas_id)
+        try:
+            res.raise_for_status()
+            succeeded += 1
+        except requests.HTTPError as e:
+            logger.warning(
+                "Failed to delete Canvas assignment: %d. Error %s", canvas_id, str(e)
+            )
+    if operations_map["delete"]:
+        logger.info(
+            "%d for %d assignments were successfully deleted in Canvas.",
+            succeeded,
+            len(operations_map["delete"]),
+        )

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -5,8 +5,9 @@ The initialization of the context for the Canvas Integration Plugin
 import pkg_resources
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from ol_openedx_canvas_integration.utils import get_canvas_course_id
 from web_fragments.fragment import Fragment
+
+from ol_openedx_canvas_integration.utils import get_canvas_course_id
 
 
 def get_resource_bytes(path):

--- a/src/ol_openedx_canvas_integration/handlers.py
+++ b/src/ol_openedx_canvas_integration/handlers.py
@@ -1,0 +1,23 @@
+"""Event Handlers for the openedx-events signals."""
+
+from django.dispatch import receiver
+from openedx_events.content_authoring.signals import XBLOCK_DELETED, XBLOCK_PUBLISHED
+
+from ol_openedx_canvas_integration.cms_tasks import sync_course_assignments_with_canvas
+
+
+@receiver(XBLOCK_PUBLISHED)
+def handle_xblock_publised_event(signal, sender, xblock_info, metadata, **kwargs):  # noqa: ARG001
+    """
+    Update Canvas assignments if the courses are linked.
+    """
+    sync_course_assignments_with_canvas.delay(str(xblock_info.usage_key.course_key))
+
+
+@receiver(XBLOCK_DELETED)
+def handle_xblock_deleted_event(signal, sender, xblock_info, metadata, **kwargs):  # noqa: ARG001
+    """
+    Update Canvas assignments if the courses are linked.
+    """
+    if xblock_info.block_type in ["chapter", "sequential"]:
+        sync_course_assignments_with_canvas.delay(str(xblock_info.usage_key.course_key))

--- a/src/ol_openedx_canvas_integration/task_helpers.py
+++ b/src/ol_openedx_canvas_integration/task_helpers.py
@@ -10,6 +10,7 @@ from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.instructor_task.api import get_running_instructor_tasks
 from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.runner import TaskProgress
+
 from ol_openedx_canvas_integration import api
 from ol_openedx_canvas_integration.constants import CANVAS_TASK_TYPES
 

--- a/src/ol_openedx_canvas_integration/tasks.py
+++ b/src/ol_openedx_canvas_integration/tasks.py
@@ -8,6 +8,7 @@ from celery import shared_task
 from lms.djangoapps.instructor_task.api_helper import submit_task
 from lms.djangoapps.instructor_task.tasks_base import BaseInstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.runner import run_main_task
+
 from ol_openedx_canvas_integration import task_helpers
 from ol_openedx_canvas_integration.constants import (
     TASK_TYPE_PUSH_EDX_GRADES_TO_CANVAS,

--- a/src/ol_openedx_canvas_integration/test_cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/test_cms_tasks.py
@@ -1,0 +1,84 @@
+import pytest
+
+from ol_openedx_canvas_integration.api import create_assignment_payload
+from ol_openedx_canvas_integration.cms_tasks import diff_assignments
+
+
+class MockSubsection:
+    def __init__(self, location) -> None:
+        self.location = location
+        self.display_name = "Mock Assignment in " + str(location)
+        self.fields = {}
+
+    @property
+    def payload(self):
+        return create_assignment_payload(self)
+
+
+subsection_mocks = [MockSubsection(f"id-{i}") for i in range(10)]
+
+
+@pytest.mark.parametrize(
+    "openedx_assignments,canvas_assignments_map,expected_output",
+    [
+        # All empty
+        ([], {}, {"add": [], "update": {}, "delete": []}),
+        # Add new assignments to Canvas
+        (
+            subsection_mocks[0:3],
+            {},
+            {
+                "add": [s.payload for s in subsection_mocks[0:3]],
+                "update": {},
+                "delete": [],
+            },
+        ),
+        # Update existing assignments
+        (
+            subsection_mocks[8:],
+            {
+                "id-8": 1008,
+                "id-9": 1009,
+            },
+            {
+                "add": [],
+                "update": {
+                    1008: subsection_mocks[8].payload,
+                    1009: subsection_mocks[9].payload,
+                },
+                "delete": [],
+            },
+        ),
+        # Remove existing assignments
+        (
+            [],
+            {
+                "synced-1": 1002,
+                "synced-2": 1003,
+            },
+            {"add": [], "update": {}, "delete": [1002, 1003]},
+        ),
+        # Add some, update some and remove some assignments
+        (
+            subsection_mocks[4:8],
+            {
+                "id-2": 12,  # remove
+                "id-3": 13,  # remove
+                "id-4": 14,  # update
+                "id-5": 15,  # update
+            },
+            {
+                "add": [s.payload for s in subsection_mocks[6:8]],
+                "update": {
+                    14: subsection_mocks[4].payload,
+                    15: subsection_mocks[5].payload,
+                },
+                "delete": [12, 13],
+            },
+        ),
+    ],
+)
+def test_diff_assignments(openedx_assignments, canvas_assignments_map, expected_output):
+    assert (
+        diff_assignments(openedx_assignments, canvas_assignments_map) == expected_output
+    )

--- a/src/ol_openedx_canvas_integration/urls.py
+++ b/src/ol_openedx_canvas_integration/urls.py
@@ -3,6 +3,7 @@ Canvas Integration API endpoint urls.
 """
 
 from django.urls import re_path
+
 from ol_openedx_canvas_integration import views
 
 urlpatterns = [

--- a/src/ol_openedx_canvas_integration/views.py
+++ b/src/ol_openedx_canvas_integration/views.py
@@ -14,11 +14,12 @@ from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.instructor import permissions
 from lms.djangoapps.instructor.views.api import require_course_permission
 from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError
+from opaque_keys.edx.locator import CourseLocator
+
 from ol_openedx_canvas_integration import tasks
 from ol_openedx_canvas_integration.client import CanvasClient
 from ol_openedx_canvas_integration.constants import COURSE_KEY_ID_EMPTY
 from ol_openedx_canvas_integration.utils import get_canvas_course_id
-from opaque_keys.edx.locator import CourseLocator
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)

The changes to the course content are tracked by listening to the `XBLOCK_PUBLISHED` and `XBLOCK_DELETED` events via the openedx-events library. If the course where these events occur is linked to a Canvas course, then the graded subsections in the course are synced as assignments in Canvas.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

* Use the instructions in https://github.com/mitodl/open-edx-plugins/pull/500#issue-3068562385 to install the `ol-openedx-canvas-integration` plugin and setup a course link between canvas and open-edx.
* Add Graded blocks, delete them and make changes and publish them to test changes reflect in Canvas.


### Additional Context

The Syncing primarily relies on course content getting published in Open edX, which is expected after author finalize changes. However, there is one scenario where the "Publish" step might be skipped: XBlock deletion.

So, this PR also includes an event listener for that event explicitly. 


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
