### PR TITLE
fix: wrap-instructor-info css to correctly display staff buttons on Show Answer

### DIFF
--- a/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
@@ -113,3 +113,13 @@
 .video {
     margin: 0 0;
 }
+
+@media (min-width: 768px) {
+  .wrap-instructor-info {
+    display: flex !important;
+    flex-wrap: wrap;
+    gap: 10px;
+    width: 100%;
+    flex-shrink: 0;
+  }
+}

--- a/src/ol_openedx_chat/pyproject.toml
+++ b/src/ol_openedx_chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat"
-version = "0.5.6"
+version = "0.5.7"
 description = "An Open edX plugin to add Open Learning AI chat aside to xBlocks"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11304

### Description (What does it do?)
When a learner clicks "Show Answer" on a problem, the revealed answer content expands within a flex parent container, causing .wrap-instructor-info (Staff Debug Info / Submission History buttons) to collapse to zero width. This adds width: 100%, flex-shrink: 0, and flex-wrap: wrap to ensure the buttons maintain their layout regardless of sibling content expansion.

### Screenshots (if appropriate):
Before
<img width="829" height="795" alt="Screenshot 2026-05-18 at 5 33 28 PM" src="https://github.com/user-attachments/assets/e89052d5-f4f1-42b6-b715-db5e0342eab1" />

After
<img width="829" height="795" alt="Screenshot 2026-05-18 at 5 31 38 PM" src="https://github.com/user-attachments/assets/42d4abc4-5388-40ef-983b-24ee0b75752b" />

### How can this be tested?
- Enabling the AskTim button is not required for testing. The issue can be reproduced without it.
- Install ol-openedx-chat from this branch.
- Enable the theme, and open a problem.
- Click the "Show answer" button.
- Verify that it doesn't break the styling of Staff Debug Info / Submission History buttons.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
