### PR TITLE
feat: add tracking logs

### DIFF
--- a/src/ol_openedx_chat/BUILD
+++ b/src/ol_openedx_chat/BUILD
@@ -16,7 +16,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="ol-openedx-chat",
-        version="0.3.4",
+        version="0.3.5",
         description="An Open edX plugin to add Open Learning AI chat aside to xBlocks",
         license="BSD-3-Clause",
         author="MIT Office of Digital Learning",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -143,7 +143,8 @@ class OLChatAside(XBlockAside):
             "block_id": block_id,
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "drawer_payload": {
-                "blockUsageKey": block_usage_key,
+                "blockUsageKey": str(block_usage_key),
+                "trackingUrl": self.runtime.handler_url(self, "track_user_events"),
                 "blockType": block_type,
                 # Frontend will style AskTIM slightly
                 "title": f"AskTIM about {block.display_name}",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -5,6 +5,7 @@ import pkg_resources
 from django.conf import settings
 from django.template import Context, Template
 from django.utils.translation import gettext_lazy as _
+from eventtracking import tracker
 from rest_framework import status as api_status
 from web_fragments.fragment import Fragment
 from webob.response import Response
@@ -230,4 +231,15 @@ class OLChatAside(XBlockAside):
             )
 
         self.ol_chat_enabled = posted_data.get("is_enabled", True)
