### PR TITLE
feat: add event handler webhook for certificate generation

### DIFF
--- a/src/ol_openedx_events_handler/CHANGELOG.rst
+++ b/src/ol_openedx_events_handler/CHANGELOG.rst
@@ -4,10 +4,8 @@ Change Log
 Version 0.2.0 (2026-04-17)
 ---------------------------
 
-* Migrated certificate webhook handling from ``ol_openedx_event_bridge``.
 * Added LMS receiver for ``COURSE_GRADE_NOW_PASSED`` to trigger certificate
   creation callbacks in MIT systems.
-* Added backward-compatible support for legacy certificate-related env tokens.
 
 Version 0.1.0 (2026-03-17)
 ---------------------------

--- a/src/ol_openedx_events_handler/CHANGELOG.rst
+++ b/src/ol_openedx_events_handler/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Version 0.2.0 (2026-04-17)
+---------------------------
+
+* Migrated certificate webhook handling from ``ol_openedx_event_bridge``.
+* Added LMS receiver for ``COURSE_GRADE_NOW_PASSED`` to trigger certificate
+  creation callbacks in MIT systems.
+* Added backward-compatible support for legacy certificate-related env tokens.
+
 Version 0.1.0 (2026-03-17)
 ---------------------------
 

--- a/src/ol_openedx_events_handler/README.rst
+++ b/src/ol_openedx_events_handler/README.rst
@@ -18,6 +18,8 @@ Currently handled events:
   access role (e.g. instructor, staff) is added, notifies an external system
   via webhook so the user can be enrolled as an auditor in the corresponding
   course.
+* ``openedx.core.djangoapps.signals.signals.COURSE_GRADE_NOW_PASSED`` — When a learner earns a passing grade,
+  notifies an external system to create a certificate.
 
 
 Installation
@@ -43,6 +45,8 @@ edx-platform configuration
 
     ENROLLMENT_WEBHOOK_URL: "https://example.com/api/openedx_webhook/enrollment/"
     ENROLLMENT_WEBHOOK_ACCESS_TOKEN: "<your-oauth-access-token>"
+    CERTIFICATE_WEBHOOK_URL: "https://example.com/api/openedx_webhook/certificate/"
+    CERTIFICATE_WEBHOOK_ACCESS_TOKEN: "<your-oauth-access-token>"
 
 - Optionally, override the roles that trigger the webhook (defaults to ``["instructor", "staff"]``):
 

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/apps.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/apps.py
@@ -15,6 +15,26 @@ _COURSE_ACCESS_ROLE_ADDED_RECEIVER = {
     ),
 }
 
+_COURSE_GRADE_NOW_PASSED_RECEIVER = {
+    PluginSignals.RECEIVER_FUNC_NAME: "listen_for_passing_grade",
+    PluginSignals.SIGNAL_PATH: (
+        "openedx.core.djangoapps.signals.signals.COURSE_GRADE_NOW_PASSED"
+    ),
+    PluginSignals.DISPATCH_UID: (
+        "ol_openedx_events_handler.receivers.certificate_passing_receiver"
+        ".listen_for_passing_grade"
+    ),
+}
+
+_SETTINGS_CONFIG = {
+    SettingsType.COMMON: {
+        PluginSettings.RELATIVE_PATH: "settings.common",
+    },
+    SettingsType.PRODUCTION: {
+        PluginSettings.RELATIVE_PATH: "settings.production",
+    },
+}
+
 
 class OlOpenedxEventsHandlerConfig(AppConfig):
     """App configuration for the OL Open edX events handler plugin."""
