### PR TITLE
Fix the number of plurals in translation files

### DIFF
--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/sync_and_translate_language.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/sync_and_translate_language.py
@@ -814,7 +814,7 @@ class Command(BaseCommand):
 
         self.stdout.write("\nApplying translations...")
         applied_count, applied_by_app = self._apply_translations(
-            translations, empty_keys, self.stdout
+            translations, empty_keys, self.stdout, lang_code
         )
         self.stdout.write(f"   Applied {applied_count} translations")
 
@@ -2112,6 +2112,7 @@ class Command(BaseCommand):
         file_translations: dict[str, Any],
         empty_keys: list[dict],
         stdout,
+        lang_code: str | None = None,
     ) -> tuple[int, str]:
         """Apply translations to a single file. Returns (count, app)."""
         if not file_path.exists():
@@ -2137,7 +2138,7 @@ class Command(BaseCommand):
         if key_info["file_type"] == "json":
             count = apply_json_translations(file_path, file_translations)
         elif key_info["file_type"] == "po":
-            count = apply_po_translations(file_path, file_translations)
+            count = apply_po_translations(file_path, file_translations, lang_code)
         else:
             logger.warning(
                 "Unknown file type '%s' for file: %s", key_info["file_type"], file_path
@@ -2156,6 +2157,7 @@ class Command(BaseCommand):
         translations: dict[str, Any],
         empty_keys: list[dict],
         stdout,
+        lang_code: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         """Apply translations to files."""
         translations_by_file = self._group_translations_by_file(
@@ -2173,7 +2175,7 @@ class Command(BaseCommand):
         for file_path_str, file_translations in translations_by_file.items():
             full_path = Path(file_path_str)
             count, app = self._apply_file_translations(
-                full_path, file_translations, empty_keys, stdout
+                full_path, file_translations, empty_keys, stdout, lang_code
             )
 
             applied += count


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
 For languages with two plural forms (e.g. French), `djangojs.po` was getting an extra empty line msgstr[2] "" because some PO files had nplurals=3 in the header and the code expanded to match it.
**Solution:** When applying translations, we set the PO file’s Plural-Forms from our constants (using the command’s lang_code) so two-form languages use 2 slots. We save the file when only the header changes so `djangojs.po` no longer gets an empty msgstr[2].

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
```
tutor dev exec lms bash
./manage.py cms sync_and_translate_language fr --provider openai
```

It will create right number of plurals and change the headers aswell. 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
