### PR TITLE
Update smoot-design version

### DIFF
--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -48,7 +48,7 @@ This will download the smoot-design package and copy the pre-bundled JS file to 
 
 .. code-block:: sh
 
-   npm pack @mitodl/smoot-design@^6.4.0
+   npm pack @mitodl/smoot-design@^6.17.0
    tar -xvzf mitodl-smoot-design*.tgz
    mkdir -p public/static/smoot-design
    cp package/dist/bundles/* public/static/smoot-design

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/lms.js
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/lms.js
@@ -1,5 +1,5 @@
 function OLChatBlock(runtime, element, init_args) {
-    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.16.0/dist/bundles/aiChat.es.js").then(aiChat => {
+    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.17.0/dist/bundles/aiChat.es.js").then(aiChat => {
         const requestOpts = {
             apiUrl: runtime.handlerUrl(element, 'ol_chat'),
             transformBody: (messages, { problem_set_title }) => {

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/studio.js
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/studio.js
@@ -1,5 +1,5 @@
 function OLChatBlock(runtime, element, init_args) {
-    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.16.0/dist/bundles/aiChat.es.js").then(aiChat => {
+    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.17.0/dist/bundles/aiChat.es.js").then(aiChat => {
         var studioRuntime = new window.StudioRuntime.v1();
         const requestOpts = {
             apiUrl: studioRuntime.handlerUrl(element, 'ol_chat'),


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/smoot-design/pull/167 and https://github.com/mitodl/learn-ai/pull/276

### Description (What does it do?)
Updates smoot-design to the latest version, which properly formats any chatbot citation links that might be in AI responses (primarily for the syllabus bots).

### How can this be tested?
- Tests should pass.
- Ask a question in the syllabus chat xBlock like:
  ` What is this course about? Please provide a link to the course in the format "[^🔗^](course_url)"`
-  The answer should include a link to the course that looks something like this:
  
<img width="839" height="81" alt="Screenshot 2025-08-26 082306" src="https://github.com/user-attachments/assets/227bca63-833f-45e3-b03c-682c9015f1f3" />

### Additional Context
See https://github.com/mitodl/smoot-design/pull/167 and https://github.com/mitodl/learn-ai/pull/276