@@ -25,8 +45,11 @@ class OlOpenedxEventsHandlerConfig(AppConfig):
     plugin_app = {
         PluginSignals.CONFIG: {
             ProjectType.LMS: {
-                PluginSignals.RELATIVE_PATH: "handlers.course_access_role",
-                PluginSignals.RECEIVERS: [_COURSE_ACCESS_ROLE_ADDED_RECEIVER],
+                PluginSignals.RELATIVE_PATH: "handlers.lms",
+                PluginSignals.RECEIVERS: [
+                    _COURSE_ACCESS_ROLE_ADDED_RECEIVER,
+                    _COURSE_GRADE_NOW_PASSED_RECEIVER,
+                ],
             },
             ProjectType.CMS: {
                 PluginSignals.RELATIVE_PATH: "handlers.course_access_role",
@@ -34,21 +57,7 @@ class OlOpenedxEventsHandlerConfig(AppConfig):
             },
         },
         PluginSettings.CONFIG: {
-            ProjectType.LMS: {
-                SettingsType.COMMON: {
-                    PluginSettings.RELATIVE_PATH: "settings.common",
-                },
-                SettingsType.PRODUCTION: {
-                    PluginSettings.RELATIVE_PATH: "settings.production",
-                },
-            },
-            ProjectType.CMS: {
-                SettingsType.COMMON: {
-                    PluginSettings.RELATIVE_PATH: "settings.common",
-                },
-                SettingsType.PRODUCTION: {
-                    PluginSettings.RELATIVE_PATH: "settings.production",
-                },
-            },
+            ProjectType.LMS: _SETTINGS_CONFIG,
+            ProjectType.CMS: _SETTINGS_CONFIG,
         },
     }

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/handlers/lms.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/handlers/lms.py
@@ -1,0 +1,10 @@
+"""LMS-only signal handlers exported for plugin signal registration."""
+
+from ol_openedx_events_handler.handlers.course_access_role import (
+    handle_course_access_role_added,
+)
+from ol_openedx_events_handler.receivers.certificate_passing_receiver import (
+    listen_for_passing_grade,
+)
+
+__all__ = ["handle_course_access_role_added", "listen_for_passing_grade"]

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/receivers/__init__.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/receivers/__init__.py
@@ -1,0 +1,1 @@
+"""Signal receivers for ol_openedx_events_handler."""

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/receivers/certificate_passing_receiver.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/receivers/certificate_passing_receiver.py
@@ -1,0 +1,64 @@
+"""Django Signal handlers."""
+
+import logging
+
+from common.djangoapps.course_modes import api as modes_api
+from common.djangoapps.student.models import CourseEnrollment
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from xmodule.data import CertificatesDisplayBehaviors
+
+from ol_openedx_events_handler.tasks.certificate_passing import (
+    create_certificate_for_passing_grade,
+)
+from ol_openedx_events_handler.utils import validate_certificate_webhook
+
+log = logging.getLogger(__name__)
+
+
+def _is_eligible_for_certificate(user, course_id):
+    """
+    Determine whether certificate generation should be triggered.
+    """
+    enrollment_mode, _ = CourseEnrollment.enrollment_mode_for_user(user, course_id)
+    is_mode_eligible_for_cert = modes_api.is_eligible_for_certificate(enrollment_mode)
+    course_overview = CourseOverview.get_from_id(course_id)
+    certificate_display_behavior = course_overview.certificates_display_behavior
+
+    return is_mode_eligible_for_cert and (
+        course_overview.self_paced
+        or certificate_display_behavior == CertificatesDisplayBehaviors.EARLY_NO_INFO
+    )
+
+
+def listen_for_passing_grade(sender, user, course_id, **kwargs):  # noqa: ARG001
+    """
+    Automatically create a certificate in the relevant MIT application when a user
+    completes a course and gets a passing grade.
+    """
+
+    if not _is_eligible_for_certificate(user, course_id):
+        return
+
+    if not validate_certificate_webhook():
+        return
+
+    course_key = str(course_id)
+    user_email = getattr(user, "email", None)
+    if not user_email and getattr(user, "pii", None):
+        user_email = getattr(user.pii, "email", None)
+    if not user_email:
+        log.error(
+            "Cannot dispatch certificate webhook without user email for course '%s'.",
+            course_key,
+        )
+        return
+
+    log.info(
+        "User '%s' passed course '%s'. Dispatching certificate webhook.",
+        user_email,
+        course_key,
+    )
+    create_certificate_for_passing_grade.delay(
+        user_email=user_email,
+        course_key=course_key,
+    )

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/receivers/certificate_passing_receiver.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/receivers/certificate_passing_receiver.py
@@ -19,7 +19,13 @@ def _is_eligible_for_certificate(user, course_id):
     """
     Determine whether certificate generation should be triggered.
     """
-    enrollment_mode, _ = CourseEnrollment.enrollment_mode_for_user(user, course_id)
+    enrollment_mode, is_active = CourseEnrollment.enrollment_mode_for_user(
+        user, course_id
+    )
+
+    if not is_active:
+        return False
+
     is_mode_eligible_for_cert = modes_api.is_eligible_for_certificate(enrollment_mode)
     course_overview = CourseOverview.get_from_id(course_id)
     certificate_display_behavior = course_overview.certificates_display_behavior

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/settings/common.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/settings/common.py
@@ -14,3 +14,9 @@ def plugin_settings(settings):
 
     # Course access roles that should trigger the enrollment webhook.
     settings.ENROLLMENT_COURSE_ACCESS_ROLES = ["instructor", "staff"]
