### PR TITLE
refactor: use login_id to match canvas and openedx users

### DIFF
--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/__init__.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/__init__.py
@@ -2,6 +2,6 @@
 This is an integration of canvas with edX.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.5.3"
 
 default_app_config = "ol_openedx_canvas_integration.app.CanvasIntegrationConfig"  # pylint: disable=invalid-name

--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/client.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/client.py
@@ -116,11 +116,12 @@ class CanvasClient:
         search_results = self._paginate(
             url, params={"search_term": email, "enrollment_type[]": "student"}
         )
+        log.debug("Canvas search results for %s: %s", email, search_results)
         student_id = next(
             (
                 user["id"]
                 for user in search_results
-                if user.get("email", "").lower() == email.lower()
+                if user.get("login_id", "").lower() == email.lower()
             ),
             None,
         )

--- a/src/ol_openedx_canvas_integration/pyproject.toml
+++ b/src/ol_openedx_canvas_integration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-canvas-integration"
-version = "0.5.2"
+version = "0.5.4"
 description = "An Open edX plugin to add canvas integration support"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_canvas_integration/pyproject.toml
+++ b/src/ol_openedx_canvas_integration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-canvas-integration"
-version = "0.5.4"
+version = "0.5.3"
 description = "An Open edX plugin to add canvas integration support"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
Following up on #590 

### Description (What does it do?)
When matching the users between openedx and canvas, we use the "login_id" instead of the "email" in Canvas's response, as matching on email doesn't seem to be working in production.

### Screenshots (if appropriate):

N/A

### How can this be tested?

Following the testing instructions in #500 

### Additional Context
- We also add a log.debug statement to log the full Canvas response. We decided to do this for short-term debugging as we don't have any visibility into Canvas's logs.

