### PR TITLE
fix: return NOT FOUND state when UserTaskStatus is not yet created

### DIFF
--- a/src/ol_openedx_course_export/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/ol_openedx_course_export/views.py
@@ -158,7 +158,7 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
                 name=name, task_id=task_id
             ).first()
             if not task_status:
-            return Response({"detail": "Task not found"}, status=status.HTTP_404_NOT_FOUND)
+                return Response({"detail": "Task not found"}, status=status.HTTP_404_NOT_FOUND)
             return Response({"state": task_status.state})
         except Exception as e:
             log.exception(str(e))  # noqa: TRY401

--- a/src/ol_openedx_course_export/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/ol_openedx_course_export/views.py
@@ -157,8 +157,8 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
             task_status = UserTaskStatus.objects.filter(
                 name=name, task_id=task_id
             ).first()
-            # If no UserTaskStatus exists yet, return a PENDING state to indicate the
-            # task is still waiting to run.
+            # If no UserTaskStatus exists yet, return a "not found" state to indicate
+            # that the task has not started execution.
             if not task_status:
                 return Response({"state": "Task not found"})
             return Response({"state": task_status.state})

--- a/src/ol_openedx_course_export/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/ol_openedx_course_export/views.py
@@ -157,6 +157,10 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
             task_status = UserTaskStatus.objects.filter(
                 name=name, task_id=task_id
             ).first()
+            # If no UserTaskStatus exists yet, return a PENDING state to indicate the
+            # task is still waiting to run.
+            if not task_status:
+                return Response({"state": UserTaskStatus.PENDING})
             return Response({"state": task_status.state})
         except Exception as e:
             log.exception(str(e))  # noqa: TRY401

--- a/src/ol_openedx_course_export/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/ol_openedx_course_export/views.py
@@ -158,7 +158,9 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
                 name=name, task_id=task_id
             ).first()
             if not task_status:
-                return Response({"detail": "Task not found"}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"detail": "Task not found"}, status=status.HTTP_404_NOT_FOUND
+                )
             return Response({"state": task_status.state})
         except Exception as e:
             log.exception(str(e))  # noqa: TRY401

--- a/src/ol_openedx_course_export/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/ol_openedx_course_export/views.py
@@ -160,7 +160,7 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
             # If no UserTaskStatus exists yet, return a PENDING state to indicate the
             # task is still waiting to run.
             if not task_status:
-                return Response({"state": UserTaskStatus.PENDING})
+                return Response({"state": "Task not found"})
             return Response({"state": task_status.state})
         except Exception as e:
             log.exception(str(e))  # noqa: TRY401

--- a/src/ol_openedx_course_export/ol_openedx_course_export/views.py
+++ b/src/ol_openedx_course_export/ol_openedx_course_export/views.py
@@ -157,10 +157,8 @@ class CourseExportView(CourseImportExportViewMixin, GenericAPIView):
             task_status = UserTaskStatus.objects.filter(
                 name=name, task_id=task_id
             ).first()
-            # If no UserTaskStatus exists yet, return a "not found" state to indicate
-            # that the task has not started execution.
             if not task_status:
-                return Response({"state": "Task not found"})
+            return Response({"detail": "Task not found"}, status=status.HTTP_404_NOT_FOUND)
             return Response({"state": task_status.state})
         except Exception as e:
             log.exception(str(e))  # noqa: TRY401


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8223

### Description (What does it do?)
This PR adds the code to return `PENDING` state when `UserTaskStatus` is not yet created. This avoids the code from breaking while accessing the status from the object, which doesn't exist yet. More details in the linked issue.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- To test this, we need to use tutor local to run the celery workers.
- First, create a tutor-plugin for settings. I tried other approaches as well, such as adding directly to the production.py file and also trying to add it to the config.yml file, but they didn't work. Run the commands below:
   - First create a plugins file in the plugin root: 
      ```
      cd "$(tutor plugins printroot)"
      touch myplugin.py
      ```
   - Next, paste the following code in the file:
     ```python
     from tutor import hooks

      hooks.Filters.ENV_PATCHES.add_item(
          (
              "openedx-cms-common-settings",
              """
      COURSE_IMPORT_EXPORT_BUCKET = "courseexportbucket"
      AWS_ACCESS_KEY_ID= "<your-access-key>"
      AWS_SECRET_ACCESS_KEY= "<your-secret-key>"
              """
          )
      )
     ``` 
   - Enable the plugin and start the tutor local setup:
     ```
      tutor plugins enable myplugin
      tutor local launch  # If you had already built the images once, run `tutor local restart` instead
     ```
- In open-edx-plugins, change [this line ](https://github.com/mitodl/open-edx-plugins/blob/main/src/ol_openedx_course_export/ol_openedx_course_export/views.py#L129) to run the task with a delay of 2 min using the below code:
  ```python
  task_detail = task_upload_course_s3.apply_async(
                      args=[request.user.id, course_id],
                      countdown=120
                  )
  ```
- Generate a build using `uv build --all-packages`. Copy the `dist/ol_openedx_course_export-0.1.2.tar.gz` into your edx-platform directory.
- In both the cms and cms-worker containers, install the package using pip and restart the containers.
- Create an API access token in edx-platform with the instructions mentioned [here](https://discuss.openedx.org/t/api-access-token-tutor/8109/4).
- Send a post request as below:
```
curl --location 'http://studio.local.openedx.io/api/courses/v0/export/' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <token-you-generated-in-previous-step>' \
--data '{
    "courses": ["<your-course-id>"]
}'
```
If everything works well, you will receive a task ID in response.
- Verify that the celery worker has received the task.
- Send a get request to the URL: `http://studio.local.openedx.io/api/courses/v0/export/<course-id>/?task_id=<task-id-received-in-post-request>`. You should see the following response:
```
{"detail":"Task not found"}
```
- Wait for the task to execute. Try again, and you should see the following status:
```
{"state":"Succeeded"}
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
