### PR TITLE
fix: run CI with tutor directory instead if tutor main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,10 @@ jobs:
       run: |
         if [[ "${{ matrix.edx_branch }}" == "master" ]]; then
           DEV="tutor_main_dev"
-          DIRECTORY="tutor-main"
         else
-          DIRECTORY="tutor"
           DEV="tutor_dev"
         fi
-        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/$DIRECTORY/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
+        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/tutor/env/local/docker-compose.yml -f /home/runner/.local/share/tutor/env/dev/docker-compose.yml --project-name $DEV run -v $PWD:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
 
     - name: Upload coverage to CodeCov
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
The CI was broken again for open-edx-plugins repo since the ulmo release for tutor was cut. The structure was changed in the latest tutor release and the environment directory now again becomes the `tutor` instead of `tutor-main`.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
The CI should pass
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
