### PR TITLE
fix: renovate PRs creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    ":automergeMinor",
-    ":rebaseStalePrs",
-    ":separateMajorReleases",
-    "config:recommended"
-  ],
-  "schedule": [
-    "every weekend"
-  ],
-  "timezone": "US/Eastern",
-  "lockFileMaintenance": {
-    "enabled": true
-  }
+    "local>mitodl/.github:renovate-config"
+  ]
 }


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR updates the renovate configuration to match the one in ol-django, aiming to generate renovate PRs that haven't been created since the UV migration was merged.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
