### PR TITLE
Fix error if LTI is disabled

### DIFF
--- a/src/ol_openedx_lti_utilities/ol_openedx_lti_utilities/urls.py
+++ b/src/ol_openedx_lti_utilities/ol_openedx_lti_utilities/urls.py
@@ -5,6 +5,8 @@ OL Open edX LTI Utilities URLs
 from django.conf import settings
 from django.urls import re_path
 
+urlpatterns = []
+
 if settings.FEATURES.get("ENABLE_LTI_PROVIDER"):
     from ol_openedx_lti_utilities.views import LtiUserFixView
 

--- a/src/ol_openedx_lti_utilities/pyproject.toml
+++ b/src/ol_openedx_lti_utilities/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-lti-utilities"
-version = "0.1.1"
+version = "0.1.2"
 description = "An Open edX plugin to add utilities for LTI operations"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes a django error if LTI is disabled because no urlpatterns were being defined.
