### PR TITLE
fix: plugin settings fixed when override from yaml file

### DIFF
--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/settings/common.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/settings/common.py
@@ -8,8 +8,15 @@ from ol_openedx_git_auto_export.constants import (
 
 def plugin_settings(settings):
     """Settings for the git auto export plugin."""  # noqa: D401
-    settings.GIT_REPO_EXPORT_DIR = "/openedx/export_course_repos"
-    settings.GITHUB_ORG_API_URL = "https://github.mit.edu/api/v3/orgs/mitodl"
-    settings.GITHUB_ACCESS_TOKEN = "token"  # noqa: S105
-    settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = True
-    settings.FEATURES[ENABLE_AUTO_GITHUB_REPO_CREATION] = False
+    env_tokens = getattr(settings, "ENV_TOKENS", {})
+    settings.GIT_REPO_EXPORT_DIR = env_tokens.get(
+        "GIT_REPO_EXPORT_DIR", "/openedx/export_course_repos"
+    )
+    settings.GITHUB_ORG_API_URL = env_tokens.get("GITHUB_ORG_API_URL", "")
+    settings.GITHUB_ACCESS_TOKEN = env_tokens.get("GITHUB_ACCESS_TOKEN")
+    settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = env_tokens.get("FEATURES", {}).get(
+        ENABLE_GIT_AUTO_EXPORT, True
+    )
+    settings.FEATURES[ENABLE_AUTO_GITHUB_REPO_CREATION] = env_tokens.get(
+        "FEATURES", {}
+    ).get(ENABLE_AUTO_GITHUB_REPO_CREATION, False)

--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/settings/production.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/settings/production.py
@@ -8,8 +8,15 @@ from ol_openedx_git_auto_export.constants import (
 
 def plugin_settings(settings):
     """Settings for the git auto export plugin."""  # noqa: D401
-    settings.GIT_REPO_EXPORT_DIR = "/openedx/export_course_repos"
-    settings.GITHUB_ORG_API_URL = "https://github.mit.edu/api/v3/orgs/mitodl"
-    settings.GITHUB_ACCESS_TOKEN = "token"  # noqa: S105
-    settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = True
-    settings.FEATURES[ENABLE_AUTO_GITHUB_REPO_CREATION] = False
+    env_tokens = getattr(settings, "ENV_TOKENS", {})
+    settings.GIT_REPO_EXPORT_DIR = env_tokens.get(
+        "GIT_REPO_EXPORT_DIR", "/openedx/export_course_repos"
+    )
+    settings.GITHUB_ORG_API_URL = env_tokens.get("GITHUB_ORG_API_URL", "")
+    settings.GITHUB_ACCESS_TOKEN = env_tokens.get("GITHUB_ACCESS_TOKEN")
+    settings.FEATURES[ENABLE_GIT_AUTO_EXPORT] = env_tokens.get("FEATURES", {}).get(
+        ENABLE_GIT_AUTO_EXPORT, True
+    )
+    settings.FEATURES[ENABLE_AUTO_GITHUB_REPO_CREATION] = env_tokens.get(
+        "FEATURES", {}
+    ).get(ENABLE_AUTO_GITHUB_REPO_CREATION, False)

--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/tasks.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/tasks.py
@@ -18,6 +18,7 @@ from ol_openedx_git_auto_export.models import CourseGitRepository
 from ol_openedx_git_auto_export.utils import (
     export_course_to_git,
     github_repo_name_format,
+    is_auto_repo_creation_enabled,
 )
 
 LOGGER = get_task_logger(__name__)
@@ -55,7 +56,8 @@ def async_export_to_git(course_key_string, user=None):
             "Creating repository and exporting course content.",
             course_key_string,
         )
-        async_create_github_repo.delay(str(course_key), export_course=True)
+        if is_auto_repo_creation_enabled():
+            async_create_github_repo.delay(str(course_key), export_course=True)
     except Exception:
         LOGGER.exception(
             "Unknown error occured during async course content export to git (course id: %s)",  # noqa: E501

--- a/src/ol_openedx_git_auto_export/pyproject.toml
+++ b/src/ol_openedx_git_auto_export/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-git-auto-export"
-version = "0.7.0"
+version = "0.7.1"
 description = "A plugin that auto saves the course OLX to git when an author publishes it"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9488

### Description (What does it do?)
This PR:
1. Fixes the git-auto-export plugins settings not being override through yaml file or ol-infra settings.

### How can this be tested?

1. Make sure the package is install in CMS -- follow the [Readme instructions](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_git_auto_export)
2. Run Migration in CMS: `tutor dev exec cms ./manange.py cms migrate`
3. Try to override the values through yaml file. You can do this in different ways and one of them is by adding [custom plugin](https://docs.tutor.edly.io/tutorials/plugin.html#creating-a-tutor-plugin)
4. Verify that the behavior of the plugin is according to the settings. For example: If you have set `FEATURES["ENABLE_AUTO_GITHUB_REPO_CREATION"] = False` it shouldn't create Github repos automatically
5. Setting `FEATURES["ENABLE_AUTO_GITHUB_REPO_CREATION"] = True` along with other required settings should create repositories