### PR TITLE
fix: added lock to prevent same task run multiple time at the same time

### DIFF
--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/constants.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/constants.py
@@ -6,16 +6,11 @@ GITHUB_ACCESS_TOKEN = "GITHUB_ACCESS_TOKEN"  # noqa: S105
 COURSE_RERUN_STATE_SUCCEEDED = "succeeded"
 REPOSITORY_NAME_MAX_LENGTH = 100  # Max length from GitHub for repo name
 
-# Per-course git export distributed lock settings.
-# The pending task's total wait budget (MAX_RETRIES * RETRY_DELAY) must exceed
-# the lock TTL so a pending task cannot exhaust its retries while the running
-# export is still in progress.
-EXPORT_LOCK_TIMEOUT = 120  # seconds; safety TTL if a worker crashes holding the lock
-EXPORT_LOCK_RETRY_DELAY = 30  # seconds between retries for the pending task
-EXPORT_LOCK_MAX_RETRIES = 5  # max retries for the pending task
-# At most one extra task queues behind the running task; all other duplicates drop.
-EXPORT_PENDING_TIMEOUT = EXPORT_LOCK_TIMEOUT  # match the lock TTL
-
-# Cache key templates for the distributed git-export lock.
-EXPORT_LOCK_CACHE_KEY = "git_export_lock:{course_key}"
-EXPORT_PENDING_CACHE_KEY = "git_export_pending:{course_key}"
+# Debounce settings for the signal handler.
+# A single course save triggers 10-30 COURSE_PUBLISHED signals in one request.
+# cache.add() on this key ensures only the first signal schedules a task; all
+# subsequent signals within the window are silently dropped before hitting the broker.
+# The task is scheduled with countdown=EXPORT_DEBOUNCE_DELAY so it runs after
+# the burst window has closed and the course state is fully settled.
+EXPORT_DEBOUNCE_DELAY = 5  # seconds — must exceed the publish burst window
+EXPORT_DEBOUNCE_CACHE_KEY = "git_export_debounce:{course_key}"

--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/constants.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/constants.py
@@ -5,3 +5,17 @@ GITHUB_ACCESS_TOKEN = "GITHUB_ACCESS_TOKEN"  # noqa: S105
 
 COURSE_RERUN_STATE_SUCCEEDED = "succeeded"
 REPOSITORY_NAME_MAX_LENGTH = 100  # Max length from GitHub for repo name
+
+# Per-course git export distributed lock settings.
+# The pending task's total wait budget (MAX_RETRIES * RETRY_DELAY) must exceed
+# the lock TTL so a pending task cannot exhaust its retries while the running
+# export is still in progress.
+EXPORT_LOCK_TIMEOUT = 120  # seconds; safety TTL if a worker crashes holding the lock
+EXPORT_LOCK_RETRY_DELAY = 30  # seconds between retries for the pending task
+EXPORT_LOCK_MAX_RETRIES = 5  # max retries for the pending task
+# At most one extra task queues behind the running task; all other duplicates drop.
+EXPORT_PENDING_TIMEOUT = EXPORT_LOCK_TIMEOUT  # match the lock TTL
+
+# Cache key templates for the distributed git-export lock.
+EXPORT_LOCK_CACHE_KEY = "git_export_lock:{course_key}"
+EXPORT_PENDING_CACHE_KEY = "git_export_pending:{course_key}"

--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/tasks.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/tasks.py
@@ -16,29 +16,20 @@ from xmodule.modulestore.django import modulestore
 
 from ol_openedx_git_auto_export.models import CourseGitRepository
 from ol_openedx_git_auto_export.utils import (
-    acquire_export_lock_or_schedule,
     clear_stale_git_lock,
     export_course_to_git,
     github_repo_name_format,
     is_auto_repo_creation_enabled,
-    release_export_lock,
 )
 
 LOGGER = get_task_logger(__name__)
 
 
-@shared_task(bind=True)
-def async_export_to_git(self, course_key_string, user=None):
+@shared_task
+def async_export_to_git(course_key_string, user=None):
     """
     Exports a course to Git.
-
-    Concurrency and deduplication are handled by
-    ``acquire_export_lock_or_schedule`` / ``release_export_lock`` in utils.
-    See those functions for the full locking protocol.
     """  # noqa: D401
-    if not acquire_export_lock_or_schedule(self, course_key_string):
-        return  # duplicate task — dropped by the lock helper
-
     course_key = CourseKey.from_string(course_key_string)
     course_module = modulestore().get_course(course_key)
 
@@ -77,8 +68,6 @@ def async_export_to_git(self, course_key_string, user=None):
             "Unknown error occured during async course content export to git (course id: %s)",  # noqa: E501
             course_module.id,
         )
