### PR TITLE
fix: delete old assets and copy new

### DIFF
--- a/src/ol_openedx_course_sync/BUILD
+++ b/src/ol_openedx_course_sync/BUILD
@@ -10,7 +10,7 @@ python_distribution(
     dependencies=[":ol_openedx_course_sync_source"],
     provides=setup_py(
         name="ol-openedx-course-sync",
-        version="0.2.0",
+        version="0.3.0",
         description="An Open edX plugin to sync course changes to its reruns.",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_course_sync/tasks.py
+++ b/src/ol_openedx_course_sync/tasks.py
@@ -47,6 +47,7 @@ def async_course_sync(source_course_id, dest_course_id):
     # These steps are taken from the course_rerun task in edx-platform.
     module_store = modulestore()
     if module_store.contentstore:
+        module_store.contentstore.delete_all_course_assets(dest_course_key)
         module_store.contentstore.copy_all_course_assets(
             source_course_key, dest_course_key
         )

--- a/src/ol_openedx_course_sync/tests/test_tasks.py
+++ b/src/ol_openedx_course_sync/tests/test_tasks.py
@@ -31,8 +31,10 @@ class TestReSyncTasks(OLOpenedXCourseSyncTestCase):
             "ol_openedx_course_sync.tasks.copy_course_videos"
         ) as mock_copy_course_videos:
             mock_copy_all_course_assets = mock.Mock()
+            mock_delete_all_course_assets = mock.Mock()
             mock_contentstore = mock.Mock()
             mock_contentstore.copy_all_course_assets = mock_copy_all_course_assets
+            mock_contentstore.delete_all_course_assets = mock_delete_all_course_assets
 
             mock_module_store_instance = mock.Mock()
             mock_module_store_instance.contentstore = mock_contentstore
@@ -64,3 +66,4 @@ class TestReSyncTasks(OLOpenedXCourseSyncTestCase):
                 self.target_course.usage_key.course_key,
             )
             mock_copy_all_course_assets.assert_called_once()
+            mock_delete_all_course_assets.assert_called_once()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
A follow up fix for https://github.com/mitodl/hq/issues/7523

### Description (What does it do?)
<!--- Describe your changes in detail -->
Deletes old assets and keeps the one that the source course has.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup [ol_openedx_course_sync](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_course_sync)
- Add assets to a source course
- Create a target course
- Add assets in source course and use those assets in the course content.
- Trigger course publish
- Now assets should sync and SHOULD NOT BE BROKEN, Content should sync and IMAGES should work.