### PR TITLE
config: add ol_clear_expired_tokens task in production settings

### DIFF
--- a/src/ol_social_auth/ol_social_auth/settings/production.py
+++ b/src/ol_social_auth/ol_social_auth/settings/production.py
@@ -4,7 +4,7 @@ from celery.schedules import crontab
 
 
 def plugin_settings(settings):
-    """Production overrides for ol-social-auth plugin."""  # noqa: D401
+    """Production overrides for ol-social-auth plugin."""
     # Re-add the celery beat schedule here because the YAML config loading
     # in production.py replaces the entire CELERYBEAT_SCHEDULE dict,
     # wiping out what common.py set. This runs after YAML loading.

--- a/src/ol_social_auth/ol_social_auth/settings/production.py
+++ b/src/ol_social_auth/ol_social_auth/settings/production.py
@@ -1,5 +1,16 @@
 """Production settings for the ol-social-auth plugin."""
 
+from celery.schedules import crontab
+
 
 def plugin_settings(settings):
-    """Production overrides for ol-social-auth plugin."""
+    """Production overrides for ol-social-auth plugin."""  # noqa: D401
+    # Re-add the celery beat schedule here because the YAML config loading
+    # in production.py replaces the entire CELERYBEAT_SCHEDULE dict,
+    # wiping out what common.py set. This runs after YAML loading.
+    if not hasattr(settings, "CELERYBEAT_SCHEDULE"):
+        settings.CELERYBEAT_SCHEDULE = {}
+    settings.CELERYBEAT_SCHEDULE["ol_clear_expired_tokens"] = {
+        "task": "ol_social_auth.tasks.ol_clear_expired_tokens",
+        "schedule": crontab(hour=9, minute=0, day_of_week="monday"),
+    }

--- a/src/ol_social_auth/pyproject.toml
+++ b/src/ol_social_auth/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-social-auth"
-version = "0.2.1"
+version = "0.2.2"
 description = "An Open edX plugin implementing MIT social auth backend"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10116

### Description (What does it do?)
The task is not appearing in the `CELERYBEAT_SCHEDULE` on RC, despite `ol-social-auth` 0.2.1 being installed. This PR adds the `ol_clear_expired_tokens` task in production.py. I am not entirely sure how the deployment flow works, but according to the co-pilot, this is the ordering:

1. The plugin's common.py `plugin_settings()` runs during common.py loading (early) — this correctly adds `ol_clear_expired_tokens` with a real `crontab()` object.
2. The YAML config (loaded in production.py ~line 70) overwrites `CELERYBEAT_SCHEDULE` entirely via `vars().update()`, wiping out what common.py set.
3. `refresh-saml-metadata` is added back by the platform's own production.py at line 322 (hardcoded post-YAML logic) — which is why it still appears in RC.
4. `add_plugins(__name__, ProjectType.LMS, SettingsType.PRODUCTION)` runs at line 441 — **after** the YAML override — so anything set in a plugin's production.py survives.

By duplicating the schedule entry in production.py, it gets re-added after the YAML wipe and persists at runtime. The common.py entry is kept as-is so local dev environments continue to work.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
