### PR TITLE
fix: extract style after translations

### DIFF
--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
@@ -993,19 +993,31 @@ class HtmlXmlTranslationHelper:
         Serialize the DOM back to markup.
 
         For HTML parsing, lxml frequently wraps content in <html><body>.
-        If a <body> exists, this returns its inner HTML to better match original
-        fragment inputs while keeping structure valid.
+        We extract the inner content of both <head> and <body> so that
+        elements like <style> (which lxml hoists into <head>) are preserved.
         """
         if not self.is_xml:
+            parts: list[str] = []
+
+            head = root.find(".//head")
+            if head is not None:
+                if head.text:
+                    parts.append(head.text)
+                for child in head:
+                    parts.append(  # noqa: PERF401
+                        etree.tostring(child, encoding="unicode", method="html")
+                    )
+
             body = root.find(".//body")
             if body is not None:
-                parts: list[str] = []
                 if body.text:
                     parts.append(body.text)
                 for child in body:
                     parts.append(  # noqa: PERF401
                         etree.tostring(child, encoding="unicode", method="html")
                     )
+
+            if parts:
                 return "".join(parts)
 
         return etree.tostring(

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.5.2"
+version = "0.5.3"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/uv.lock
+++ b/uv.lock
@@ -2075,7 +2075,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-chat"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "src/ol_openedx_chat" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Modified serialize() to also extract and serialize children of <head> before <body>, so <style>, <script>, <meta>, <link>, and <title> elements are preserved.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup the plugin and translate https://studio.courses.rc.learn.mit.edu/authoring/course/course-v1:HZN+GA.2+T12026