### PR TITLE
feat: Add exclusions for Sentry collector to exclude spammy already handled exceptions

### DIFF
--- a/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
+++ b/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
@@ -1,4 +1,3 @@
-# noqa: D100
 from __future__ import annotations
 
 import builtins
@@ -90,14 +89,16 @@ def _load_env_tokens(app_settings) -> dict[str, Any]:
         app_settings,
         "ENV_TOKENS",
         {
-            "SENTRY_IGNORED_EXCEPTION_CLASSES": ["NoUpstream",
-                                                 "DisallowedHost",
-                                                 "GitExportError",
-                                                 "CalledProcessError"],
+            "SENTRY_IGNORED_EXCEPTION_CLASSES": [
+                "NoUpstream",
+                "DisallowedHost",
+                "GitExportError",
+                "CalledProcessError",
+            ],
             "SENTRY_IGNORED_EXCEPTION_MESSAGES": [
                 "A label was requested for language code `ht` but the code is\
                         completely unknown"
-                ],
+            ],
             "SENTRY_DSN": "",
             "SENTRY_ENVIRONMENT": None,
             "SENTRY_SAMPLE_RATE": 0,
@@ -107,7 +108,7 @@ def _load_env_tokens(app_settings) -> dict[str, Any]:
     )
 
 
-def plugin_settings(app_settings): # noqa: D103
+def plugin_settings(app_settings):
     env_tokens = _load_env_tokens(app_settings)
     ignored_exceptions = env_tokens.get("SENTRY_IGNORED_EXCEPTION_CLASSES", [])
     ignored_messages = env_tokens.get("SENTRY_IGNORED_EXCEPTION_MESSAGES", [])


### PR DESCRIPTION
I'll list the Sentry issues in the PR.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Work towards mitodl/ol-infrastructure/#3986


### Description (What does it do?)
Excludes super spammy exceptions in mitxonline openedx from being collected by Sentry.

Candidate Sentry issues:

https://mit-office-of-digital-learning.sentry.io/issues/6011906340/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/6693435061/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/6531712941/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/6658720102/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/5827787531/?project=5939801


### How can this be tested?
Deploy this and ensure these excep;tions aren't collected in QA?