### PR TITLE
fix: filter fixed for standalone xblock render /xblock/{block_key}

### DIFF
--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/filters.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/filters.py
@@ -23,21 +23,36 @@ class AddDestLangForVideoBlock(PipelineStep):
         Add the destination language to the student view context if a video block
         with transcripts in the course language is found among the child blocks.
         """
-        for child in dict(context)["block"].children:
-            if child.block_type == VIDEO_BLOCK_TYPE:
-                student_view_context["dest_lang"] = (
-                    ENGLISH_LANGUAGE_CODE  # default to English
-                )
-                video_block = modulestore().get_item(child)
-                transcripts_info = video_block.get_transcripts_info()
-                dest_lang = getattr(
-                    context.get("course", None), "language", ENGLISH_LANGUAGE_CODE
-                )
-                dest_lang = LanguageCode(dest_lang).to_bcp47()
-                if (
-                    transcripts_info
-                    and transcripts_info.get("transcripts", {})
-                    and dest_lang in transcripts_info["transcripts"]
-                ):
-                    student_view_context["dest_lang"] = dest_lang
+
+        def set_dest_lang_for_video_block(block_key):
+            """
+            Set the destination language for video blocks with
+            transcripts in the course language.
+            """
+            student_view_context["dest_lang"] = (
+                ENGLISH_LANGUAGE_CODE  # default to English
+            )
+            video_block = modulestore().get_item(block_key)
+            transcripts_info = video_block.get_transcripts_info()
+            dest_lang = getattr(
+                context.get("course", None), "language", ENGLISH_LANGUAGE_CODE
+            )
+            dest_lang = LanguageCode(dest_lang).to_bcp47()
+            if (
+                transcripts_info
+                and transcripts_info.get("transcripts", {})
+                and dest_lang in transcripts_info["transcripts"]
+            ):
+                student_view_context["dest_lang"] = dest_lang
+
+        block = dict(context)["block"]
+        block_usage_key = block.usage_key
+        block_type = block_usage_key.block_type
+        if block_type == "vertical":
+            for child in getattr(block, "children", []):
+                if child.block_type == VIDEO_BLOCK_TYPE:
+                    set_dest_lang_for_video_block(child)
+        elif block_type == VIDEO_BLOCK_TYPE:
+            set_dest_lang_for_video_block(block_usage_key)
+
         return {"context": context, "student_view_context": student_view_context}

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.4.1"
+version = "0.4.2"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes filter to fix issue with xBlock render API `/xblock/{usage_key}`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout main branch and setup the plugin.
- Visit http://local.openedx.io:8000/xblock/{BLOCK_KEY} for any problem/video block
- See the error that block has no children.
- Checkout this branch and test it again.
- Also, test that transcripts load in the same language as course language.