-    finally:
-        release_export_lock(course_key_string)
 
 
 @shared_task(

--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/tasks.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/tasks.py
@@ -16,19 +16,29 @@ from xmodule.modulestore.django import modulestore
 
 from ol_openedx_git_auto_export.models import CourseGitRepository
 from ol_openedx_git_auto_export.utils import (
+    acquire_export_lock_or_schedule,
+    clear_stale_git_lock,
     export_course_to_git,
     github_repo_name_format,
     is_auto_repo_creation_enabled,
+    release_export_lock,
 )
 
 LOGGER = get_task_logger(__name__)
 
 
-@shared_task
-def async_export_to_git(course_key_string, user=None):
+@shared_task(bind=True)
+def async_export_to_git(self, course_key_string, user=None):
     """
     Exports a course to Git.
+
+    Concurrency and deduplication are handled by
+    ``acquire_export_lock_or_schedule`` / ``release_export_lock`` in utils.
+    See those functions for the full locking protocol.
     """  # noqa: D401
+    if not acquire_export_lock_or_schedule(self, course_key_string):
+        return  # duplicate task — dropped by the lock helper
+
     course_key = CourseKey.from_string(course_key_string)
     course_module = modulestore().get_course(course_key)
 
@@ -39,6 +49,10 @@ def async_export_to_git(course_key_string, user=None):
                 "Starting async course content export to git (course id: %s)",
                 course_module.id,
             )
+            # Remove any stale .git/index.lock left by a previously crashed worker.
+            # Dirty working-tree files from a prior crash are cleaned by the
+            # `git reset --hard origin/<branch>` + `git clean` inside export_to_git.
+            clear_stale_git_lock(course_repo.git_url)
             export_to_git(course_module.id, course_repo.git_url, user=user)
         else:
             LOGGER.info(
@@ -63,6 +77,8 @@ def async_export_to_git(course_key_string, user=None):
             "Unknown error occured during async course content export to git (course id: %s)",  # noqa: E501
             course_module.id,
         )
+    finally:
+        release_export_lock(course_key_string)
 
 
 @shared_task(

--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/utils.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/utils.py
@@ -16,12 +16,8 @@ from xmodule.modulestore.django import modulestore
 from ol_openedx_git_auto_export.constants import (
     ENABLE_AUTO_GITHUB_REPO_CREATION,
     ENABLE_GIT_AUTO_EXPORT,
-    EXPORT_LOCK_CACHE_KEY,
-    EXPORT_LOCK_MAX_RETRIES,
-    EXPORT_LOCK_RETRY_DELAY,
-    EXPORT_LOCK_TIMEOUT,
-    EXPORT_PENDING_CACHE_KEY,
-    EXPORT_PENDING_TIMEOUT,
+    EXPORT_DEBOUNCE_CACHE_KEY,
+    EXPORT_DEBOUNCE_DELAY,
     REPOSITORY_NAME_MAX_LENGTH,
 )
 
@@ -108,16 +104,30 @@ def export_course_to_git(course_key):
         )
 
         user = get_publisher_username(course_module)
-        async_export_to_git.delay(str(course_key), user)
+
+        debounce_key = EXPORT_DEBOUNCE_CACHE_KEY.format(course_key=str(course_key))
+        if cache.add(debounce_key, "1", timeout=EXPORT_DEBOUNCE_DELAY):
+            log.info(
+                "Scheduling git export for course %s with %ds debounce delay",
+                course_key,
+                EXPORT_DEBOUNCE_DELAY,
+            )
+            async_export_to_git.apply_async(
+                args=[str(course_key), user],
+                countdown=EXPORT_DEBOUNCE_DELAY,
+            )
+        else:
+            log.info(
+                "Git export already scheduled for course %s, skipping duplicate signal",
+                course_key,
+            )
 
 
 def clear_stale_git_lock(git_url):
     """
     Remove a stale .git/index.lock file for the local clone of git_url, if present.
 
-    This must only be called after acquiring the per-course distributed cache lock,
-    which guarantees no other process is running git operations on the same directory.
-    A stale lock file is left behind when a worker process is killed mid-operation.
+    A stale lock file can be left behind when a worker process is killed mid-operation.
     """
     git_repo_export_dir = getattr(
         settings, "GIT_REPO_EXPORT_DIR", "/openedx/export_course_repos"
@@ -129,76 +139,6 @@ def clear_stale_git_lock(git_url):
             "Removing stale .git/index.lock for repo %s at %s", git_url, index_lock
         )
         index_lock.unlink()
