### PR TITLE
chore: bump AI chat smoot design to 6.19.0

### DIFF
--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -48,7 +48,7 @@ This will download the smoot-design package and copy the pre-bundled JS file to 
 
 .. code-block:: sh
 
-   npm pack @mitodl/smoot-design@^6.17.0
+   npm pack @mitodl/smoot-design@^6.19.0
    tar -xvzf mitodl-smoot-design*.tgz
    mkdir -p public/static/smoot-design
    cp package/dist/bundles/* public/static/smoot-design
@@ -78,7 +78,7 @@ The Unit is rendered inside an Iframe and we use postMessage to communicate betw
 
    export default config;
 
-(Alternatively, you can import the drawer code from a CDN like kg.com/@mitodl/smoot-design@6.4.0/dist/bundles/remoteTutorDrawer.umd.js to skip Step 3. However, the steps outlined here are most similar to what we do in production.)
+(Alternatively, you can import the drawer code from a CDN like kg.com/@mitodl/smoot-design@6.19.0/dist/bundles/remoteTutorDrawer.umd.js to skip Step 3. However, the steps outlined here are most similar to what we do in production.)
 
 5. Start learning MFE by ``npm run dev``
 ----------------------------------------

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -48,7 +48,7 @@ This will download the smoot-design package and copy the pre-bundled JS file to 
 
 .. code-block:: sh
 
-   npm pack @mitodl/smoot-design@^6.19.0
+   npm pack @mitodl/smoot-design@^6.33.3
    tar -xvzf mitodl-smoot-design*.tgz
    mkdir -p public/static/smoot-design
    cp package/dist/bundles/* public/static/smoot-design
@@ -78,7 +78,7 @@ The Unit is rendered inside an Iframe and we use postMessage to communicate betw
 
    export default config;
 
-(Alternatively, you can import the drawer code from a CDN like kg.com/@mitodl/smoot-design@6.19.0/dist/bundles/remoteTutorDrawer.umd.js to skip Step 3. However, the steps outlined here are most similar to what we do in production.)
+(Alternatively, you can import the drawer code from a CDN like https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.33.3/dist/bundles/remoteTutorDrawer.umd.js to skip Step 3. However, the steps outlined here are most similar to what we do in production.)
 
 5. Start learning MFE by ``npm run dev``
 ----------------------------------------

--- a/src/ol_openedx_chat_xblock/CHANGELOG.rst
+++ b/src/ol_openedx_chat_xblock/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 
+[0.4.8] - 2026-08-28
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Changed
+-------
+* Bump the bundled ``@mitodl/smoot-design`` AI chat build from 6.19.0 to 6.33.3.
+
 [0.4.6] - 2026-07-03
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/lms.js
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/lms.js
@@ -1,5 +1,5 @@
 function OLChatBlock(runtime, element, init_args) {
-    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.18.2/dist/bundles/aiChat.es.js").then(aiChat => {
+    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.19.0/dist/bundles/aiChat.es.js").then(aiChat => {
         const requestOpts = {
             apiUrl: runtime.handlerUrl(element, 'ol_chat'),
             feedbackApiUrl: init_args.chat_rating_url,

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/lms.js
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/lms.js
@@ -1,5 +1,5 @@
 function OLChatBlock(runtime, element, init_args) {
-    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.19.0/dist/bundles/aiChat.es.js").then(aiChat => {
+    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.33.3/dist/bundles/aiChat.es.js").then(aiChat => {
         const requestOpts = {
             apiUrl: runtime.handlerUrl(element, 'ol_chat'),
             feedbackApiUrl: init_args.chat_rating_url,

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/studio.js
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/studio.js
@@ -1,5 +1,5 @@
 function OLChatBlock(runtime, element, init_args) {
-    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.18.2/dist/bundles/aiChat.es.js").then(aiChat => {
+    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.19.0/dist/bundles/aiChat.es.js").then(aiChat => {
         var studioRuntime = new window.StudioRuntime.v1();
         const requestOpts = {
             apiUrl: studioRuntime.handlerUrl(element, 'ol_chat'),

--- a/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/studio.js
+++ b/src/ol_openedx_chat_xblock/ol_openedx_chat_xblock/static/js/studio.js
@@ -1,5 +1,5 @@
 function OLChatBlock(runtime, element, init_args) {
-    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.19.0/dist/bundles/aiChat.es.js").then(aiChat => {
+    import("https://cdn.jsdelivr.net/npm/@mitodl/smoot-design@6.33.3/dist/bundles/aiChat.es.js").then(aiChat => {
         var studioRuntime = new window.StudioRuntime.v1();
         const requestOpts = {
             apiUrl: studioRuntime.handlerUrl(element, 'ol_chat'),

--- a/src/ol_openedx_chat_xblock/pyproject.toml
+++ b/src/ol_openedx_chat_xblock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat-xblock"
-version = "0.4.6"
+version = "0.4.7"
 description = "An Open edX xBlock to add Open Learning AI chat"
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/src/ol_openedx_chat_xblock/pyproject.toml
+++ b/src/ol_openedx_chat_xblock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat-xblock"
-version = "0.4.7"
+version = "0.4.8"
 description = "An Open edX xBlock to add Open Learning AI chat"
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/uv.lock
+++ b/uv.lock
@@ -2138,7 +2138,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-chat-xblock"
-version = "0.4.6"
+version = "0.4.7"
 source = { editable = "src/ol_openedx_chat_xblock" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/uv.lock
+++ b/uv.lock
@@ -2138,7 +2138,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-chat-xblock"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "src/ol_openedx_chat_xblock" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?
None, The Only thing I remember about this now is that it was requested by Jon Kafton in the past.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Bumps the smoot design version in chat xblock to 6.19.0
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):

https://github.com/user-attachments/assets/e6945486-3ed0-4ad2-954d-5c2ef44928f4


<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Set up AskTIM chat with our chat plugin
- Make sure that it is working fine.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