+        return Response()
+
+    @XBlock.handler
+    def track_user_events(self, request, suffix=""):  # noqa: ARG002
+        """
+        Track user events by emitting them to the event tracker.
+        """
+        request_data = request.json
+        tracker.emit(
+            request_data.get("event_name", ""), request_data.get("event_data", {})
+        )
         return Response()

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -143,6 +143,7 @@ class OLChatAside(XBlockAside):
             "block_id": block_id,
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "drawer_payload": {
+                "blockUsageKey": block_usage_key,
                 "blockType": block_type,
                 # Frontend will style AskTIM slightly
                 "title": f"AskTIM about {block.display_name}",
@@ -240,6 +241,6 @@ class OLChatAside(XBlockAside):
         """
         request_data = request.json
         tracker.emit(
-            request_data.get("event_name", ""), request_data.get("event_data", {})
+            request_data.get("event_type", ""), request_data.get("event_data", {})
         )
         return Response()

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -144,7 +144,7 @@ class OLChatAside(XBlockAside):
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "drawer_payload": {
                 "blockUsageKey": str(block_usage_key),
-                "trackingUrl": f"{settings.LMS_BASE_URL}{self.runtime.handler_url(self, 'track_user_events')}",
+                "trackingUrl": f"{settings.LMS_BASE_URL}{self.runtime.handler_url(self, 'track_user_events')}",  # noqa: E501
                 "blockType": block_type,
                 # Frontend will style AskTIM slightly
                 "title": f"AskTIM about {block.display_name}",

--- a/src/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/block.py
@@ -144,7 +144,7 @@ class OLChatAside(XBlockAside):
             "learning_mfe_base_url": settings.LEARNING_MICROFRONTEND_URL,
             "drawer_payload": {
                 "blockUsageKey": str(block_usage_key),
-                "trackingUrl": self.runtime.handler_url(self, "track_user_events"),
+                "trackingUrl": f"{settings.LMS_BASE_URL}{self.runtime.handler_url(self, 'track_user_events')}",
                 "blockType": block_type,
                 # Frontend will style AskTIM slightly
                 "title": f"AskTIM about {block.display_name}",

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -9,10 +9,7 @@
         window.parent.postMessage(
           {
             type: "smoot-design::tutor-drawer-open",
-            payload: {
-              ...event.data.payload,
-              trackingUrl: runtime.handlerUrl(element, 'track_user_events')
-            },
+            payload: event.data.payload,
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin
         );

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -9,7 +9,10 @@
         window.parent.postMessage(
           {
             type: "smoot-design::tutor-drawer-open",
-            payload: event.data.payload
+            payload: {
+              ...event.data.payload,
+              trackingUrl: runtime.handlerUrl(element, 'track_user_events')
+            },
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin
         );

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -1,5 +1,19 @@
 (function ($) {
   function AiChatAsideView(runtime, element, block_element, init_args) {
+
+    function emitTrackingEvent(eventName, eventData) {
+        $.ajax({
+            type: 'POST',
+            url: runtime.handlerUrl(element, 'track_user_events'),
+            data: JSON.stringify({
+              event_name: eventName,
+              event_data: eventData
+            }),
+            dataType: 'json',
+            contentType: 'application/json; charset=utf-8'
+        });
+    }
+
     $(function ($) {
 
       $(`#chat-button-${init_args.block_id}`).on("click", {
@@ -13,6 +27,11 @@
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin
         );
+
+        emitTrackingEvent('ol_openedx_chat.chat_drawer_opened', {
+          block_usage_key: event.data.payload.chat.requestBody.edx_module_id,
+          user_id: event.data.payload.chat.userId,
+        });
 
       });
     });

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -9,7 +9,7 @@
         window.parent.postMessage(
           {
             type: "smoot-design::tutor-drawer-open",
-            payload: event.data.payload,
+            payload: event.data.payload
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin
         );

--- a/src/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/static/js/ai_chat.js
@@ -1,19 +1,5 @@
 (function ($) {
   function AiChatAsideView(runtime, element, block_element, init_args) {
-
-    function emitTrackingEvent(eventName, eventData) {
-        $.ajax({
-            type: 'POST',
-            url: runtime.handlerUrl(element, 'track_user_events'),
-            data: JSON.stringify({
-              event_name: eventName,
-              event_data: eventData
-            }),
-            dataType: 'json',
-            contentType: 'application/json; charset=utf-8'
-        });
-    }
-
     $(function ($) {
 
       $(`#chat-button-${init_args.block_id}`).on("click", {
@@ -27,11 +13,6 @@
           },
           init_args.learning_mfe_base_url, // Ensure correct parent origin
         );
-
-        emitTrackingEvent('ol_openedx_chat.chat_drawer_opened', {
-          block_usage_key: event.data.payload.chat.requestBody.edx_module_id,
-          user_id: event.data.payload.chat.userId,
-        });
 
       });
     });

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from ddt import data, ddt, unpack
 from django.conf import settings
+from django.test import override_settings
 from django.test.client import Client
 from django.urls import reverse
 from opaque_keys.edx.asides import AsideUsageKeyV2
@@ -36,6 +37,7 @@ class OLChatAsideTests(OLChatTestCase):
     )
     @unpack
     @skip_unless_lms
+    @override_settings(LMS_BASE_URL="http://local.openedx.io")
     def test_student_view(self, ol_chat_enabled_value, should_render_aside, block_type):
         """
         Test that the aside student view returns a fragment if ol-chat is enabled.
@@ -155,7 +157,7 @@ class OLChatAsideTests(OLChatTestCase):
 
             expected_payload = {
                 "blockUsageKey": str(block.usage_key),
-                "trackingUrl": f"/xblock/{aside_usage_key}/handler/track_user_events",
+                "trackingUrl": f"{settings.LMS_BASE_URL}/xblock/{aside_usage_key}/handler/track_user_events",  # noqa: E501
                 "blockType": block_type,
                 "title": f"AskTIM about {block.display_name}",
                 "chat": {

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -59,6 +59,11 @@ class OLChatAsideTests(OLChatTestCase):
                 if block_type == PROBLEM_BLOCK_CATEGORY
                 else self.video_block
             )
+            aside_usage_key = str(AsideUsageKeyV2(
+                block.location, self.aside_name
+            ))
+            self.runtime.handler_url = Mock(return_value=f"/xblock/{aside_usage_key}/handler/track_user_events")
+            aside_instance.runtime = self.runtime
             fragment = aside_instance.student_view_aside(block)
 
             assert bool(fragment.content) is should_render_aside
@@ -81,6 +86,8 @@ class OLChatAsideTests(OLChatTestCase):
             assert list(fragment.json_init_args.keys()) == expected_json_init_args_keys
 
             expected_drawer_payload_keys = [
+                "blockUsageKey",
+                "trackingUrl",
                 "blockType",
                 "title",
                 "chat",
@@ -147,6 +154,8 @@ class OLChatAsideTests(OLChatTestCase):
                 expected_request_body["transcript_asset_id"] = "video-transcript-en.srt"
 
             expected_payload = {
+                "blockUsageKey": str(block.usage_key),
+                "trackingUrl": f"/xblock/{aside_usage_key}/handler/track_user_events",
                 "blockType": block_type,
                 "title": f"AskTIM about {block.display_name}",
                 "chat": {
@@ -297,3 +306,32 @@ class OLChatAsideTests(OLChatTestCase):
             block = self.store.get_item(block.location)
             ol_chat_aside = block.runtime.get_aside_of_type(block, self.aside_name)
             assert ol_chat_aside.ol_chat_enabled == ol_chat_enabled
+
+    @XBlockAside.register_temp_plugin(OLChatAside, "ol_chat_aside")
+    @patch("ol_openedx_chat.block.tracker")
+    @skip_unless_cms
+    def test_track_user_events(self, mock_tracker):
+        """
+        Tests the track_user_events handler
+        """
+        block = self.problem_block
+        aside_usage_key = str(AsideUsageKeyV2(block.location, self.aside_name))
+        handler_url = f"/xblock/{aside_usage_key}/handler/track_user_events"
+
+        client = Client()
+        client.login(username=self.user.username, password=self.user_password)
+        response = client.post(
+            handler_url,
+            json.dumps(
+                {
+                    "event_type": "chat_opened",
+                    "event_data": {
+                        "blockUsageKey": str(block.usage_key),
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200  # noqa: PLR2004
+        assert mock_tracker.emit.call_count == 1

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -59,10 +59,10 @@ class OLChatAsideTests(OLChatTestCase):
                 if block_type == PROBLEM_BLOCK_CATEGORY
                 else self.video_block
             )
-            aside_usage_key = str(AsideUsageKeyV2(
-                block.location, self.aside_name
-            ))
-            self.runtime.handler_url = Mock(return_value=f"/xblock/{aside_usage_key}/handler/track_user_events")
+            aside_usage_key = str(AsideUsageKeyV2(block.location, self.aside_name))
+            self.runtime.handler_url = Mock(
+                return_value=f"/xblock/{aside_usage_key}/handler/track_user_events"
+            )
             aside_instance.runtime = self.runtime
             fragment = aside_instance.student_view_aside(block)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/7632

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds event tracking backend for the tutor plugin

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup chat plugin by following the [readme](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat)
- Now follow the testing instructions in https://github.com/mitodl/smoot-design/pull/139. Do update the Learning MFE env.config.jsx
- Now test that chat drawer events like open, close, submit, tabchange are logged in lms logs.

Sample Log for Drawer Open:
```
lms-1          | 2025-07-02 09:25:33,914 INFO 524 [tracking] [user 4] [ip 192.168.65.1] logger.py:41 - {"name": "ol_openedx_chat.drawer.open", "context": {"course_id": "course-v1:TDT+TDT101+R3", "course_user_tags": {}, "user_id": 4, "path": "/courses/course-v1:TDT+TDT101+R3/xblock/aside-usage-v2:block-v1$:TDT+TDT101+R3+type@problem+block@89eff35e5fe447338306953e65e2ea2a::ol_openedx_chat/handler/track_user_events", "org_id": "TDT", "enterprise_uuid": "", "module": {"display_name": "Checkboxes", "usage_key": "block-v1:TDT+TDT101+R3+type@problem+block@89eff35e5fe447338306953e65e2ea2a"}}, "username": "edx", "session": "9c5a30e9e8b99e4e3cdaedb78091981a", "ip": "192.168.65.1", "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36", "host": "local.openedx.io:8000", "referer": "http://apps.local.openedx.io:2000/", "accept_language": "en-GB,en-US;q=0.9,en;q=0.8", "event": {"blockUsageKey": "block-v1:TDT+TDT101+R3+type@problem+block@89eff35e5fe447338306953e65e2ea2a"}, "time": "2025-07-02T09:25:33.914104+00:00", "event_type": "ol_openedx_chat.drawer.open", "event_source": "server", "page": null}
```