### PR TITLE
chore: remove Sumac and add Ulmo for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
         - 3.11
         edx_branch:
         - master
-        - open-release/sumac.master
         - release/teak
+        - release/ulmo
+
           # Add more branches as needed
 
     steps:
@@ -38,13 +39,13 @@ jobs:
 
     - name: Install tutor
       run: |
-        if [[ "${{ matrix.edx_branch }}" == "open-release/sumac.master" ]]; then
-          pip install "tutor>=19.0.0,<20.0.0"
+        if [[ "${{ matrix.edx_branch }}" == "open-release/teak.master" ]]; then
+          pip install "tutor>=20.0.0,<21.0.0"
         elif [[ "${{ matrix.edx_branch }}" == "master" ]]; then
           git clone --branch=main https://github.com/overhangio/tutor.git
           pip install -e "./tutor"
         else
-          pip install "tutor>=20.0.0,<21.0.0"
+          pip install "tutor>=21.0.0,<22.0.0"
         fi
     - name: clone edx-platform and add mounts
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install tutor
       run: |
-        if [[ "${{ matrix.edx_branch }}" == "open-release/teak.master" ]]; then
+        if [[ "${{ matrix.edx_branch }}" == "release/teak" ]]; then
           pip install "tutor>=20.0.0,<21.0.0"
         elif [[ "${{ matrix.edx_branch }}" == "master" ]]; then
           git clone --branch=main https://github.com/overhangio/tutor.git


### PR DESCRIPTION
### What are the relevant tickets?
None
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This pull request updates the CI workflow to support the new `release/ulmo` branch and ensures compatibility with newer versions of Tutor for different Open edX branches. The main changes are:

Branch support updates:
* Added `release/ulmo` to the test matrix and removed `open-release/sumac.master`, keeping the workflow up to date with supported Open edX branches.

Tutor version management:
* Updated Tutor installation logic to use `tutor>=20.0.0,<21.0.0` for `open-release/teak.master` and `tutor>=21.0.0,<22.0.0` for all other branches except `master`, which uses the latest code from the `main` branch.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
