### PR TITLE
fix: broken CI on tutor initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,12 @@ jobs:
       run: |
         if [[ "${{ matrix.edx_branch }}" == "master" ]]; then
           DEV="tutor_main_dev"
+          DIRECTORY="tutor-main"
         else
+          DIRECTORY="tutor"
           DEV="tutor_dev"
         fi
-        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/tutor/env/local/docker-compose.yml -f /home/runner/.local/share/tutor/env/dev/docker-compose.yml --project-name $DEV run -v $PWD/../open-edx-plugins:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh
+        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/$DIRECTORY/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD/../open-edx-plugins:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh
 
     - name: Upload coverage to CodeCov
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
### What are the relevant tickets?
None
### Description (What does it do?)
-  I made some changes based on the new commits on https://github.com/overhangio/tutor because the main branch would not have the Docker-Compose file at the right location. 
- Now, it looks like they have got the things working on their end, so I reverted parts of my fixes in https://github.com/mitodl/open-edx-plugins/pull/505 back to the original.
<!--- Describe your changes in detail -->


### How can this be tested?
Same testing steps as https://github.com/mitodl/open-edx-plugins/pull/505