+
+    # Settings for the Certificate Webhook
+    # Webhook URL used to request certificate creation after course completion.
+    settings.CERTIFICATE_WEBHOOK_URL = None
+    # OAuth access token for the certificate webhook.
+    settings.CERTIFICATE_WEBHOOK_ACCESS_TOKEN = None

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/settings/production.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/settings/production.py
@@ -16,3 +16,10 @@ def plugin_settings(settings):
     settings.ENROLLMENT_COURSE_ACCESS_ROLES = env_tokens.get(
         "ENROLLMENT_COURSE_ACCESS_ROLES", settings.ENROLLMENT_COURSE_ACCESS_ROLES
     )
+
+    settings.CERTIFICATE_WEBHOOK_URL = env_tokens.get(
+        "CERTIFICATE_WEBHOOK_URL", settings.CERTIFICATE_WEBHOOK_URL
+    )
+    settings.CERTIFICATE_WEBHOOK_ACCESS_TOKEN = env_tokens.get(
+        "CERTIFICATE_WEBHOOK_ACCESS_TOKEN", settings.CERTIFICATE_WEBHOOK_ACCESS_TOKEN
+    )

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/tasks/certificate_passing.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/tasks/certificate_passing.py
@@ -1,0 +1,80 @@
+"""Celery tasks for certificate passing webhook notifications."""
+
+import logging
+
+import requests
+from celery import shared_task
+from django.conf import settings
+
+log = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 30
+
+
+def _get_certificate_webhook_url():
+    """Return the configured certificate webhook URL."""
+    return getattr(settings, "CERTIFICATE_WEBHOOK_URL", None)
+
+
+def _get_certificate_webhook_access_token():
+    """Return the configured certificate webhook access token."""
+    return getattr(settings, "CERTIFICATE_WEBHOOK_ACCESS_TOKEN", None)
+
+
+@shared_task(
+    autoretry_for=(requests.exceptions.RequestException,),
+    retry_kwargs={"max_retries": 3},
+    retry_backoff=True,
+    retry_backoff_max=120,
+)
+def create_certificate_for_passing_grade(user_email, course_key):
+    """
+    Notify an external system that a learner passed a course.
+
+    Sends a POST request to the configured certificate webhook endpoint so the
+    external system can create a certificate for the learner.
+    """
+    webhook_url = _get_certificate_webhook_url()
+    access_token = _get_certificate_webhook_access_token()
+
+    if not webhook_url or not access_token:
+        log.error(
+            "Certificate webhook is not fully configured. "
+            "Skipping dispatch for user '%s' in course '%s'.",
+            user_email,
+            course_key,
+        )
+        return
+
+    payload = {
+        "email": user_email,
+        "course_id": course_key,
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+    }
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+
+    log.info(
+        "Sending certificate webhook for user '%s' in course '%s'.",
+        user_email,
+        course_key,
+    )
+
+    response = requests.post(
+        webhook_url,
+        json=payload,
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+
+    log.info(
+        "Successfully sent certificate webhook for user '%s' in course '%s'. "
+        "Response status: %s",
+        user_email,
+        course_key,
+        response.status_code,
+    )

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/tasks/certificate_passing.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/tasks/certificate_passing.py
@@ -23,7 +23,7 @@ def _get_certificate_webhook_access_token():
 
 @shared_task(
     autoretry_for=(requests.exceptions.RequestException,),
-    retry_kwargs={"max_retries": 3},
+    retry_kwargs={"max_retries": 2},
     retry_backoff=True,
     retry_backoff_max=120,
 )
@@ -62,7 +62,6 @@ def create_certificate_for_passing_grade(user_email, course_key):
         user_email,
         course_key,
     )
