### PR TITLE
increase chat height

### DIFF
--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/css/ai_chat_xblock.css
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/css/ai_chat_xblock.css
@@ -1,4 +1,8 @@
 .ai-chat-container {
+  /*
+  * MFE Iframe doesn't have a height set, so ensure a min height.
+  */
+  min-height: 400px;
   height: calc(100vh - 100px);
   position: relative;
 }

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/css/ai_chat_xblock.css
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/css/ai_chat_xblock.css
@@ -1,8 +1,14 @@
 .ai-chat-container {
   /*
-  * MFE Iframe doesn't have a height set, so ensure a min height.
+  * Learning MFE iframe sets its height based on size of contents.
+  * If no min height, then when only block, the iframe height collapses
+  * to zero.
+  * If no max height, the iframe resizes itself over and over, endlessly increasing its height.
+  *
+  * In Canvas, Iframe is set based on parent window height, which works very well.
   */
   min-height: 400px;
+  max-height: 1200px;
   height: calc(100vh - 100px);
   position: relative;
 }

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/css/ai_chat_xblock.css
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/css/ai_chat_xblock.css
@@ -1,4 +1,17 @@
 .ai-chat-container {
-    min-height: 400px;
-    position: relative;
+  height: calc(100vh - 100px);
+  position: relative;
+}
+
+/*
+* This overrides an openedx default style that is problematic
+* when embedding the xblock inside a canvas LTI.
+*
+* The top-margin on this container, combined with min-height: 100%
+* on the body element cause the iframe content to be taller than the iframe.
+*
+* So, get rid of this margin.
+*/
+.content-wrapper.main-container {
+  margin-top: 0px;
 }

--- a/src/ol_openedx_chat_xblock/pyproject.toml
+++ b/src/ol_openedx_chat_xblock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat-xblock"
-version = "0.1.3"
+version = "0.1.4"
 description = "An Open edX xBlock to add Open Learning AI chat"
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7849

### Description (What does it do?)
Increases height of canvas chat ui.

### Screenshots (if appropriate):

**In Canvas:** (Manually edited the existing CSS—i.e., not actually this version—but the canvas view is what matters.)
<img width="1849" height="734" alt="Screenshot 2025-07-17 at 5 30 59 PM" src="https://github.com/user-attachments/assets/8335d17d-fc1c-4067-9e5e-01915671237a" />

**In MFE LMS**:
<img width="1731" height="783" alt="Screenshot 2025-07-18 at 11 16 53 AM" src="https://github.com/user-attachments/assets/c2c2b6b3-4787-4ebe-8185-b7a470ea97a9" />

**In Legacy Studio:**
<img width="1604" height="929" alt="Screenshot 2025-07-18 at 11 06 09 AM" src="https://github.com/user-attachments/assets/ade86c60-b5f3-45d4-b825-bbb376aca763" />



### How can this be tested?
1. Enable the xblock locally; view it in LMS and CMS.

@asadali145 I had trouble enabling this locally. So I actually haven't tested it locally.  I added `["ol_openedx_chat_xblock"]` to the advanced module list.

Do I need a waffle flag?

**Edit:** Resolved; tested it locally now.