### PR TITLE
Automatically sync assignments on Open edX to Canvas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ opentelemetry-distro = "*"
 opentelemetry-instrumentation-django = "*"
 opentelemetry-exporter-richconsole = "*"
 opentelemetry-exporter-otlp-proto-http = "*"
+openedx-events = "*"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.0.0"

--- a/src/ol_openedx_canvas_integration/BUILD
+++ b/src/ol_openedx_canvas_integration/BUILD
@@ -19,7 +19,9 @@ python_distribution(
             "lms.djangoapp": [
                 "ol_openedx_canvas_integration = ol_openedx_canvas_integration.app:CanvasIntegrationConfig"
             ],
-            "cms.djangoapp": [],
+            "cms.djangoapp": [
+                "ol_openedx_canvas_integration = ol_openedx_canvas_integration.app:CanvasIntegrationConfig"
+            ],
         },
     ),
 )

--- a/src/ol_openedx_canvas_integration/api.py
+++ b/src/ol_openedx_canvas_integration/api.py
@@ -9,6 +9,8 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.grades.context import grading_context_for_course
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+from opaque_keys.edx.locator import CourseLocator
+
 from ol_openedx_canvas_integration.client import (
     CanvasClient,
     create_assignment_payload,
@@ -16,7 +18,6 @@ from ol_openedx_canvas_integration.client import (
 )
 from ol_openedx_canvas_integration.constants import COURSE_KEY_ID_EMPTY
 from ol_openedx_canvas_integration.utils import get_canvas_course_id
-from opaque_keys.edx.locator import CourseLocator
 
 log = logging.getLogger(__name__)
 

--- a/src/ol_openedx_canvas_integration/app.py
+++ b/src/ol_openedx_canvas_integration/app.py
@@ -36,7 +36,7 @@ class CanvasIntegrationConfig(AppConfig):
                     PluginSettings.RELATIVE_PATH: "settings.production"
                 },
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
-            }
+            },
         },
         PluginContexts.CONFIG: {
             ProjectType.LMS: {

--- a/src/ol_openedx_canvas_integration/app.py
+++ b/src/ol_openedx_canvas_integration/app.py
@@ -30,6 +30,12 @@ class CanvasIntegrationConfig(AppConfig):
                     PluginSettings.RELATIVE_PATH: "settings.production"
                 },
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
+            },
+            ProjectType.CMS: {
+                SettingsType.PRODUCTION: {
+                    PluginSettings.RELATIVE_PATH: "settings.production"
+                },
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: "settings.common"},
             }
         },
         PluginContexts.CONFIG: {
@@ -38,3 +44,10 @@ class CanvasIntegrationConfig(AppConfig):
             }
         },
     }
+
+    def ready(self):
+        """Perform initialization tasks required for the plugin."""
+        print("^"*100)
+        print("The ready function has been called.")
+        print("^"*100)
+        from ol_openedx_canvas_integration import handlers  # noqa: F401

--- a/src/ol_openedx_canvas_integration/app.py
+++ b/src/ol_openedx_canvas_integration/app.py
@@ -47,7 +47,4 @@ class CanvasIntegrationConfig(AppConfig):
 
     def ready(self):
         """Perform initialization tasks required for the plugin."""
-        print("^"*100)
-        print("The ready function has been called.")
-        print("^"*100)
         from ol_openedx_canvas_integration import handlers  # noqa: F401

--- a/src/ol_openedx_canvas_integration/client.py
+++ b/src/ol_openedx_canvas_integration/client.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 import pytz
 import requests
 from django.conf import settings
+
 from ol_openedx_canvas_integration.constants import DEFAULT_ASSIGNMENT_POINTS
 
 log = logging.getLogger(__name__)
@@ -157,9 +158,9 @@ class CanvasClient:
         return self.session.put(
             url=urljoin(
                 settings.CANVAS_BASE_URL,
-                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}"
+                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}",
             ),
-            json=payload
+            json=payload,
         )
 
     def delete_canvas_assignment(self, assignment_id):
@@ -172,7 +173,7 @@ class CanvasClient:
         return self.session.delete(
             url=urljoin(
                 settings.CANVAS_BASE_URL,
-                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}"
+                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}",
             ),
         )
 

--- a/src/ol_openedx_canvas_integration/client.py
+++ b/src/ol_openedx_canvas_integration/client.py
@@ -146,6 +146,36 @@ class CanvasClient:
             json=payload,
         )
 