-
     response = requests.post(
         webhook_url,
         json=payload,

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/tasks/course_access_role.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/tasks/course_access_role.py
@@ -13,7 +13,7 @@ REQUEST_TIMEOUT = 30
 
 @shared_task(
     autoretry_for=(requests.exceptions.RequestException,),
-    retry_kwargs={"max_retries": 3},
+    retry_kwargs={"max_retries": 2},
     retry_backoff=True,
     retry_backoff_max=120,
 )

--- a/src/ol_openedx_events_handler/ol_openedx_events_handler/utils.py
+++ b/src/ol_openedx_events_handler/ol_openedx_events_handler/utils.py
@@ -34,3 +34,32 @@ def validate_enrollment_webhook():
         return False
 
     return True
+
+
+def validate_certificate_webhook():
+    """
+    Validate that the certificate webhook is properly configured.
+
+    Checks that both the certificate webhook URL and access token are set in
+    Django settings.
+
+    Returns:
+        bool: True if the webhook is fully configured, False otherwise.
+    """
+    webhook_url = getattr(settings, "CERTIFICATE_WEBHOOK_URL", None)
+    if not webhook_url:
+        log.warning(
+            "Certificate webhook URL is not configured. "
+            "Skipping certificate webhook dispatch."
+        )
+        return False
+
+    webhook_key = getattr(settings, "CERTIFICATE_WEBHOOK_ACCESS_TOKEN", None)
+    if not webhook_key:
+        log.warning(
+            "Certificate webhook access token is not configured. "
+            "Skipping certificate webhook dispatch."
+        )
+        return False
+
+    return True

--- a/src/ol_openedx_events_handler/pyproject.toml
+++ b/src/ol_openedx_events_handler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ol-openedx-events-handler"
-version = "0.1.0"
+version = "0.2.0"
 description = "Open edX plugin to handle Open edX signals and events for MIT OL"
 readme = "README.rst"
 requires-python = ">=3.11"

--- a/src/ol_openedx_events_handler/tests/test_certificate_passing_receiver.py
+++ b/src/ol_openedx_events_handler/tests/test_certificate_passing_receiver.py
@@ -1,0 +1,80 @@
+"""Tests for the COURSE_GRADE_NOW_PASSED signal handler."""
+
+from unittest import mock
+
+from ol_openedx_events_handler.receivers.certificate_passing_receiver import (
+    listen_for_passing_grade,
+)
+
+COURSE_KEY = "course-v1:MITx+6.001x+2026_T1"
+VALID_WEBHOOK_PATCH = mock.patch(
+    "ol_openedx_events_handler.receivers.certificate_passing_receiver"
+    ".validate_certificate_webhook",
+    return_value=True,
+)
+TASK_PATCH = mock.patch(
+    "ol_openedx_events_handler.receivers.certificate_passing_receiver"
+    ".create_certificate_for_passing_grade"
+)
+
+
+@mock.patch(
+    "ol_openedx_events_handler.receivers.certificate_passing_receiver"
+    "._is_eligible_for_certificate",
+    return_value=False,
+)
+@TASK_PATCH
+def test_skips_when_not_eligible(mock_task, _mock_is_eligible):  # noqa: PT019
+    """Do nothing when the enrollment is not certificate-eligible."""
+    user = mock.MagicMock(email="user@example.com", username="user")
+
+    listen_for_passing_grade(sender=None, user=user, course_id=COURSE_KEY)
+
+    mock_task.delay.assert_not_called()
+
+
+@VALID_WEBHOOK_PATCH
+@mock.patch(
+    "ol_openedx_events_handler.receivers.certificate_passing_receiver"
+    "._is_eligible_for_certificate",
+    return_value=True,
+)
+@TASK_PATCH
+def test_dispatches_certificate_task(
+    mock_task,
+    _mock_is_eligible,  # noqa: PT019
+    _mock_validate,  # noqa: PT019
+):
+    """Dispatch certificate task when learner is eligible and configured."""
+    user = mock.MagicMock(email="user@example.com", username="user")
+
+    listen_for_passing_grade(sender=None, user=user, course_id=COURSE_KEY)
+
+    mock_task.delay.assert_called_once_with(
+        user_email="user@example.com",
+        course_key=COURSE_KEY,
+    )
+
+
+@mock.patch(
+    "ol_openedx_events_handler.receivers.certificate_passing_receiver"
+    ".validate_certificate_webhook",
+    return_value=False,
+)
+@mock.patch(
+    "ol_openedx_events_handler.receivers.certificate_passing_receiver"
+    "._is_eligible_for_certificate",
+    return_value=True,
+)
+@TASK_PATCH
+def test_skips_when_certificate_webhook_not_configured(
+    mock_task,
+    _mock_is_eligible,  # noqa: PT019
+    _mock_validate,  # noqa: PT019
+):
+    """Skip dispatch when no certificate webhook URL is configured."""
+    user = mock.MagicMock(email="user@example.com", username="user")
+
+    listen_for_passing_grade(sender=None, user=user, course_id=COURSE_KEY)
+
+    mock_task.delay.assert_not_called()

--- a/src/ol_openedx_events_handler/tests/test_certificate_passing_tasks.py
+++ b/src/ol_openedx_events_handler/tests/test_certificate_passing_tasks.py
@@ -1,0 +1,95 @@
+"""Tests for the certificate passing webhook Celery task."""
+
+from unittest import mock
+
+import pytest
+import requests
+from django.test import override_settings
+from ol_openedx_events_handler.tasks.certificate_passing import (
+    create_certificate_for_passing_grade,
+)
+
+WEBHOOK_URL = "https://example.com/api/openedx_webhook/certificate/"
+ACCESS_TOKEN = "certificate-access-token"  # noqa: S105
+USER_EMAIL = "learner@example.com"
+COURSE_KEY = "course-v1:MITx+6.001x+2026_T1"
+
+
+@mock.patch("ol_openedx_events_handler.tasks.certificate_passing.requests.post")
+def test_sends_certificate_webhook(mock_post):
+    """POST the certificate payload with the configured auth header."""
+    mock_response = mock.MagicMock()
+    mock_response.status_code = 200
+    mock_post.return_value = mock_response
+
+    with override_settings(
+        CERTIFICATE_WEBHOOK_URL=WEBHOOK_URL,
+        CERTIFICATE_WEBHOOK_ACCESS_TOKEN=ACCESS_TOKEN,
+    ):
+        create_certificate_for_passing_grade(
+            user_email=USER_EMAIL,
+            course_key=COURSE_KEY,
+        )
+
+    mock_post.assert_called_once_with(
+        WEBHOOK_URL,
+        json={
+            "email": USER_EMAIL,
+            "course_id": COURSE_KEY,
+        },
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {ACCESS_TOKEN}",
+        },
+        timeout=30,
+    )
+    mock_response.raise_for_status.assert_called_once()
+
+
+@override_settings(
+    CERTIFICATE_WEBHOOK_URL=WEBHOOK_URL,
+    CERTIFICATE_WEBHOOK_ACCESS_TOKEN=ACCESS_TOKEN,
+)
+@mock.patch("ol_openedx_events_handler.tasks.certificate_passing.requests.post")
+def test_raises_on_http_error(mock_post):
+    """HTTP errors should propagate for Celery retry."""
+    mock_response = mock.MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "500 Server Error"
+    )
+    mock_post.return_value = mock_response
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        create_certificate_for_passing_grade(
+            user_email=USER_EMAIL,
+            course_key=COURSE_KEY,
+        )
+
+
+@pytest.mark.parametrize(
+    ("certificate_webhook_url", "certificate_webhook_access_token"),
+    [
+        pytest.param(None, ACCESS_TOKEN, id="missing-webhook-url"),
+        pytest.param(WEBHOOK_URL, None, id="missing-access-token"),
+    ],
+)
+@mock.patch("ol_openedx_events_handler.tasks.certificate_passing.log.error")
+@mock.patch("ol_openedx_events_handler.tasks.certificate_passing.requests.post")
+def test_skips_dispatch_when_webhook_not_fully_configured(
+    mock_post,
+    mock_log_error,
+    certificate_webhook_url,
+    certificate_webhook_access_token,
+):
+    """Do not call certificate webhook when required settings are missing."""
+    with override_settings(
+        CERTIFICATE_WEBHOOK_URL=certificate_webhook_url,
+        CERTIFICATE_WEBHOOK_ACCESS_TOKEN=certificate_webhook_access_token,
+    ):
+        create_certificate_for_passing_grade(
+            user_email=USER_EMAIL,
+            course_key=COURSE_KEY,
+        )
+
+    mock_post.assert_not_called()
+    mock_log_error.assert_called_once()


