### PR TITLE
feat: trigger post message to authoring MFE when chat aside changes

### DIFF
--- a/src/ol_openedx_chat/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/block.py
@@ -193,12 +193,7 @@ class OLChatAside(XBlockAside):
         )
         fragment.add_css(get_resource_bytes("static/css/studio.css"))
         fragment.add_javascript(get_resource_bytes("static/js/studio.js"))
-        fragment.initialize_js(
-            "OLChatInit",
-            json_args={
-                "authoring_mfe_base_url": settings.COURSE_AUTHORING_MICROFRONTEND_URL
-            },
-        )
+        fragment.initialize_js("OLChatInit")
         return fragment
 
     @classmethod

--- a/src/ol_openedx_chat/ol_openedx_chat/static/js/studio.js
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/js/studio.js
@@ -1,7 +1,7 @@
 (function($) {
     'use strict';
 
-    function OpenLearningChatView(runtime, element, block_element, init_args) {
+    function OpenLearningChatView(runtime, element) {
         var $element = $(element);
         var AIChatConfigUpdateInProgress = false;
         // we need studio runtime to get handler capable of saving xblock data
@@ -26,11 +26,15 @@
                     dataType: 'json',
                     contentType: 'application/json; charset=utf-8'
                 }).done(function () {
-                    window.parent.postMessage(
-                        {
-                            type: "COURSE_REFRESH_TRIGGER",
-                        }, init_args.authoring_mfe_base_url
-                    );
+                    try {
+                        window.parent.postMessage({
+                            type: 'saveEditedXBlockData',
+                            message: 'Sends a message when the xblock data is saved',
+                            payload: {}
+                        }, document.referrer);
+                    } catch (e) {
+                        console.error(e);
+                    }
                 }).always(function() {
                     runtime.notify('save', {
                         state: 'end',
@@ -43,8 +47,8 @@
         });
     }
 
-    function initializeOLChat(runtime, element, block_element, init_args) {
-        return new OpenLearningChatView(runtime, element, block_element, init_args);
+    function initializeOLChat(runtime, element) {
+        return new OpenLearningChatView(runtime, element);
     }
 
     window.OLChatInit = initializeOLChat;

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -212,9 +212,6 @@ class OLChatAsideTests(OLChatTestCase):
 
             assert bool(fragment.content)
             assert fragment.js_init_fn == "OLChatInit"
-            assert fragment.json_init_args == {
-                "authoring_mfe_base_url": settings.COURSE_AUTHORING_MICROFRONTEND_URL
-            }
 
     @data(
         *[


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/8113

### Description (What does it do?)
<!--- Describe your changes in detail -->
Triggers a PostMessage from the Aside to the Authoring MFE to enable the publish button when the Aside changes.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

https://github.com/user-attachments/assets/07acaa7d-e605-4a60-bc09-0b324c86876c



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Check out this branch and follow the [readme](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat) to setup ol_chat_aside
- Enable the Authoring MFE unit page, Make sure that you have latest master branch.
- Change the ol chat flag and notice that the Publish button is enabled in the sidebar