+    def update_canvas_assignment(self, assignment_id, payload):
+        """
+        Update an assignment with the given ID in Canvas.
+
+        Args:
+            assignment_id (int): ID of the Canvas assignment
+            payload (dict):
+        """
+        return self.session.put(
+            url=urljoin(
+                settings.CANVAS_BASE_URL,
+                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}"
+            ),
+            json=payload
+        )
+
+    def delete_canvas_assignment(self, assignment_id):
+        """
+        Deletes an assignment with the given ID in Canvas.
+
+        Args:
+            assignment_id (int): ID of the Canvas Assignment
+        """
+        return self.session.delete(
+            url=urljoin(
+                settings.CANVAS_BASE_URL,
+                f"/api/v1/courses/{self.canvas_course_id}/assignments/{assignment_id}"
+            ),
+        )
+
     def update_assignment_grades(self, canvas_assignment_id, payload):
         return self.session.post(
             url=urljoin(

--- a/src/ol_openedx_canvas_integration/cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/cms_tasks.py
@@ -1,0 +1,130 @@
+import logging
+import requests
+
+from celery import shared_task
+from lms.djangoapps.courseware.courses import get_course_by_id
+from opaque_keys.edx.locator import CourseLocator
+
+from ol_openedx_canvas_integration.api import course_graded_items
+from ol_openedx_canvas_integration.client import CanvasClient, create_assignment_payload
+from ol_openedx_canvas_integration.utils import get_canvas_course_id
+
+logger = logging.getLogger(__name__)
+
+
+def diff_assignments(openedx_assignments, canvas_assignments_map):
+    """
+    Peform a diff between the assignments in Canvas and Open edX.
+
+    Args:
+        openedx_assignments: List of Subsections
+        canvas_assignments_map: Map of the assignment's Integration ID and Canvas ID
+
+    Returns:
+        The diff between the assignments as a dictionary of the following format:
+
+        {
+            "add": ["JSON Payload of Assignments"],
+            "update": {"Map of Canvas IDs":  "JSON payload of assignments"},
+            "delete": ["Integer IDs of Canvas assignments"]
+        }
+    """
+    diff = {
+        "add": [],
+        "update": {},
+        "delete": []
+    }
+
+    for subsection in openedx_assignments:
+        payload = create_assignment_payload(subsection)
+        integration_id = str(subsection.location)
+
+        # remove from the map to indicate it's synced
+        if canvas_id := canvas_assignments_map.pop(integration_id, None):
+            diff["update"][canvas_id] = payload
+        else:
+            diff["add"].append(payload)
+
+    # any left over assignments in the map is considered as deleted in Open edX
+    diff["delete"] = list(canvas_assignments_map.values())
+
+    return diff
+
+
+@shared_task
+def sync_course_assignments_with_canvas(course_id):
+    """
+    Syncs the assignments in the course with Canvas if there is a linked Canvas course.
+
+    Args:
+        course_id (str): Open edX Course ID
+    """
+    course_key = CourseLocator.from_string(course_id)
+    course = get_course_by_id(course_key)
+    canvas_course_id = get_canvas_course_id(course)
+
+    if not canvas_course_id:
+        logger.info("Course %s is not mapped to a Canvas Course. Skipping assignment sync.", course_id)
+        return
+
+    openedx_assignments = [item["subsection_block"] for _, item, _ in course_graded_items(course)]
+    canvas = CanvasClient(canvas_course_id=canvas_course_id)
+    canvas_assignments = canvas.get_assignments_by_int_id()
+
+    operations_map = diff_assignments(openedx_assignments, canvas_assignments)
+    logger.info(
+        "Syncing assignments with Canvas. Adding: %d, Updating: %d, Deleting: %d",
+        len(operations_map["add"]), len(operations_map["update"]), len(operations_map["delete"])
+    )
+
+    succeeded = 0
+    for payload in operations_map["add"]:
+        res = canvas.create_canvas_assignment(payload)
+        try:
+            res.raise_for_status()
+            succeeded += 1
+        except requests.HTTPError as e:
+            logger.warning(
+                "Failed to create new assignment for subsection: %s. Error: %s",
+                payload["assignment"]["integration_id"], str(e)
+            )
+    if operations_map["add"]:
+        logger.info(
+            "%d of %d new assignments were successfully added in Canvas.",
+            succeeded, len(operations_map["add"])
+        )
+
+
+    succeeded = 0
+    for canvas_id, payload in operations_map["update"].items():
+        res = canvas.update_canvas_assignment(canvas_id, payload)
+        try:
+            res.raise_for_status()
+            succeeded += 1
+        except requests.HTTPError as e:
+            logger.warning(
+                "Failed to update Canvas Assignment %d. Error: %s",
+                canvas_id, str(e)
+            )
+    if operations_map["update"]:
+        logger.info(
+            "%d of %d assignments were successfully updated in Canvas.",
+            succeeded, len(operations_map["update"])
+        )
+
+    succeeded = 0
+    for canvas_id in operations_map["delete"]:
+        res = canvas.delete_canvas_assignment(canvas_id)
+        try:
+            res.raise_for_status()
+            succeeded += 1
+        except requests.HTTPError as e:
+            logger.warning(
+                "Failed to delete Canvas assignment: %d. Error %s",
+                canvas_id, str(e)
+            )
+    if operations_map["delete"]:
+        logger.info(
+            "%d for %d assignments were successfully deleted in Canvas.",
+            succeeded, len(operations_map["delete"])
+        )

--- a/src/ol_openedx_canvas_integration/cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/cms_tasks.py
@@ -1,3 +1,13 @@
+"""
+Module containing the Celery tasks that are called from the CMS.
+
+This module ideally should be merged with tasks.py. However, tasks.py
+contains references to settings which are not present in the 'cms'.
+Since cms dynamically loads handlers.py via ready() in app config,
+making handler.py depend on tasks.py results in initialization failures.
+So, this module has been added without any dependencies on LMS only
+settings.
+"""
 import logging
 import requests
 

--- a/src/ol_openedx_canvas_integration/context_api.py
+++ b/src/ol_openedx_canvas_integration/context_api.py
@@ -5,8 +5,9 @@ The initialization of the context for the Canvas Integration Plugin
 import pkg_resources
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from ol_openedx_canvas_integration.utils import get_canvas_course_id
 from web_fragments.fragment import Fragment
+
+from ol_openedx_canvas_integration.utils import get_canvas_course_id
 
 
 def get_resource_bytes(path):

--- a/src/ol_openedx_canvas_integration/handlers.py
+++ b/src/ol_openedx_canvas_integration/handlers.py
@@ -1,0 +1,24 @@
+"""Event Handlers for the openedx-events signals."""
+from django.dispatch import receiver
+from openedx_events.content_authoring.signals import XBLOCK_PUBLISHED, XBLOCK_DELETED
+
+from ol_openedx_canvas_integration.cms_tasks import sync_course_assignments_with_canvas
+
+@receiver(XBLOCK_PUBLISHED)
+def handle_xblock_publised_event(signal, sender, xblock_info, metadata, **kwargs):  # noqa: ARG001
+    """
+    Update Canvas assignments if the courses are linked.
+    """
+    sync_course_assignments_with_canvas.delay(
+        str(xblock_info.usage_key.course_key)
+    )
+
+@receiver(XBLOCK_DELETED)
+def handle_xblock_deleted_event(signal, sender, xblock_info, metadata, **kwargs):  # noqa: ARG001
+    """
+    Update Canvas assignments if the courses are linked.
+    """
+    if xblock_info.block_type in ["chapter", "sequential"]:
+        sync_course_assignments_with_canvas.delay(
+            str(xblock_info.usage_key.course_key)
+        )

--- a/src/ol_openedx_canvas_integration/handlers.py
+++ b/src/ol_openedx_canvas_integration/handlers.py
@@ -1,17 +1,18 @@
 """Event Handlers for the openedx-events signals."""
+
 from django.dispatch import receiver
-from openedx_events.content_authoring.signals import XBLOCK_PUBLISHED, XBLOCK_DELETED
+from openedx_events.content_authoring.signals import XBLOCK_DELETED, XBLOCK_PUBLISHED
 
 from ol_openedx_canvas_integration.cms_tasks import sync_course_assignments_with_canvas
+
 
 @receiver(XBLOCK_PUBLISHED)
 def handle_xblock_publised_event(signal, sender, xblock_info, metadata, **kwargs):  # noqa: ARG001
     """
     Update Canvas assignments if the courses are linked.
     """
-    sync_course_assignments_with_canvas.delay(
-        str(xblock_info.usage_key.course_key)
-    )
+    sync_course_assignments_with_canvas.delay(str(xblock_info.usage_key.course_key))
+
 
 @receiver(XBLOCK_DELETED)
 def handle_xblock_deleted_event(signal, sender, xblock_info, metadata, **kwargs):  # noqa: ARG001
@@ -19,6 +20,4 @@ def handle_xblock_deleted_event(signal, sender, xblock_info, metadata, **kwargs)
     Update Canvas assignments if the courses are linked.
     """
     if xblock_info.block_type in ["chapter", "sequential"]:
-        sync_course_assignments_with_canvas.delay(
-            str(xblock_info.usage_key.course_key)
-        )
+        sync_course_assignments_with_canvas.delay(str(xblock_info.usage_key.course_key))

--- a/src/ol_openedx_canvas_integration/task_helpers.py
+++ b/src/ol_openedx_canvas_integration/task_helpers.py
@@ -10,6 +10,7 @@ from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.instructor_task.api import get_running_instructor_tasks
 from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.runner import TaskProgress
+
 from ol_openedx_canvas_integration import api
 from ol_openedx_canvas_integration.constants import CANVAS_TASK_TYPES
 

--- a/src/ol_openedx_canvas_integration/tasks.py
+++ b/src/ol_openedx_canvas_integration/tasks.py
@@ -8,6 +8,7 @@ from celery import shared_task
 from lms.djangoapps.instructor_task.api_helper import submit_task
 from lms.djangoapps.instructor_task.tasks_base import BaseInstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.runner import run_main_task
+
 from ol_openedx_canvas_integration import task_helpers
 from ol_openedx_canvas_integration.constants import (
     TASK_TYPE_PUSH_EDX_GRADES_TO_CANVAS,

--- a/src/ol_openedx_canvas_integration/test_cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/test_cms_tasks.py
@@ -1,0 +1,87 @@
+import pytest
+
+from uuid import uuid4
+from ol_openedx_canvas_integration.cms_tasks import diff_assignments
+from ol_openedx_canvas_integration.api import create_assignment_payload
+
+
+class MockSubsection:
+    def __init__(self, location) -> None:
+        self.location = location
+        self.display_name = "Mock Assignment in " + str(location)
+        self.fields = {}
+
+    @property
+    def payload(self):
+        return create_assignment_payload(self)
+
+
+subsection_mocks = [MockSubsection(f'id-{i}') for i in range(10)]
+
+
+@pytest.mark.parametrize(
+    "openedx_assignments,canvas_assignments_map,expected_output",
+    [
+        # All empty
+        ([], {}, {"add": [], "update": {}, "delete": []}),
+        # Add new assignments to Canvas
+        (
+            subsection_mocks[0:3],
+            {},
+            {
+                "add": [s.payload for s in subsection_mocks[0:3]],
+                "update": {},
+                "delete": []
+            }
+        ),
+        # Update existing assignments
+        (
+            subsection_mocks[8:],
+            {
+                "id-8": 1008,
+                "id-9": 1009,
+            },
+            {
+                "add": [],
+                "update": {
+                    1008: subsection_mocks[8].payload,
+                    1009: subsection_mocks[9].payload,
+                },
+                "delete": [],
+            }
+        ),
+        # Remove existing assignments
+        (
+            [],
+            {
+                "synced-1": 1002,
+                "synced-2": 1003,
+            },
+            {
+                "add": [],
+                "update": {},
+                "delete": [1002, 1003]
+            }
+        ),
+        # Add some, update some and remove some assignments
+        (
+            subsection_mocks[4:8],
+            {
+                "id-2": 12, # remove
+                "id-3": 13, # remove
+                "id-4": 14, # update
+                "id-5": 15, # update
+            },
+            {
+                "add": [s.payload for s in subsection_mocks[6:8]],
+                "update": {
+                    14: subsection_mocks[4].payload,
+                    15: subsection_mocks[5].payload,
+                },
+                "delete": [12, 13],
+            }
+        )
+    ]
+)
+def test_diff_assignments(openedx_assignments, canvas_assignments_map, expected_output):
+    assert diff_assignments(openedx_assignments, canvas_assignments_map) == expected_output

--- a/src/ol_openedx_canvas_integration/test_cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/test_cms_tasks.py
@@ -1,8 +1,7 @@
 import pytest
 
-from uuid import uuid4
-from ol_openedx_canvas_integration.cms_tasks import diff_assignments
 from ol_openedx_canvas_integration.api import create_assignment_payload
+from ol_openedx_canvas_integration.cms_tasks import diff_assignments
 
 
 class MockSubsection:
@@ -16,7 +15,7 @@ class MockSubsection:
         return create_assignment_payload(self)
 
 
-subsection_mocks = [MockSubsection(f'id-{i}') for i in range(10)]
+subsection_mocks = [MockSubsection(f"id-{i}") for i in range(10)]
 
 
 @pytest.mark.parametrize(
@@ -31,8 +30,8 @@ subsection_mocks = [MockSubsection(f'id-{i}') for i in range(10)]
             {
                 "add": [s.payload for s in subsection_mocks[0:3]],
                 "update": {},
-                "delete": []
-            }
+                "delete": [],
+            },
         ),
         # Update existing assignments
         (
@@ -48,7 +47,7 @@ subsection_mocks = [MockSubsection(f'id-{i}') for i in range(10)]
                     1009: subsection_mocks[9].payload,
                 },
                 "delete": [],
-            }
+            },
         ),
         # Remove existing assignments
         (
@@ -57,20 +56,16 @@ subsection_mocks = [MockSubsection(f'id-{i}') for i in range(10)]
                 "synced-1": 1002,
                 "synced-2": 1003,
             },
-            {
-                "add": [],
-                "update": {},
-                "delete": [1002, 1003]
-            }
+            {"add": [], "update": {}, "delete": [1002, 1003]},
         ),
         # Add some, update some and remove some assignments
         (
             subsection_mocks[4:8],
             {
-                "id-2": 12, # remove
-                "id-3": 13, # remove
-                "id-4": 14, # update
-                "id-5": 15, # update
+                "id-2": 12,  # remove
+                "id-3": 13,  # remove
+                "id-4": 14,  # update
+                "id-5": 15,  # update
             },
             {
                 "add": [s.payload for s in subsection_mocks[6:8]],
@@ -79,9 +74,11 @@ subsection_mocks = [MockSubsection(f'id-{i}') for i in range(10)]
                     15: subsection_mocks[5].payload,
                 },
                 "delete": [12, 13],
-            }
-        )
-    ]
+            },
+        ),
+    ],
 )
 def test_diff_assignments(openedx_assignments, canvas_assignments_map, expected_output):
-    assert diff_assignments(openedx_assignments, canvas_assignments_map) == expected_output
+    assert (
+        diff_assignments(openedx_assignments, canvas_assignments_map) == expected_output
+    )

--- a/src/ol_openedx_canvas_integration/urls.py
+++ b/src/ol_openedx_canvas_integration/urls.py
@@ -3,6 +3,7 @@ Canvas Integration API endpoint urls.
 """
 
 from django.urls import re_path
+
 from ol_openedx_canvas_integration import views
 
 urlpatterns = [

--- a/src/ol_openedx_canvas_integration/views.py
+++ b/src/ol_openedx_canvas_integration/views.py
@@ -14,11 +14,12 @@ from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.instructor import permissions
 from lms.djangoapps.instructor.views.api import require_course_permission
 from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError
+from opaque_keys.edx.locator import CourseLocator
+
 from ol_openedx_canvas_integration import tasks
 from ol_openedx_canvas_integration.client import CanvasClient
 from ol_openedx_canvas_integration.constants import COURSE_KEY_ID_EMPTY
 from ol_openedx_canvas_integration.utils import get_canvas_course_id
-from opaque_keys.edx.locator import CourseLocator
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)

The changes to the course content are tracked by listening to the `XBLOCK_PUBLISHED` and `XBLOCK_DELETED` events via the openedx-events library. If the course where these events occur is linked to a Canvas course, then the graded subsections in the course are synced as assignments in Canvas.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

* Use the instructions in https://github.com/mitodl/open-edx-plugins/pull/500#issue-3068562385 to install the `ol-openedx-canvas-integration` plugin and setup a course link between canvas and open-edx.
* Add Graded blocks, delete them and make changes and publish them to test changes reflect in Canvas.


### Additional Context

The Syncing primarily relies on course content getting published in Open edX, which is expected after author finalize changes. However, there is one scenario where the "Publish" step might be skipped: XBlock deletion.

So, this PR also includes an event listener for that event explicitly. 


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