### PR DESCRIPTION
This pull request introduces support for handling certificate creation webhooks when a learner passes a course in the Open edX LMS. The main changes add a new signal handler for the `COURSE_GRADE_NOW_PASSED` event, which triggers a Celery task to notify an external system to create a certificate. Configuration options and tests for the new functionality are also included.

**Certificate Webhook Integration:**

* Added a signal receiver (`listen_for_passing_grade`) for the `COURSE_GRADE_NOW_PASSED` event, which checks certificate eligibility and dispatches a webhook notification when a learner passes a course. (`ol_openedx_events_handler/receivers/certificate_passing_receiver.py`, [[1]](diffhunk://#diff-4bb37af776a82a9921af3bd7a34e0004a51a7727536feb1124ff5650ad1c66c0R18-R37) [[2]](diffhunk://#diff-4bb37af776a82a9921af3bd7a34e0004a51a7727536feb1124ff5650ad1c66c0L28-R61) [[3]](diffhunk://#diff-1e970408f59addc8b52f724564dbf1972cbbff0722a7a00293b812ba8c604822R1-R10) [[4]](diffhunk://#diff-db3896853cd2f57b766130dd70bce034e13956c924d14df4b56f2d01d6ba29f4R21-R22)
* Implemented a Celery task (`create_certificate_for_passing_grade`) to send a POST request to the configured certificate webhook endpoint, including error handling and retry logic. (`ol_openedx_events_handler/tasks/certificate_passing.py`, [src/ol_openedx_events_handler/ol_openedx_events_handler/tasks/certificate_passing.pyR1-R80](diffhunk://#diff-6cebc75456e46b379280021550b96ef246e688baff965102f5fa50c127bcc466R1-R80))
* Added utility function to validate certificate webhook configuration. (`ol_openedx_events_handler/utils.py`, [src/ol_openedx_events_handler/ol_openedx_events_handler/utils.pyR37-R65](diffhunk://#diff-3693d460b9c749f295570ec0c4b03b5e53fcee940973797edb64850956bc445eR37-R65))

**Configuration and Documentation:**

* Introduced new settings (`CERTIFICATE_WEBHOOK_URL`, `CERTIFICATE_WEBHOOK_ACCESS_TOKEN`) with support for environment token overrides, and documented their usage in the README. (`ol_openedx_events_handler/settings/common.py`, [[1]](diffhunk://#diff-6ded701c257565f4a2b630ad0050ac88d22bba02f9f1e7f1258269006c4d7a10R17-R22); `ol_openedx_events_handler/settings/production.py`, [[2]](diffhunk://#diff-116f2189efe5566256dfbf1a95f7f89e0e24c0fa413600cf5ceaf4dde0aef9acR19-R25); `README.rst`, [[3]](diffhunk://#diff-db3896853cd2f57b766130dd70bce034e13956c924d14df4b56f2d01d6ba29f4R48-R49)
* Updated the changelog and project version to 0.2.0 to reflect the new functionality. (`CHANGELOG.rst`, [[1]](diffhunk://#diff-d0b9a691cdc346fe7f3bbc322169607a2b2f5dd9d8646677f626cb124b9256deR4-R11); `pyproject.toml`, [[2]](diffhunk://#diff-43977a776765df1b70f4158cb4b5243ffd57384d2ffbf1f66e05fa69bae72c1dL7-R7)

**Testing:**

* Added unit tests for both the signal receiver and the Celery task to ensure correct behavior under various conditions, including eligibility checks and error scenarios. (`tests/test_certificate_passing_receiver.py`, [[1]](diffhunk://#diff-78b1186f13d1a823cb261ad543d869ff040c58875a3f42474c916da611fd1aafR1-R78); `tests/test_certificate_passing_tasks.py`, [[2]](diffhunk://#diff-50519b78af75f8e37a72c80931d06f852452b01aa3e51debc66523863c575a0cR1-R95)

These changes enable automated certificate creation workflows integrated with external systems upon course completion.### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9693, https://github.com/mitodl/hq/issues/10267
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- The PR adds a certificate event listener in edx instance
- The listener then calls the MIT app's certificate generation API to generate the certificates
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
NOTE: Will be tested along with the counterpart https://github.com/mitodl/mitxonline/pull/3459
- Setup on this branch
- Install the plugin ol_openedx_events_handler
- Set up a course with a grading policy and units
- Enroll a user in the paid course mode of this course
- Set up the configuration values for `CERTIFICATE_WEBHOOK_URL` (This is the API URL of the API from MITx Online) and `CERTIFICATE_WEBHOOK_ACCESS_TOKEN` (This is the staff token from your MITx Online instance)
- Set up the course to be self-paced and pass the user in a course, the webhook should be called, and a certificate should be created in MITx Online if validation passes
- Set up the certificate display behavior to `Immediately upon passing` and pass the user in the course, the certificate webhook should be called, and a certificate should be created in MITx Online
- Set up certificate display behavior to any value other than `Immediately upon passing`, and the webhook should not be called.
- 
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
Will be tested along with the counterpart https://github.com/mitodl/mitxonline/pull/3459
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
