### PR TITLE
feat: added AskTim block_type translations

### DIFF
--- a/src/ol_openedx_chat/ol_openedx_chat/block.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/block.py
@@ -34,7 +34,6 @@ from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
 
 from ol_openedx_chat.compat import get_ol_openedx_chat_enabled_flag
 from ol_openedx_chat.constants import (
-    BLOCK_TYPE_LABELS,
     ENGLISH_LANGUAGE_TRANSCRIPT,
     MIT_AI_CHAT_URL_PATHS,
     PROBLEM_BLOCK_CATEGORY,
@@ -115,7 +114,7 @@ class OLChatAside(XBlockAside):
                     "block_usage_key": block_usage_key,
                     "block_type": block_type,
                     "about_block": gettext("about this %(block_type)s")
-                    % {"block_type": BLOCK_TYPE_LABELS.get(block_type, block_type)},
+                    % {"block_type": gettext(block_type)},
                 },
             )
         )

--- a/src/ol_openedx_chat/ol_openedx_chat/constants.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/constants.py
@@ -1,15 +1,7 @@
-from django.utils.translation import gettext_lazy as _
-
 # The dictionary should contain all the block types for which the chat should be
 # applicable if a block has sub-blocks or sub category, that should be added in the list
 VIDEO_BLOCK_CATEGORY = "video"
 PROBLEM_BLOCK_CATEGORY = "problem"
-
-# Translatable display labels for block categories (for UI)
-BLOCK_TYPE_LABELS = {
-    VIDEO_BLOCK_CATEGORY: _("video"),
-    PROBLEM_BLOCK_CATEGORY: _("problem"),
-}
 
 # The actual chat URL is `https://api-learn-ai.ol.mit.edu/http/video_gpt_agent/`
 # for video blocks and`https://api-learn-ai.ol.mit.edu/http/tutor_agent/`


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9923

### Description (What does it do?)
This PR enables the translation for `block_type` inside the A**skTim about this Problem/Video** button. 

### Screenshots (if appropriate):
<img width="862" height="784" alt="Screenshot 2026-02-27 at 2 36 00 PM" src="https://github.com/user-attachments/assets/b2a0e8f8-6aa2-49be-9183-1a9f53770759" />

<img width="866" height="668" alt="Screenshot 2026-02-27 at 2 36 18 PM" src="https://github.com/user-attachments/assets/7c35e06e-bc0b-4cdb-abd5-2bb3f7260266" />


### How can this be tested?
Checkout this branch locally.

```
tutor dev exec lms bash
export ATLAS_OPTIONS='--repository zamanafzal/mitxonline-translations --revision main'
make pull_translations

pip install -e /openedx/src/open-edx-plugins/src/ol_openedx_chat
```

Now you can test this with locale **el**.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
