### PR TITLE
fix: copy course assets on publish

### DIFF
--- a/src/ol_openedx_course_sync/BUILD
+++ b/src/ol_openedx_course_sync/BUILD
@@ -10,7 +10,7 @@ python_distribution(
     dependencies=[":ol_openedx_course_sync_source"],
     provides=setup_py(
         name="ol-openedx-course-sync",
-        version="0.1.0",
+        version="0.2.0",
         description="An Open edX plugin to sync course changes to its reruns.",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_course_sync/tasks.py
+++ b/src/ol_openedx_course_sync/tasks.py
@@ -38,6 +38,11 @@ def async_course_sync(source_course_id, dest_course_id):
         source_course_key, dest_course_key, ModuleStoreEnum.BranchName.draft
     )
 
+    logger.info(
+        "Copying course assets from %s to %s",
+        source_course_key,
+        dest_course_key,
+    )
     # Copy course assets and update discussion state.
     # These steps are taken from the course_rerun task in edx-platform.
     module_store = modulestore()

--- a/src/ol_openedx_course_sync/tasks.py
+++ b/src/ol_openedx_course_sync/tasks.py
@@ -5,9 +5,10 @@ Tasks for the ol-openedx-course-sync plugin.
 from celery import shared_task  # pylint: disable=import-error
 from celery.utils.log import get_task_logger
 from celery_utils.persist_on_failure import LoggedPersistOnFailureTask
+from edxval.api import copy_course_videos
 from opaque_keys.edx.locator import CourseLocator
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import SignalHandler
+from xmodule.modulestore.django import SignalHandler, modulestore
 
 from ol_openedx_course_sync.apps import OLOpenEdxCourseSyncConfig
 from ol_openedx_course_sync.utils import copy_course_content
@@ -36,6 +37,15 @@ def async_course_sync(source_course_id, dest_course_id):
     copy_course_content(
         source_course_key, dest_course_key, ModuleStoreEnum.BranchName.draft
     )
+
+    # Copy course assets and update discussion state.
+    # These steps are taken from the course_rerun task in edx-platform.
+    module_store = modulestore()
+    if module_store.contentstore:
+        module_store.contentstore.copy_all_course_assets(
+            source_course_key, dest_course_key
+        )
+    copy_course_videos(source_course_key, dest_course_key)
 
     logger.info(
         "Copying published course content from %s to %s",

--- a/src/ol_openedx_course_sync/tasks.py
+++ b/src/ol_openedx_course_sync/tasks.py
@@ -43,7 +43,7 @@ def async_course_sync(source_course_id, dest_course_id):
         source_course_key,
         dest_course_key,
     )
-    # Copy course assets and update discussion state.
+    # Copy course assets and videos.
     # These steps are taken from the course_rerun task in edx-platform.
     module_store = modulestore()
     if module_store.contentstore:

--- a/src/ol_openedx_course_sync/tests/test_tasks.py
+++ b/src/ol_openedx_course_sync/tests/test_tasks.py
@@ -25,7 +25,18 @@ class TestReSyncTasks(OLOpenedXCourseSyncTestCase):
             "ol_openedx_course_sync.tasks.copy_course_content"
         ) as mock_copy_course_content, mock.patch(
             "ol_openedx_course_sync.tasks.SignalHandler"
-        ) as mock_signal_handler:
+        ) as mock_signal_handler, mock.patch(
+            "ol_openedx_course_sync.tasks.modulestore"
+        ) as mock_modulestore, mock.patch(
+            "ol_openedx_course_sync.tasks.copy_course_videos"
+        ) as mock_copy_course_videos:
+            mock_copy_all_course_assets = mock.Mock()
+            mock_contentstore = mock.Mock()
+            mock_contentstore.copy_all_course_assets = mock_copy_all_course_assets
+
+            mock_module_store_instance = mock.Mock()
+            mock_module_store_instance.contentstore = mock_contentstore
+            mock_modulestore.return_value = mock_module_store_instance
             mock_signal_handler.return_value = mock.Mock(
                 course_published=mock.Mock(send=mock.Mock())
             )
@@ -48,3 +59,8 @@ class TestReSyncTasks(OLOpenedXCourseSyncTestCase):
                 ]
             )
             mock_signal_handler.course_published.send.assert_called_once()
+            mock_copy_course_videos.assert_called_once_with(
+                self.source_course.usage_key.course_key,
+                self.target_course.usage_key.course_key,
+            )
+            mock_copy_all_course_assets.assert_called_once()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/7523

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes a bug with the course sync plugin to copy the course assets.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup course sync plugin by following the [readme](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_course_sync)
- Now add assets in the source course and publish the course. The assets should get copied to the target/rerun courses.