-
-
-def acquire_export_lock_or_schedule(task, course_key_string):
-    """
-    Attempt to acquire the per-course git-export distributed lock.
-
-    Uses two cache keys:
-    - ``EXPORT_LOCK_CACHE_KEY``    — held while the export is running.
-    - ``EXPORT_PENDING_CACHE_KEY`` — stores the task-ID of the single task
-      that is waiting to run after the lock-holder finishes.
-
-    Returns True if the caller acquired the lock and should proceed with the
-    export.  Returns False if the caller is a duplicate that was dropped.
-    Raises ``celery.exceptions.Retry`` if the caller is the designated pending
-    task and needs to retry later.
-    """
-    lock_key = EXPORT_LOCK_CACHE_KEY.format(course_key=course_key_string)
-    pending_key = EXPORT_PENDING_CACHE_KEY.format(course_key=course_key_string)
-    task_id = task.request.id
-
-    if not cache.add(lock_key, task_id, timeout=EXPORT_LOCK_TIMEOUT):
-        # Lock is held — check if we are already the designated pending task.
-        if cache.get(pending_key) == task_id:
-            log.info(
-                "Export lock still held for %s, pending task %s retrying in %ds"
-                " (attempt %d/%d)",
-                course_key_string,
-                task_id,
-                EXPORT_LOCK_RETRY_DELAY,
-                task.request.retries + 1,
-                EXPORT_LOCK_MAX_RETRIES,
-            )
-            raise task.retry(
-                countdown=EXPORT_LOCK_RETRY_DELAY, max_retries=EXPORT_LOCK_MAX_RETRIES
-            )
-
-        # Try to become the single designated pending task (atomic).
-        if cache.add(pending_key, task_id, timeout=EXPORT_PENDING_TIMEOUT):
-            log.info(
-                "Export already in progress for %s; task %s queued as pending,"
-                " retrying in %ds",
-                course_key_string,
-                task_id,
-                EXPORT_LOCK_RETRY_DELAY,
-            )
-            raise task.retry(
-                countdown=EXPORT_LOCK_RETRY_DELAY, max_retries=EXPORT_LOCK_MAX_RETRIES
-            )
-
-        # Pending slot already taken — drop this duplicate.
-        log.info(
-            "Dropping duplicate export task %s for %s (lock held, pending slot taken)",
-            task_id,
-            course_key_string,
-        )
-        return False
-
-    # Lock acquired — clear the pending slot so a fresh task can claim it.
-    cache.delete(pending_key)
-    return True
-
-
-def release_export_lock(course_key_string):
-    """
-    Release the per-course git-export distributed lock.
-
-    Must be called in a ``finally`` block after ``acquire_export_lock_or_schedule``
-    returns True.
-    """
-    cache.delete(EXPORT_LOCK_CACHE_KEY.format(course_key=course_key_string))
 
 
 def is_auto_repo_creation_enabled():

--- a/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/utils.py
+++ b/src/ol_openedx_git_auto_export/ol_openedx_git_auto_export/utils.py
@@ -5,15 +5,23 @@ Utility functions for the ol_openedx_git_auto_export app.
 import logging
 import os
 import re
+from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from xmodule.modulestore.django import modulestore
 
 from ol_openedx_git_auto_export.constants import (
     ENABLE_AUTO_GITHUB_REPO_CREATION,
     ENABLE_GIT_AUTO_EXPORT,
+    EXPORT_LOCK_CACHE_KEY,
+    EXPORT_LOCK_MAX_RETRIES,
+    EXPORT_LOCK_RETRY_DELAY,
+    EXPORT_LOCK_TIMEOUT,
+    EXPORT_PENDING_CACHE_KEY,
+    EXPORT_PENDING_TIMEOUT,
     REPOSITORY_NAME_MAX_LENGTH,
 )
 
@@ -101,6 +109,96 @@ def export_course_to_git(course_key):
 
         user = get_publisher_username(course_module)
         async_export_to_git.delay(str(course_key), user)
