### PR TITLE
chore: run CI on teak.1 as 'teak' is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         edx_branch:
         - master
         - open-release/sumac.master
-        - release/teak
+        - release/teak.1
           # Add more branches as needed
 
     steps:


### PR DESCRIPTION
### What are the relevant tickets?
None, noticed when the CI failed in https://github.com/mitodl/open-edx-plugins/pull/546
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
There is no `release/teak` branch or tag available in https://github.com/openedx/edx-platform now. Instead of `release/teak`, there is `release/teak.1`, the extended version of teak with more changes. So, this branch runs our CI on the lastest one available.

**NOTE:** _I think we should make the branch selection dynamic using env variables in the CI. But, I will work on that later or create a ticket for that but I am not doing that right now in this PR._

<!--- Describe your changes in detail -->

### How can this be tested?
CI passes
