### PR TITLE
Fix: Video block chat button container box-shadow overflow

### DIFF
--- a/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
@@ -14,13 +14,13 @@
     display: flex;
     width: 100%;
     justify-content: flex-end;
+    position: relative;
+    z-index: 1;
+    padding: 12px 0;
     box-shadow:
-            0 -50px 0 12px whitesmoke,
-            -12px 12px 0 0 whitesmoke,
-            12px 12px 0 0 whitesmoke,
-            0 2px 0 0 whitesmoke;
+        0 -40px 0 0 whitesmoke,
+        0 10px 0 0 whitesmoke;
 }
-
 .ai-chat-button {
     all: unset;
     display: flex;

--- a/src/ol_openedx_chat/pyproject.toml
+++ b/src/ol_openedx_chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat"
-version = "0.5.7"
+version = "0.5.8"
 description = "An Open edX plugin to add Open Learning AI chat aside to xBlocks"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10589

### Description (What does it do?)

The `.video-block-chat-button-container` in the [ol_openedx_chat](https://github.com/mitodl/open-edx-plugins/blob/main/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css) plugin renders a grey box-shadow bleeding out from both sides of the video block.

This was caused by horizontal box-shadow offsets (-12px and 12px) in the original CSS. These horizontal shadows previously aligned with the parent container's padding, but recent upstream changes broke that assumption.

openedx/frontend-app-learning ([0664dc38](https://github.com/openedx/frontend-app-learning/commit/0664dc38d9e05eb6731be7899e0aa8e6f58afaeb)) — The sidebar refactor ("decouple notifications panel using widget registry mechanism") restructured the layout around the unit container, further changing available width and overflow behaviour.


- Removes horizontal box-shadow offsets entirely — the root cause of the overflow. Vertical-only shadows cannot bleed outside the container width regardless of parent layout changes.

- position: relative + z-index: 1 — establishes a stacking context so the shadow renders predictably above adjacent elements (e.g., video player controls) without depending on DOM order.

- padding: 12px 0 — provides internal spacing for the button without relying on fragile position: relative; bottom: 70px offsets on the child element.


### Screenshots (if appropriate):

Previous:
<img width="1084" height="723" alt="Screenshot 2026-05-20 at 12 29 35 PM" src="https://github.com/user-attachments/assets/042f6bbe-cba5-4153-8c1b-5371b1912745" />


After:
<img width="1427" height="923" alt="Screenshot 2026-05-20 at 5 54 02 PM" src="https://github.com/user-attachments/assets/64ad3841-a009-46bc-8a75-422fc93229fc" />


### How can this be tested?
To test this feature locally:

1. **Set up Tutor instance locally** as described in [this guide](https://docs.google.com/document/d/1kt_8VspC_SSU5zpmw8kyRQPWQaPtEbzTcDJeKYNBOfE/edit?tab=t.0)

2. **Mount frontend-app-learning locally**

3. **Enable AI Chatbot** by following the configuration steps in the [ol_openedx_chat plugin documentation](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat)
4. Install ol-openedx-chat from this branch.
5. Box shadow will not overflow.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