+
+
+def clear_stale_git_lock(git_url):
+    """
+    Remove a stale .git/index.lock file for the local clone of git_url, if present.
+
+    This must only be called after acquiring the per-course distributed cache lock,
+    which guarantees no other process is running git operations on the same directory.
+    A stale lock file is left behind when a worker process is killed mid-operation.
+    """
+    git_repo_export_dir = getattr(
+        settings, "GIT_REPO_EXPORT_DIR", "/openedx/export_course_repos"
+    )
+    rdir = git_url.rsplit("/", 1)[-1].rsplit(".git", 1)[0]
+    index_lock = Path(git_repo_export_dir) / rdir / ".git" / "index.lock"
+    if index_lock.exists():
+        log.warning(
+            "Removing stale .git/index.lock for repo %s at %s", git_url, index_lock
+        )
+        index_lock.unlink()
+
+
+def acquire_export_lock_or_schedule(task, course_key_string):
+    """
+    Attempt to acquire the per-course git-export distributed lock.
+
+    Uses two cache keys:
+    - ``EXPORT_LOCK_CACHE_KEY``    — held while the export is running.
+    - ``EXPORT_PENDING_CACHE_KEY`` — stores the task-ID of the single task
+      that is waiting to run after the lock-holder finishes.
+
+    Returns True if the caller acquired the lock and should proceed with the
+    export.  Returns False if the caller is a duplicate that was dropped.
+    Raises ``celery.exceptions.Retry`` if the caller is the designated pending
+    task and needs to retry later.
+    """
+    lock_key = EXPORT_LOCK_CACHE_KEY.format(course_key=course_key_string)
+    pending_key = EXPORT_PENDING_CACHE_KEY.format(course_key=course_key_string)
+    task_id = task.request.id
+
+    if not cache.add(lock_key, task_id, timeout=EXPORT_LOCK_TIMEOUT):
+        # Lock is held — check if we are already the designated pending task.
+        if cache.get(pending_key) == task_id:
+            log.info(
+                "Export lock still held for %s, pending task %s retrying in %ds"
+                " (attempt %d/%d)",
+                course_key_string,
+                task_id,
+                EXPORT_LOCK_RETRY_DELAY,
+                task.request.retries + 1,
+                EXPORT_LOCK_MAX_RETRIES,
+            )
+            raise task.retry(
+                countdown=EXPORT_LOCK_RETRY_DELAY, max_retries=EXPORT_LOCK_MAX_RETRIES
+            )
+
+        # Try to become the single designated pending task (atomic).
+        if cache.add(pending_key, task_id, timeout=EXPORT_PENDING_TIMEOUT):
+            log.info(
+                "Export already in progress for %s; task %s queued as pending,"
+                " retrying in %ds",
+                course_key_string,
+                task_id,
+                EXPORT_LOCK_RETRY_DELAY,
+            )
+            raise task.retry(
+                countdown=EXPORT_LOCK_RETRY_DELAY, max_retries=EXPORT_LOCK_MAX_RETRIES
+            )
+
+        # Pending slot already taken — drop this duplicate.
+        log.info(
+            "Dropping duplicate export task %s for %s (lock held, pending slot taken)",
+            task_id,
+            course_key_string,
+        )
+        return False
+
+    # Lock acquired — clear the pending slot so a fresh task can claim it.
+    cache.delete(pending_key)
+    return True
+
+
+def release_export_lock(course_key_string):
+    """
+    Release the per-course git-export distributed lock.
+
+    Must be called in a ``finally`` block after ``acquire_export_lock_or_schedule``
+    returns True.
+    """
+    cache.delete(EXPORT_LOCK_CACHE_KEY.format(course_key=course_key_string))
 
 
 def is_auto_repo_creation_enabled():

--- a/src/ol_openedx_git_auto_export/pyproject.toml
+++ b/src/ol_openedx_git_auto_export/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-git-auto-export"
-version = "0.7.1"
+version = "0.7.2"
 description = "A plugin that auto saves the course OLX to git when an author publishes it"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10758#issuecomment-4201469687
https://github.com/mitodl/hq/issues/10243

### Description (What does it do?)
This pull request introduces two main improvements to the git export process for courses: (1) it debounces repeated export tasks triggered by multiple signals during a single course save, ensuring only one export is scheduled per burst, and (2) it adds cleanup of stale git lock files to prevent export failures due to prior crashes.

**Debounce logic for export tasks:**

- Added `EXPORT_DEBOUNCE_DELAY` and `EXPORT_DEBOUNCE_CACHE_KEY` constants to control and identify the debounce window for export scheduling.
- Modified `export_course_to_git` to use Django's cache to ensure only the first export signal within the debounce window schedules a task, with subsequent signals being ignored. The export task is scheduled with a delay to allow the burst of signals to settle.

**Robustness improvements for git operations:**

- Introduced a `clear_stale_git_lock` utility function to remove any leftover `.git/index.lock` files from previously crashed workers before starting a new export. This prevents git operations from failing due to stale locks.
- Updated `async_export_to_git` to call `clear_stale_git_lock` before exporting, ensuring a clean working directory.

### How can this be tested?
1. **Prerequisites**
    - A local Tutor dev environment with `ol_openedx_git_auto_export` installed
    - A course with `CourseGitRepository` configured and `is_export_enabled = True`
    - Celery workers running with `concurrency >= 2` (to reproduce the original race)

2. In Studio, make a change on the "Schedule & Details" page (this fires ~10–30 signals).
3. This should cause errors in cms-worker logs -- different sort of errors
4. Checkout to this branch -- re-install if needed and restart cms-workers
5. Repeat the process -- You should be able to see 1 new commit and there will only 1 red log with message similar to "Nothing to commit"

### Additional Info:
This multiple signal fire issue is also being resolved here https://github.com/openedx/openedx-platform/pull/38126