### PR TITLE
feat(ol-openedx-logging): replace python-json-logger with structlog

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,32 @@
+{
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.11",
+  "include": ["src"],
+  "extraPaths": [
+    "src/edx_sysadmin",
+    "src/edx_username_changer",
+    "src/ol_openedx_ai_static_translations",
+    "src/ol_openedx_auto_select_language",
+    "src/ol_openedx_canvas_integration",
+    "src/ol_openedx_chat",
+    "src/ol_openedx_chat_xblock",
+    "src/ol_openedx_checkout_external",
+    "src/ol_openedx_course_export",
+    "src/ol_openedx_course_outline_api",
+    "src/ol_openedx_course_structure_api",
+    "src/ol_openedx_course_sync",
+    "src/ol_openedx_course_translations",
+    "src/ol_openedx_events_handler",
+    "src/ol_openedx_git_auto_export",
+    "src/ol_openedx_logging",
+    "src/ol_openedx_lti_utilities",
+    "src/ol_openedx_otel_monitoring",
+    "src/ol_openedx_rapid_response_reports",
+    "src/ol_openedx_sentry",
+    "src/ol_openedx_uai_content_customization",
+    "src/ol_social_auth",
+    "src/openedx_companion_auth",
+    "src/rapid_response_xblock"
+  ]
+}

--- a/run_edx_integration_tests.sh
+++ b/run_edx_integration_tests.sh
@@ -8,51 +8,51 @@ SKIP_BUILD=false
 
 # Parse named arguments
 while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    --plugin)
-      PLUGIN_NAME="$2"
-      shift # past argument
-      shift # past value
-      ;;
-    --mount-dir)
-      MOUNT_DIR="$2"
-      shift
-      shift
-      ;;
-    --skip-build)
-      SKIP_BUILD=true
-      shift
-      # Check if the next argument looks like a value (not a flag)
-      if [[ "$1" != "" && "$1" != --* ]]; then
-        echo "Error: --skip-build does not take a value (did you mean just --skip-build?)"
-        exit 1
-      fi
-      ;;
-    *)    # unknown option
-      echo "Unknown option $1"
-      exit 1
-      ;;
-  esac
+	key="$1"
+	case $key in
+	--plugin)
+		PLUGIN_NAME="$2"
+		shift # past argument
+		shift # past value
+		;;
+	--mount-dir)
+		MOUNT_DIR="$2"
+		shift
+		shift
+		;;
+	--skip-build)
+		SKIP_BUILD=true
+		shift
+		# Check if the next argument looks like a value (not a flag)
+		if [[ "$1" != "" && "$1" != --* ]]; then
+			echo "Error: --skip-build does not take a value (did you mean just --skip-build?)"
+			exit 1
+		fi
+		;;
+	*) # unknown option
+		echo "Unknown option $1"
+		exit 1
+		;;
+	esac
 done
 
 echo "Running edx integration tests with the following parameters:"
 
 if [ -n "$PLUGIN_NAME" ]; then
-  echo "PLUGIN_NAME: $PLUGIN_NAME"
+	echo "PLUGIN_NAME: $PLUGIN_NAME"
 else
-  echo "PLUGIN_NAME: (Running tests for ALL plugins)"
+	echo "PLUGIN_NAME: (Running tests for ALL plugins)"
 fi
 
 # Remove trailing slash if present (but not if it's just "/")
 if [ -n "$MOUNT_DIR" ] && [ "$MOUNT_DIR" != "/" ]; then
-  MOUNT_DIR="${MOUNT_DIR%/}"
+	MOUNT_DIR="${MOUNT_DIR%/}"
 fi
 
 if [ -n "$MOUNT_DIR" ]; then
-  echo "MOUNT_DIR: $MOUNT_DIR"
+	echo "MOUNT_DIR: $MOUNT_DIR"
 else
-  echo "MOUNT_DIR: (Using current working directory: $(pwd))"
+	echo "MOUNT_DIR: (Using current working directory: $(pwd))"
 fi
 echo "=========================================="
 
@@ -63,10 +63,10 @@ pwd
 mkdir -p reports
 
 if [ $CI ]; then
-  pip install -r ./requirements/edx/testing.txt
+	pip install -r ./requirements/edx/testing.txt
 
-  # Installing edx-platform
-  pip install -e .
+	# Installing edx-platform
+	pip install -e .
 fi
 
 echo "Copying static files in edx-platform test_root if it doesn't exist"
@@ -74,25 +74,28 @@ echo "Copying static files in edx-platform test_root if it doesn't exist"
 cp -r /openedx/staticfiles /openedx/edx-platform/test_root/staticfiles
 
 if [ -n "$MOUNT_DIR" ]; then
-  echo "Switching to mount directory: $MOUNT_DIR"
-  cd "$MOUNT_DIR" || { echo "Failed to cd into $MOUNT_DIR"; exit 1; }
+	echo "Switching to mount directory: $MOUNT_DIR"
+	cd "$MOUNT_DIR" || {
+		echo "Failed to cd into $MOUNT_DIR"
+		exit 1
+	}
 fi
 
 if [ "$SKIP_BUILD" != true ]; then
-    # Installing test dependencies using UV (this includes pytest-mock, responses, codecov, etc.)
-    echo "===== Installing uv ====="
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    source $HOME/.local/bin/env
-    echo "===== Installing Packages ====="
-    uv export --only-dev --no-hashes --no-annotate > ol_test_requirements.txt
-    pip install -r ol_test_requirements.txt
+	# Installing test dependencies using UV (this includes pytest-mock, responses, codecov, etc.)
+	echo "===== Installing uv ====="
+	curl -LsSf https://astral.sh/uv/install.sh | sh
+	source $HOME/.local/bin/env
+	echo "===== Installing Packages ====="
+	uv export --only-dev --no-hashes --no-annotate >ol_test_requirements.txt
+	pip install -r ol_test_requirements.txt
 
-    # output the packages which are installed for logging
-    echo "===== Installed Python Packages ====="
-    pip freeze | sort
-    echo "====================================="
+	# output the packages which are installed for logging
+	echo "===== Installed Python Packages ====="
+	pip freeze | sort
+	echo "====================================="
 else
-  echo "Skipping build and package installation as --skip-build is enabled."
+	echo "Skipping build and package installation as --skip-build is enabled."
 fi
 
 # Plugins that may affect the tests of other plugins.
@@ -104,106 +107,112 @@ export EDXAPP_TEST_MONGO_HOST=mongodb
 # Function to run tests for a plugin
 run_plugin_tests() {
 
-    local plugin_dir="$1"
-    local tests_directory="$plugin_dir/tests"
+	local plugin_dir="$1"
+	local tests_directory="$plugin_dir/tests"
 
-    # Check if tests directory exists
-    if [ ! -d "$tests_directory" ]; then
-        return 0
-    fi
+	# Check if tests directory exists
+	if [ ! -d "$tests_directory" ]; then
+		return 0
+	fi
 
-    # Installing the plugin
-    plugin_name=$(basename "$plugin_dir" | sed 's/src\///' | sed 's/_/-/g')
+	# Installing the plugin
+	plugin_name=$(basename "$plugin_dir" | sed 's/src\///' | sed 's/_/-/g')
 
-    # Check if we have a built wheel/tarball for the plugin
-    # Try both underscore and hyphen versions of the name
-    plugin_name_underscore=$(basename "$plugin_dir" | sed 's/src\///')
+	# Check if we have a built wheel/tarball for the plugin
+	# Try both underscore and hyphen versions of the name
+	plugin_name_underscore=$(basename "$plugin_dir" | sed 's/src\///')
 
-    tarball=""
-    # Look for wheel first, then tarball
-    for ext in "whl" "tar.gz"; do
-        for name_variant in "$plugin_name" "$plugin_name_underscore"; do
-            found_file=$(ls dist 2>/dev/null | grep -E "^${name_variant}-.*\.${ext}$" | head -n 1)
-            if [ -n "$found_file" ]; then
-                tarball="$found_file"
-                break 2
-            fi
-        done
-    done
+	tarball=""
+	# Look for wheel first, then tarball
+	for ext in "whl" "tar.gz"; do
+		for name_variant in "$plugin_name" "$plugin_name_underscore"; do
+			found_file=$(ls dist 2>/dev/null | grep -E "^${name_variant}-.*\.${ext}$" | head -n 1)
+			if [ -n "$found_file" ]; then
+				tarball="$found_file"
+				break 2
+			fi
+		done
+	done
 
-    if [ -n "$tarball" ]; then
-        echo "Installing $plugin_name from dist/$tarball"
-        pip install "dist/$tarball"
-    else
-        echo "No built package found for $plugin_name, installing in development mode"
-        pip install -e "$plugin_dir"
-    fi
+	if [ -n "$tarball" ]; then
+		echo "Installing $plugin_name from dist/$tarball"
+		pip install "dist/$tarball"
+	else
+		echo "No built package found for $plugin_name, installing in development mode"
+		pip install -e "$plugin_dir"
+	fi
 
-    # Copying test_root only if it doesn't exist
+	# Copying test_root only if it doesn't exist
 
-    if [ -n "$MOUNT_DIR" ]; then
-        DEST="$MOUNT_DIR/$plugin_dir/test_root"
-    else
-        DEST="$plugin_dir/test_root"
-    fi
+	if [ -n "$MOUNT_DIR" ]; then
+		DEST="$MOUNT_DIR/$plugin_dir/test_root"
+	else
+		DEST="$plugin_dir/test_root"
+	fi
 
-    if [ ! -d "$DEST" ]; then
-        echo "Copying test_root to $DEST"
-        cp -r /openedx/edx-platform/test_root/ "$DEST"
-    else
-        echo "test_root already exists at $DEST, skipping copy."
-    fi
-    echo "==============Running $plugin_dir tests=================="
-    cd "$plugin_dir"
+	if [ ! -d "$DEST" ]; then
+		echo "Copying test_root to $DEST"
+		cp -r /openedx/edx-platform/test_root/ "$DEST"
+	else
+		echo "test_root already exists at $DEST, skipping copy."
+	fi
+	echo "==============Running $plugin_dir tests=================="
+	cd "$plugin_dir"
 
-    # Run this plugin with CMS settings only.
-    if [[ "$plugin_dir" == *"ol_openedx_uai_content_customization"* ]]; then
-        echo "Using CMS settings only for $plugin_dir (skipping LMS run)."
-        pytest_command="pytest . --cov . --ds=cms.envs.test"
-    # Check for the existence of settings/test.py
-    elif [ -f "settings/test.py" ]; then
-        pytest_command="pytest . --cov . --ds=settings.test"
-    else
-        pytest_command="pytest . --cov . --ds=lms.envs.test"
-    fi
+	# Run this plugin with CMS settings only.
+	if [[ "$plugin_dir" == *"ol_openedx_uai_content_customization"* ]]; then
+		echo "Using CMS settings only for $plugin_dir (skipping LMS run)."
+		pytest_command="pytest . --cov . --ds=cms.envs.test"
+	# Check for the existence of settings/test.py
+	elif [ -f "settings/test.py" ]; then
+		pytest_command="pytest . --cov . --ds=settings.test"
+	else
+		# Check for a standalone settings module inside the package directory.
+		# A standalone settings file is identified by the presence of INSTALLED_APPS
+		# (as opposed to plugin_settings()-style files that delegate to the LMS).
+		pkg_name=$(basename "$plugin_dir")
+		if [ -f "${pkg_name}/settings/test.py" ] && grep -q "INSTALLED_APPS" "${pkg_name}/settings/test.py"; then
+			pytest_command="pytest . --cov . --ds=${pkg_name}.settings.test"
+		else
+			pytest_command="pytest . --cov . --ds=lms.envs.test"
+		fi
+	fi
 
-    # Run the pytest command
-    local PYTEST_SUCCESS=0
-    if $pytest_command --collect-only; then
-        $pytest_command
-        PYTEST_SUCCESS=$?
-    else
-        echo "No tests found, skipping pytest."
-    fi
+	# Run the pytest command
+	local PYTEST_SUCCESS=0
+	if $pytest_command --collect-only; then
+		$pytest_command
+		PYTEST_SUCCESS=$?
+	else
+		echo "No tests found, skipping pytest."
+	fi
 
-    if [[ $PYTEST_SUCCESS -ne 0 ]]
-    then
-        echo "pytest exited with a non-zero status"
-        exit $PYTEST_SUCCESS
-    fi
+	if [[ $PYTEST_SUCCESS -ne 0 ]]; then
+		echo "pytest exited with a non-zero status"
+		exit $PYTEST_SUCCESS
+	fi
 
-    # Run the pytest command with CMS settings (for ol_openedx_chat)
-    if [[ "$plugin_dir" == *"ol_openedx_chat"* || "$plugin_dir" == *"ol_openedx_course_sync"* ]]; then
-        pytest . --cov . --ds=cms.envs.test
+	# Run the pytest command with CMS settings (for ol_openedx_chat)
+	if [[ "$plugin_dir" == *"ol_openedx_chat"* || "$plugin_dir" == *"ol_openedx_course_sync"* ]]; then
+		pytest . --cov . --ds=cms.envs.test
 
-        PYTEST_SUCCESS=$?
-        if [[ $PYTEST_SUCCESS -ne 0 ]]
-        then
-            echo "pytest exited with a non-zero status"
-            exit $PYTEST_SUCCESS
-        fi
-    fi
+		PYTEST_SUCCESS=$?
+		if [[ $PYTEST_SUCCESS -ne 0 ]]; then
+			echo "pytest exited with a non-zero status"
+			exit $PYTEST_SUCCESS
+		fi
+	fi
 
-    coverage xml
+	coverage xml
 
-    # Check if the plugin name is in the isolated_plugins list and uninstall it
-    for plugin in "${isolated_plugins[@]}"; do
-        if [[ "$plugin_name" == "$plugin" ]]; then
-            pip uninstall -y "$plugin_name"
-            break
-        fi
-    done
-    cd ../..
+	# Check if the plugin name is in the isolated_plugins list and uninstall it
+	for plugin in "${isolated_plugins[@]}"; do
+		if [[ "$plugin_name" == "$plugin" ]]; then
+			pip uninstall -y "$plugin_name"
+			break
+		fi
+	done
+	cd ../..
 }
 
 # Check if a specific plugin name was provided
@@ -211,22 +220,22 @@ plugin="$PLUGIN_NAME"
 
 set +e
 if [ -n "$plugin" ]; then
-    # Run tests only for the specified plugin
-    plugin_dir="src/$plugin"
-    if [ -d "$plugin_dir" ]; then
-        echo "Running tests for specified plugin: $plugin"
-        run_plugin_tests "$plugin_dir"
-    else
-        echo "Error: Plugin directory '$plugin_dir' not found."
-        exit 1
-    fi
+	# Run tests only for the specified plugin
+	plugin_dir="src/$plugin"
+	if [ -d "$plugin_dir" ]; then
+		echo "Running tests for specified plugin: $plugin"
+		run_plugin_tests "$plugin_dir"
+	else
+		echo "Error: Plugin directory '$plugin_dir' not found."
+		exit 1
+	fi
 else
-    # Run tests for all plugins
-    echo "Running tests for all plugins"
-    for subdir in "src"/*; do
-        if [ -d "$subdir" ]; then
-            run_plugin_tests "$subdir"
-        fi
-    done
+	# Run tests for all plugins
+	echo "Running tests for all plugins"
+	for subdir in "src"/*; do
+		if [ -d "$subdir" ]; then
+			run_plugin_tests "$subdir"
+		fi
+	done
 fi
 set -e

--- a/src/ol_openedx_logging/ol_openedx_logging/app.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/app.py
@@ -1,21 +1,68 @@
+"""AppConfig for ol_openedx_logging.
+
+Registers this plugin with the LMS and CMS and wires up structlog
+configuration both for Django web processes (via ``ready()``) and for
+Celery worker processes (via the ``setup_logging`` signal receiver).
+"""
+
 from django.apps import AppConfig
 
 
 class EdxLoggingLMS(AppConfig):
+    """Open edX LMS plugin that replaces the default logging stack with structlog."""
+
     name = "ol_openedx_logging"
-    verbose_name = "Log customization support for Open edX platform"
+    verbose_name = "Structured logging for Open edX (LMS)"
     plugin_app = {
         "settings_config": {
-            "lms.djangoapp": {"production": {"relative_path": "settings.production"}}
+            "lms.djangoapp": {
+                "production": {"relative_path": "settings.production"},
+            }
         }
     }
+
+    def ready(self) -> None:
+        """Configure structlog and wire up Celery worker logging."""
+        from ol_openedx_logging.logging import configure_structlog  # noqa: PLC0415
+
+        configure_structlog()
+        _connect_celery_signal()
 
 
 class EdxLoggingCMS(AppConfig):
+    """Open edX CMS plugin that replaces the default logging stack with structlog."""
+
     name = "ol_openedx_logging"
-    verbose_name = "Log customization support for Open edX platform"
+    verbose_name = "Structured logging for Open edX (CMS)"
     plugin_app = {
         "settings_config": {
-            "cms.djangoapp": {"production": {"relative_path": "settings.production"}}
+            "cms.djangoapp": {
+                "production": {"relative_path": "settings.production"},
+            }
         }
     }
+
+    def ready(self) -> None:
+        """Configure structlog and wire up Celery worker logging."""
+        from ol_openedx_logging.logging import configure_structlog  # noqa: PLC0415
+
+        configure_structlog()
+        _connect_celery_signal()
+
+
+def _connect_celery_signal() -> None:
+    """Connect the ``setup_logging`` Celery signal if Celery is installed.
+
+    Celery is an optional dependency — the web process runs fine without it.
+    The signal receiver calls ``configure_structlog(force=True)`` so that
+    structlog is re-applied after Celery resets the logging configuration
+    in worker processes.
+    """
+    try:
+        from celery.signals import setup_logging  # noqa: PLC0415
+
+        from ol_openedx_logging.celery import setup_celery_logging  # noqa: PLC0415
+    except ImportError:
+        return
+
+    setup_logging.connect(setup_celery_logging)

--- a/src/ol_openedx_logging/ol_openedx_logging/celery.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/celery.py
@@ -1,0 +1,45 @@
+"""Celery integration helpers for ol_openedx_logging.
+
+This module provides a ``setup_celery_logging`` function that re-applies the
+structlog configuration inside Celery worker processes.
+
+Celery fires a ``setup_logging`` signal during worker boot, giving
+applications the opportunity to override its default logging setup.  Without
+a receiver Celery installs its own basic logging config; with one it defers
+to the application entirely.
+
+The plugin wires this up automatically in ``AppConfig.ready()`` by connecting
+to the signal — no changes are required to the edx-platform ``celery.py``.
+
+Usage (manual, if auto-wiring is not desired)
+---------------------------------------------
+In the edx-platform ``openedx/core/lib/celery/__init__.py`` or a site
+celery module::
+
+    from celery.signals import setup_logging
+    from ol_openedx_logging.celery import setup_celery_logging
+
+    @setup_logging.connect
+    def on_setup_logging(**kwargs):
+        setup_celery_logging(**kwargs)
+"""
+
+from __future__ import annotations
+
+
+def setup_celery_logging(**_kwargs) -> None:
+    """Configure structlog inside a Celery worker process.
+
+    Celery can reset the logging configuration between Django setup and the
+    ``setup_logging`` signal, so we force structlog to re-apply its config
+    here via ``force=True``.
+
+    ``_kwargs`` accepts (and ignores) the keyword arguments Celery passes to
+    ``setup_logging`` receivers: ``loglevel``, ``logfile``, ``format``, and
+    ``colorize``.  Log level and debug mode are intentionally read from the
+    ``LOG_LEVEL`` / ``EDXAPP_LOG_LEVEL`` env vars and ``settings.DEBUG``,
+    matching the web-process behaviour.
+    """
+    from ol_openedx_logging.logging import configure_structlog  # noqa: PLC0415
+
+    configure_structlog(force=True)

--- a/src/ol_openedx_logging/ol_openedx_logging/logging.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/logging.py
@@ -180,7 +180,19 @@ def configure_structlog(*, debug: bool | None = None, force: bool = False) -> No
 
     tracking_logger = existing_logging.get("loggers", {}).get("tracking")
     if tracking_logger:
+        tracking_logger = dict(tracking_logger)
+        if tracking_handler:
+            handlers = list(tracking_logger.get("handlers", []))
+            if "tracking" not in handlers:
+                handlers.append("tracking")
+            tracking_logger["handlers"] = handlers
         extra_loggers["tracking"] = tracking_logger
+    elif tracking_handler:
+        extra_loggers["tracking"] = {
+            "handlers": ["tracking"],
+            "level": log_level,
+            "propagate": False,
+        }
 
     logging.config.dictConfig(
         {

--- a/src/ol_openedx_logging/ol_openedx_logging/logging.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/logging.py
@@ -1,0 +1,260 @@
+"""Structlog configuration for the Open edX platform.
+
+This module configures structlog and routes stdlib logging through it.
+It is intended to be called from the plugin's ``AppConfig.ready()`` hook,
+which runs after Django has applied the base ``LOGGING`` setting.
+
+The implementation mirrors ``mitol.observability.logging`` but is
+self-contained so that this plugin has no runtime dependency on
+``mitol-django-observability``.  Context-injection processors live in
+:mod:`ol_openedx_logging.processors`.
+
+Environment variables
+---------------------
+``LOG_LEVEL``
+    Root log level (default: ``INFO``).  Takes precedence over
+    ``EDXAPP_LOG_LEVEL``.
+``EDXAPP_LOG_LEVEL``
+    edX-style log level env token; used as fallback when ``LOG_LEVEL`` is
+    not set.
+``DJANGO_LOG_LEVEL``
+    Level for ``django.*`` loggers (default: ``INFO``).
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.config
+import os
+from typing import Any
+
+import structlog
+from structlog.tracebacks import ExceptionDictTransformer
+
+from ol_openedx_logging.processors import inject_k8s_context, inject_otel_context
+
+# Idempotency guard — prevents double-configuration under Django autoreload.
+_configured = False
+
+# Structured exception renderer for production JSON logs.
+# ``show_locals=False`` prevents local variable values from leaking into log
+# output (security + size). ``max_frames=20`` keeps payloads reasonable.
+# The dict format is preferred over a flat string because Loki/Grafana can
+# index individual fields (exc_type, exc_value, frames[].filename, etc.).
+_EXCEPTION_RENDERER = structlog.processors.ExceptionRenderer(
+    ExceptionDictTransformer(
+        show_locals=False,
+        max_frames=20,
+    )
+)
+
+
+def _get_log_level() -> str:
+    """Return root log level from env, preferring LOG_LEVEL over EDXAPP_LOG_LEVEL."""
+    return (
+        os.environ.get("LOG_LEVEL") or os.environ.get("EDXAPP_LOG_LEVEL") or "INFO"
+    ).upper()
+
+
+def _get_django_log_level() -> str:
+    """Return the level to apply to ``django.*`` loggers."""
+    return os.environ.get("DJANGO_LOG_LEVEL", "INFO").upper()
+
+
+def _shared_processors() -> list[Any]:
+    """Return processors used in both dev and prod chains."""
+    return [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        inject_otel_context,
+        inject_k8s_context,
+        structlog.processors.StackInfoRenderer(),
+    ]
+
+
+def configure_structlog(*, debug: bool | None = None, force: bool = False) -> None:
+    """Configure structlog and route stdlib logging through it.
+
+    This function is idempotent — safe to call multiple times (e.g., under
+    Django autoreload or in test setups).  In Celery worker processes pass
+    ``force=True`` to ensure structlog is reconfigured after Celery resets
+    logging.
+
+    The function reads the existing ``settings.LOGGING`` to extract any edX
+    platform-specific handlers and loggers (most importantly the ``tracking``
+    handler used for event tracking) so they are preserved in the new config.
+
+    Args:
+        debug: Override debug-mode detection.  If ``None``, reads from
+            ``django.conf.settings.DEBUG``.
+        force: Re-run configuration even if already configured.  Use in
+            Celery worker processes via a ``worker_process_init`` signal.
+    """
+    global _configured  # noqa: PLW0603
+    if _configured and not force:
+        return
+    _configured = True
+
+    from django.conf import settings  # noqa: PLC0415
+
+    if debug is None:
+        debug = getattr(settings, "DEBUG", False)
+
+    log_level = _get_log_level()
+    django_log_level = _get_django_log_level()
+
+    shared = _shared_processors()
+
+    if debug:
+        # ConsoleRenderer handles exc_info tuples natively (including rich /
+        # better-exceptions rendering when those libraries are installed).
+        # set_exc_info ensures exc_info=True is resolved to the actual tuple
+        # at call-site so that ConsoleRenderer can render it later.
+        exc_processor: Any = structlog.dev.set_exc_info
+        renderer: Any = structlog.dev.ConsoleRenderer(colors=True)
+        formatter_processors: list[Any] = [
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ]
+    else:
+        # _EXCEPTION_RENDERER converts exc_info (tuple, Exception, or True)
+        # into a structured ``exception`` dict before JSONRenderer serialises
+        # the event.  It must appear in BOTH the structlog pipeline (for
+        # structlog-native records) AND in ProcessorFormatter.processors
+        # (for foreign stdlib records, e.g. Django / third-party loggers,
+        # where exc_info is injected by ProcessorFormatter from LogRecord).
+        exc_processor = _EXCEPTION_RENDERER
+        renderer = structlog.processors.JSONRenderer()
+        formatter_processors = [
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            _EXCEPTION_RENDERER,
+            renderer,
+        ]
+
+    # structlog pipeline: ends with wrap_for_formatter so that stdlib records
+    # routed through ProcessorFormatter share the same pre-chain processing.
+    structlog.configure(
+        processors=[
+            *shared,
+            exc_processor,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    # ProcessorFormatter handles both structlog records (wrapped above) and
+    # foreign stdlib records (via foreign_pre_chain).  The final processor
+    # must be a renderer that returns a string.
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processors=formatter_processors,
+        foreign_pre_chain=shared,
+    )
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    # Preserve edX-specific handlers, formatters, and loggers from the existing
+    # LOGGING configuration.  The ``tracking`` handler/logger is critical —
+    # it routes event-tracking data to a separate syslog facility and must not
+    # be lost.  We also carry over any formatters the preserved handlers
+    # reference (e.g. edX's ``raw`` formatter used by ``tracking``).
+    existing_logging = getattr(settings, "LOGGING", {})
+    extra_handlers: dict[str, Any] = {}
+    extra_formatters: dict[str, Any] = {}
+    extra_loggers: dict[str, Any] = {}
+
+    existing_formatters = existing_logging.get("formatters", {})
+
+    tracking_handler = existing_logging.get("handlers", {}).get("tracking")
+    if tracking_handler:
+        extra_handlers["tracking"] = tracking_handler
+        # Carry over the formatter referenced by this handler, if any.
+        fmt_name = tracking_handler.get("formatter")
+        if fmt_name and fmt_name in existing_formatters:
+            extra_formatters[fmt_name] = existing_formatters[fmt_name]
+
+    tracking_logger = existing_logging.get("loggers", {}).get("tracking")
+    if tracking_logger:
+        extra_loggers["tracking"] = tracking_logger
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                **extra_formatters,
+            },
+            "handlers": {
+                "console": {
+                    "()": lambda: handler,
+                },
+                **extra_handlers,
+            },
+            "loggers": {
+                "django": {
+                    "handlers": ["console"],
+                    "level": django_log_level,
+                    "propagate": False,
+                },
+                "django.request": {
+                    "handlers": ["console"],
+                    "level": django_log_level,
+                    "propagate": False,
+                },
+                "boto3": {
+                    "handlers": ["console"],
+                    "level": "ERROR",
+                    "propagate": False,
+                },
+                "botocore": {
+                    "handlers": ["console"],
+                    "level": "ERROR",
+                    "propagate": False,
+                },
+                "opensearch": {
+                    "handlers": ["console"],
+                    "level": "ERROR",
+                    "propagate": False,
+                },
+                # django-structlog context propagation middleware
+                "django_structlog": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
+                # Celery worker and task loggers
+                "celery": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
+                "celery.task": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
+                "celery.worker": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
+                **extra_loggers,
+            },
+            "root": {"handlers": ["console"], "level": log_level},
+        }
+    )
+
+
+def reset_configuration() -> None:
+    """Reset configuration state for testing purposes.
+
+    This allows tests to re-run ``configure_structlog()`` with different
+    settings.  Should only be used in test code.
+    """
+    global _configured  # noqa: PLW0603
+    _configured = False

--- a/src/ol_openedx_logging/ol_openedx_logging/processors.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/processors.py
@@ -1,0 +1,86 @@
+"""Custom structlog processors for context injection.
+
+These processors are used in the structlog pipeline to enrich log records
+with OpenTelemetry trace context and Kubernetes pod metadata.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Precompute K8s context dict at import time — values don't change during
+# process lifetime.  A single dict.update() is faster than multiple writes.
+_K8S_CONTEXT: dict[str, str] = {
+    k: v
+    for k, v in {
+        "pod_name": os.environ.get("KUBERNETES_POD_NAME"),
+        "namespace": os.environ.get("KUBERNETES_NAMESPACE"),
+        "node_name": os.environ.get("KUBERNETES_NODE_NAME"),
+    }.items()
+    if v
+}
+
+
+def inject_otel_context(
+    _logger: Any,
+    _method: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Inject OpenTelemetry trace context into the structlog event dict.
+
+    Skips injection when ``opentelemetry`` is not installed (soft dependency),
+    when trace/span IDs are already present, or when there is no active
+    recording span.
+
+    ``opentelemetry`` is imported lazily inside the function so that the plugin
+    can be installed in environments without the OTel SDK.  Python caches
+    modules after the first import, so the per-call overhead is negligible.
+
+    Performance notes:
+    - Fast-path on ``ImportError`` (otel not installed).
+    - Skips when trace_id/span_id already present (bound via contextvars).
+    - Checks ``is_valid`` before ``is_recording`` for the fastest invalid-
+      context short-circuit.
+    """
+    if "trace_id" in event_dict and "span_id" in event_dict:
+        return event_dict
+
+    try:
+        from opentelemetry import trace  # noqa: PLC0415
+        from opentelemetry.trace.span import (  # noqa: PLC0415
+            format_span_id,
+            format_trace_id,
+        )
+    except ImportError:
+        return event_dict
+
+    span = trace.get_current_span()
+    ctx = span.get_span_context()
+
+    if not ctx.is_valid:
+        return event_dict
+    if not span.is_recording():
+        return event_dict
+
+    event_dict["trace_id"] = format_trace_id(ctx.trace_id)
+    event_dict["span_id"] = format_span_id(ctx.span_id)
+    return event_dict
+
+
+def inject_k8s_context(
+    _logger: Any,
+    _method: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Inject Kubernetes pod metadata into the structlog event dict.
+
+    Values are read once at import time from well-known Downward API env vars
+    (``KUBERNETES_POD_NAME``, ``KUBERNETES_NAMESPACE``, ``KUBERNETES_NODE_NAME``)
+    and merged into every log record with a single ``dict.update()`` call.
+    When none of the env vars are set (e.g., local development) the function
+    is a cheap no-op.
+    """
+    if _K8S_CONTEXT:
+        event_dict.update(_K8S_CONTEXT)
+    return event_dict

--- a/src/ol_openedx_logging/ol_openedx_logging/settings/production.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/settings/production.py
@@ -1,48 +1,35 @@
+"""Production settings for ol_openedx_logging.
+
+This module is loaded by the Open edX plugin settings machinery before
+``django.setup()`` runs.  Its sole responsibility is to translate edX
+environment tokens into the canonical ``LOG_LEVEL`` environment variable so
+that ``configure_structlog()`` (called later in ``AppConfig.ready()``) picks
+up the correct log level without needing direct access to ``ENV_TOKENS``.
+
+The old JSON-file handler and ``RotatingFileHandler`` configuration has been
+removed.  Structured JSON logs are now written to stdout/stderr by structlog's
+``JSONRenderer`` and should be captured by the container / log-shipper layer.
+"""
+
 from __future__ import annotations
 
+import os
 from typing import Any
 
-MEGABYTE = 1024 * 1024
 
+def plugin_settings(edx_settings: Any) -> None:
+    """Translate edX log-level tokens into the canonical ``LOG_LEVEL`` env var.
 
-def _load_env_tokens(edx_settings, default_settings: dict[str, Any]) -> dict[str, Any]:
-    configured_tokens = getattr(edx_settings, "ENV_TOKENS", {})
-    default_settings.update(configured_tokens)
-    return default_settings
+    If the operator has set ``EDXAPP_LOG_LEVEL`` via ``ENV_TOKENS`` (or the
+    environment directly) and ``LOG_LEVEL`` is not already set, we forward the
+    value so that ``configure_structlog()`` honours it without any edX-specific
+    knowledge.
+    """
+    env_tokens: dict[str, Any] = getattr(edx_settings, "ENV_TOKENS", {})
 
+    edxapp_log_level: str = (
+        env_tokens.get("EDXAPP_LOG_LEVEL") or os.environ.get("EDXAPP_LOG_LEVEL") or ""
+    ).upper()
 
-def plugin_settings(edx_settings):
-    env_tokens = _load_env_tokens(
-        edx_settings,
-        {
-            "EDXAPP_LOG_LEVEL": "INFO",
-            "EDXAPP_LOG_FILE_PATH": "/var/log/edxapp/app.log",
-            "EDXAPP_LOG_FILE_MAX_MEGABYTES": 10,
-        },
-    )
-    edx_logging = getattr(edx_settings, "LOGGING", {})
-    edx_log_level = env_tokens["EDXAPP_LOG_LEVEL"]
-
-    edx_logging["formatters"]["json_format"] = {
-        "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
-        "timestamp": True,
-        "reserved_attrs": [],  # Add all log attributes to JSON object
-    }
-
-    edx_logging["handlers"]["file"] = {
-        "level": edx_log_level,
-        "class": "logging.handlers.RotatingFileHandler",
-        "filename": env_tokens["EDXAPP_LOG_FILE_PATH"],
-        "formatter": "json_format",
-        "backupCount": 3,
-        "mode": "a",
-        "maxBytes": MEGABYTE * env_tokens["EDXAPP_LOG_FILE_MAX_MEGABYTES"],
-    }
-
-    edx_logging["loggers"][""] = {
-        "handlers": ["console", "local", "file"],
-        "level": edx_log_level,
-        "propagate": False,
-    }
-
-    edx_settings.LOGGING = edx_logging
+    if edxapp_log_level and not os.environ.get("LOG_LEVEL"):
+        os.environ["LOG_LEVEL"] = edxapp_log_level

--- a/src/ol_openedx_logging/ol_openedx_logging/settings/test.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/settings/test.py
@@ -1,0 +1,48 @@
+"""Minimal standalone Django settings for ol_openedx_logging tests.
+
+These settings allow the test suite to run without a full edx-platform
+install.  The logging plugin is self-contained, so only a minimal Django
+app configuration is required.
+"""
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "ol_openedx_logging",
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+SECRET_KEY = "test-secret-key-not-for-production"  # noqa: S105  # pragma: allowlist secret
+DEBUG = False
+
+# Minimal edX-style LOGGING with a tracking handler so tests can verify
+# it is preserved by configure_structlog().
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "raw": {"format": "%(message)s"},
+    },
+    "handlers": {
+        "tracking": {
+            "level": "DEBUG",
+            "class": "logging.handlers.MemoryHandler",
+            "capacity": 100,
+            "formatter": "raw",
+        }
+    },
+    "loggers": {
+        "tracking": {
+            "handlers": ["tracking"],
+            "level": "DEBUG",
+            "propagate": False,
+        }
+    },
+}

--- a/src/ol_openedx_logging/pyproject.toml
+++ b/src/ol_openedx_logging/pyproject.toml
@@ -1,17 +1,12 @@
 [project]
 name = "ol-openedx-logging"
-version = "0.2.0"
+version = "0.3.0"
 description = "An Open edX plugin to customize the logging configuration used by the edx-platform application"
 readme = "README.rst"
-authors = [
-  {name = "MIT Office of Digital Learning"}
-]
+authors = [{ name = "MIT Office of Digital Learning" }]
 license = "BSD-3-Clause"
 requires-python = ">=3.11"
-dependencies = [
-  "Django>=4.0",
-  "python-json-logger>=3.0.0",
-]
+dependencies = ["Django>=4.0", "structlog>=24.0.0"]
 
 [project.entry-points."lms.djangoapp"]
 ol_openedx_logging = "ol_openedx_logging.app:EdxLoggingLMS"
@@ -25,13 +20,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["ol_openedx_logging"]
-include = [
-  "ol_openedx_logging/**/*.py",
-]
+include = ["ol_openedx_logging/**/*.py"]
 
 [tool.hatch.build.targets.sdist]
-include = [
-  "ol_openedx_logging/**/*",
-  "README.rst",
-  "pyproject.toml",
-]
+include = ["ol_openedx_logging/**/*", "README.rst", "pyproject.toml"]

--- a/src/ol_openedx_logging/pyproject.toml
+++ b/src/ol_openedx_logging/pyproject.toml
@@ -14,6 +14,9 @@ ol_openedx_logging = "ol_openedx_logging.app:EdxLoggingLMS"
 [project.entry-points."cms.djangoapp"]
 ol_openedx_logging = "ol_openedx_logging.app:EdxLoggingCMS"
 
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "ol_openedx_logging.settings.test"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/ol_openedx_logging/tests/test_logging.py
+++ b/src/ol_openedx_logging/tests/test_logging.py
@@ -65,7 +65,7 @@ class TestConfigureStructlogProduction:
         assert "MemoryHandler" in handler_classes
 
     def test_tracking_handler_attached_without_logger_handlers(self):
-        """Tracking handler is attached even if settings LOGGING omits logger handlers."""
+        """Tracking handler is attached if logger handlers are omitted."""
         from django.conf import settings  # noqa: PLC0415
 
         logging_config = copy.deepcopy(settings.LOGGING)

--- a/src/ol_openedx_logging/tests/test_logging.py
+++ b/src/ol_openedx_logging/tests/test_logging.py
@@ -7,17 +7,9 @@ import logging as stdlib_logging
 import os
 from unittest.mock import patch
 
-import django
 import pytest
 import structlog
-
-os.environ.setdefault(
-    "DJANGO_SETTINGS_MODULE",
-    "ol_openedx_logging.settings.test",
-)
-django.setup()
-
-from ol_openedx_logging.logging import (  # noqa: E402
+from ol_openedx_logging.logging import (
     configure_structlog,
     reset_configuration,
 )

--- a/src/ol_openedx_logging/tests/test_logging.py
+++ b/src/ol_openedx_logging/tests/test_logging.py
@@ -1,0 +1,166 @@
+"""Tests for ol_openedx_logging.logging (configure_structlog)."""
+
+from __future__ import annotations
+
+import logging as stdlib_logging
+import os
+from unittest.mock import patch
+
+import django
+import pytest
+import structlog
+
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    "ol_openedx_logging.settings.test",
+)
+django.setup()
+
+from ol_openedx_logging.logging import (  # noqa: E402
+    configure_structlog,
+    reset_configuration,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_structlog():
+    """Reset configure_structlog idempotency guard before each test."""
+    reset_configuration()
+    yield
+    reset_configuration()
+
+
+class TestConfigureStructlogProduction:
+    """configure_structlog in production (non-debug) mode."""
+
+    def test_structlog_is_configured_after_call(self):
+        """structlog.is_configured() returns True after configure_structlog()."""
+        configure_structlog(debug=False)
+        assert structlog.is_configured()
+
+    def test_root_logger_has_stream_handler(self):
+        """Root stdlib logger has a StreamHandler using ProcessorFormatter."""
+        configure_structlog(debug=False)
+        root = stdlib_logging.getLogger()
+        assert any(isinstance(h, stdlib_logging.StreamHandler) for h in root.handlers)
+
+    def test_root_handler_uses_processor_formatter(self):
+        """StreamHandler on root is using ProcessorFormatter."""
+        configure_structlog(debug=False)
+        root = stdlib_logging.getLogger()
+        stream_handlers = [
+            h for h in root.handlers if isinstance(h, stdlib_logging.StreamHandler)
+        ]
+        assert stream_handlers, "No StreamHandler found on root logger"
+        formatter = stream_handlers[0].formatter
+        assert isinstance(formatter, structlog.stdlib.ProcessorFormatter)
+
+    def test_tracking_handler_preserved(self):
+        """edX ``tracking`` logger and its MemoryHandler are preserved."""
+        configure_structlog(debug=False)
+        tracking = stdlib_logging.getLogger("tracking")
+        assert tracking.handlers, "tracking logger has no handlers"
+        handler_classes = {type(h).__name__ for h in tracking.handlers}
+        assert "MemoryHandler" in handler_classes
+
+    def test_celery_logger_configured(self):
+        """celery logger is configured with console handler."""
+        configure_structlog(debug=False)
+        celery_logger = stdlib_logging.getLogger("celery")
+        assert celery_logger.handlers, "celery logger has no handlers"
+
+    def test_celery_task_logger_configured(self):
+        """celery.task logger is configured with console handler."""
+        configure_structlog(debug=False)
+        logger = stdlib_logging.getLogger("celery.task")
+        assert logger.handlers, "celery.task logger has no handlers"
+
+    def test_celery_worker_logger_configured(self):
+        """celery.worker logger is configured with console handler."""
+        configure_structlog(debug=False)
+        logger = stdlib_logging.getLogger("celery.worker")
+        assert logger.handlers, "celery.worker logger has no handlers"
+
+    def test_django_logger_configured(self):
+        """django logger is configured with console handler."""
+        configure_structlog(debug=False)
+        django_logger = stdlib_logging.getLogger("django")
+        assert django_logger.handlers, "django logger has no handlers"
+
+
+class TestConfigureStructlogDebug:
+    """configure_structlog in debug mode."""
+
+    def test_structlog_is_configured_after_call(self):
+        """structlog.is_configured() returns True in debug mode."""
+        configure_structlog(debug=True)
+        assert structlog.is_configured()
+
+    def test_root_logger_has_stream_handler(self):
+        """Root logger has a StreamHandler in debug mode."""
+        configure_structlog(debug=True)
+        root = stdlib_logging.getLogger()
+        assert any(isinstance(h, stdlib_logging.StreamHandler) for h in root.handlers)
+
+
+class TestConfigureStructlogIdempotency:
+    """configure_structlog is idempotent."""
+
+    def test_second_call_is_no_op(self):
+        """Calling configure_structlog() twice is safe."""
+        configure_structlog(debug=False)
+        first_root_handlers = list(stdlib_logging.getLogger().handlers)
+        configure_structlog(debug=False)
+        second_root_handlers = list(stdlib_logging.getLogger().handlers)
+        assert first_root_handlers == second_root_handlers
+
+    def test_force_reconfigures(self):
+        """force=True forces re-configuration even after initial call."""
+        configure_structlog(debug=False)
+        configure_structlog(debug=False, force=True)
+        assert structlog.is_configured()
+
+
+class TestConfigureStructlogLogLevel:
+    """configure_structlog respects log level env vars."""
+
+    def test_log_level_env_var(self):
+        """LOG_LEVEL env var sets the root logger level."""
+        with patch.dict(os.environ, {"LOG_LEVEL": "WARNING"}, clear=False):
+            configure_structlog(debug=False)
+        root = stdlib_logging.getLogger()
+        assert root.level == stdlib_logging.WARNING
+
+    def test_edxapp_log_level_fallback(self):
+        """EDXAPP_LOG_LEVEL is used when LOG_LEVEL is absent."""
+        env = {k: v for k, v in os.environ.items() if k != "LOG_LEVEL"}
+        env["EDXAPP_LOG_LEVEL"] = "ERROR"
+        with patch.dict(os.environ, env, clear=True):
+            configure_structlog(debug=False)
+        root = stdlib_logging.getLogger()
+        assert root.level == stdlib_logging.ERROR
+
+
+class TestCelerySignalIntegration:
+    """setup_celery_logging reconfigures structlog for Celery workers."""
+
+    def test_setup_celery_logging_reconfigures_structlog(self):
+        """setup_celery_logging() calls configure_structlog(force=True)."""
+        configure_structlog(debug=False)
+        # Second call without force would be no-op; signal helper uses force=True.
+        from ol_openedx_logging.celery import setup_celery_logging  # noqa: PLC0415
+
+        setup_celery_logging(loglevel="INFO", logfile=None)
+        assert structlog.is_configured()
+
+    def test_setup_celery_logging_accepts_celery_kwargs(self):
+        """setup_celery_logging() accepts and silently ignores Celery's kwargs."""
+        from ol_openedx_logging.celery import setup_celery_logging  # noqa: PLC0415
+
+        # Should not raise even with unexpected keyword arguments.
+        setup_celery_logging(
+            loglevel="DEBUG",
+            logfile="/tmp/worker.log",  # noqa: S108
+            format="%(message)s",
+            colorize=False,
+        )

--- a/src/ol_openedx_logging/tests/test_logging.py
+++ b/src/ol_openedx_logging/tests/test_logging.py
@@ -64,8 +64,8 @@ class TestConfigureStructlogProduction:
         handler_classes = {type(h).__name__ for h in tracking.handlers}
         assert "MemoryHandler" in handler_classes
 
-    def test_tracking_handler_attached_when_logger_handlers_missing(self):
-        """tracking handler is attached even if settings LOGGING omits logger handlers."""
+    def test_tracking_handler_attached_without_logger_handlers(self):
+        """Tracking handler is attached even if settings LOGGING omits logger handlers."""
         from django.conf import settings  # noqa: PLC0415
 
         logging_config = copy.deepcopy(settings.LOGGING)

--- a/src/ol_openedx_logging/tests/test_logging.py
+++ b/src/ol_openedx_logging/tests/test_logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging as stdlib_logging
 import os
 from unittest.mock import patch
@@ -58,6 +59,21 @@ class TestConfigureStructlogProduction:
     def test_tracking_handler_preserved(self):
         """edX ``tracking`` logger and its MemoryHandler are preserved."""
         configure_structlog(debug=False)
+        tracking = stdlib_logging.getLogger("tracking")
+        assert tracking.handlers, "tracking logger has no handlers"
+        handler_classes = {type(h).__name__ for h in tracking.handlers}
+        assert "MemoryHandler" in handler_classes
+
+    def test_tracking_handler_attached_when_logger_handlers_missing(self):
+        """tracking handler is attached even if settings LOGGING omits logger handlers."""
+        from django.conf import settings  # noqa: PLC0415
+
+        logging_config = copy.deepcopy(settings.LOGGING)
+        logging_config["loggers"]["tracking"].pop("handlers", None)
+
+        with patch.object(settings, "LOGGING", logging_config):
+            configure_structlog(debug=False)
+
         tracking = stdlib_logging.getLogger("tracking")
         assert tracking.handlers, "tracking logger has no handlers"
         handler_classes = {type(h).__name__ for h in tracking.handlers}

--- a/src/ol_openedx_logging/tests/test_processors.py
+++ b/src/ol_openedx_logging/tests/test_processors.py
@@ -1,0 +1,139 @@
+"""Tests for ol_openedx_logging.processors."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ol_openedx_logging.processors import inject_k8s_context, inject_otel_context
+
+# ---------------------------------------------------------------------------
+# inject_k8s_context
+# ---------------------------------------------------------------------------
+
+
+class TestInjectK8sContext:
+    """Tests for inject_k8s_context."""
+
+    def _call(self, event_dict: dict[str, Any] | None = None) -> dict[str, Any]:
+        event_dict = event_dict or {}
+        return inject_k8s_context(None, "info", event_dict)
+
+    def test_no_k8s_env_vars(self, monkeypatch):
+        """No K8s env vars → event dict is unchanged."""
+        monkeypatch.delenv("KUBERNETES_POD_NAME", raising=False)
+        monkeypatch.delenv("KUBERNETES_NAMESPACE", raising=False)
+        monkeypatch.delenv("KUBERNETES_NODE_NAME", raising=False)
+
+        # Patch the module-level dict since it's precomputed at import time.
+        with patch("ol_openedx_logging.processors._K8S_CONTEXT", {}):
+            result = self._call({"event": "hello"})
+
+        assert result == {"event": "hello"}
+
+    def test_k8s_env_vars_injected(self):
+        """K8s context dict is merged into the event dict."""
+        k8s = {
+            "pod_name": "lms-abc123",
+            "namespace": "mitx-production",
+            "node_name": "node-1",
+        }
+        with patch("ol_openedx_logging.processors._K8S_CONTEXT", k8s):
+            result = self._call({"event": "hello"})
+
+        assert result["pod_name"] == "lms-abc123"
+        assert result["namespace"] == "mitx-production"
+        assert result["node_name"] == "node-1"
+        assert result["event"] == "hello"
+
+    def test_existing_keys_not_overwritten(self):
+        """Existing keys are overwritten (dict.update semantics)."""
+        k8s = {"pod_name": "new-pod"}
+        with patch("ol_openedx_logging.processors._K8S_CONTEXT", k8s):
+            result = self._call({"event": "x", "pod_name": "old-pod"})
+        assert result["pod_name"] == "new-pod"
+
+
+# ---------------------------------------------------------------------------
+# inject_otel_context
+# ---------------------------------------------------------------------------
+
+
+class TestInjectOtelContext:
+    """Tests for inject_otel_context."""
+
+    def _call(self, event_dict: dict[str, Any] | None = None) -> dict[str, Any]:
+        event_dict = event_dict or {}
+        return inject_otel_context(None, "info", event_dict)
+
+    def test_already_has_trace_and_span(self):
+        """Skips injection when trace_id and span_id already present."""
+        event = {"trace_id": "aaa", "span_id": "bbb", "event": "x"}
+        result = self._call(event)
+        assert result["trace_id"] == "aaa"
+        assert result["span_id"] == "bbb"
+
+    def test_otel_import_error_returns_unchanged(self):
+        """Returns event dict unchanged when opentelemetry is not installed."""
+        import builtins  # noqa: PLC0415
+
+        real_import = builtins.__import__
+        err_msg = "not installed"
+
+        def mock_import(name, *args, **kwargs):
+            if name.startswith("opentelemetry"):
+                raise ImportError(err_msg)
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            result = self._call({"event": "hello"})
+
+        assert result == {"event": "hello"}
+
+    def test_no_active_span_returns_unchanged(self):
+        """Returns event dict unchanged when there is no active OTel span."""
+        try:
+            from opentelemetry import trace  # noqa: PLC0415
+            from opentelemetry.trace import (  # noqa: PLC0415
+                NonRecordingSpan,
+                SpanContext,
+            )
+        except ImportError:
+            pytest.skip("opentelemetry not installed")
+
+        invalid_ctx = SpanContext(
+            trace_id=0,
+            span_id=0,
+            is_remote=False,
+        )
+        mock_span = NonRecordingSpan(invalid_ctx)
+        with patch.object(trace, "get_current_span", return_value=mock_span):
+            result = self._call({"event": "hello"})
+
+        assert "trace_id" not in result
+        assert "span_id" not in result
+
+    def test_active_span_injects_context(self):
+        """Injects trace_id and span_id when there is a valid recording span."""
+        try:
+            from opentelemetry import trace  # noqa: PLC0415
+        except ImportError:
+            pytest.skip("opentelemetry not installed")
+
+        mock_ctx = MagicMock()
+        mock_ctx.is_valid = True
+        mock_ctx.trace_id = 0xABCD1234ABCD1234ABCD1234ABCD1234
+        mock_ctx.span_id = 0x1234ABCD1234ABCD
+
+        mock_span = MagicMock()
+        mock_span.get_span_context.return_value = mock_ctx
+        mock_span.is_recording.return_value = True
+
+        with patch.object(trace, "get_current_span", return_value=mock_span):
+            result = self._call({"event": "hello"})
+
+        assert "trace_id" in result
+        assert "span_id" in result
+        assert isinstance(result["trace_id"], str)
+        assert isinstance(result["span_id"], str)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -2353,18 +2353,18 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-logging"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "src/ol_openedx_logging" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-json-logger" },
+    { name = "structlog" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=4.0" },
-    { name = "python-json-logger", specifier = ">=3.0.0" },
+    { name = "structlog", specifier = ">=24.0.0" },
 ]
 
 [[package]]
@@ -3960,6 +3960,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Replaces `python-json-logger` with `structlog` in the `ol-openedx-logging` plugin, bringing it in line with the approach used by `mitol-django-observability`.

**New modules:**
- `processors.py` — `inject_otel_context` (soft OpenTelemetry dependency via lazy import) and `inject_k8s_context` (reads Kubernetes Downward API env vars precomputed at import time)
- `logging.py` — `configure_structlog()` with dev (`ConsoleRenderer`) and production (`JSONRenderer` + structured `ExceptionDictTransformer`) modes; preserves edX's `tracking` handler/logger/formatter from the existing `LOGGING` dict; reads `LOG_LEVEL` with `EDXAPP_LOG_LEVEL` as fallback
- `celery.py` — `setup_celery_logging()` for force-reconfiguring structlog in Celery worker processes via Celery's `setup_logging` signal

**Updated:**
- `app.py` — `AppConfig.ready()` calls `configure_structlog()` and auto-connects the Celery `setup_logging` signal (no changes to edx-platform's `celery.py` required; Celery is a soft dependency)
- `settings/production.py` — simplified to only translate `EDXAPP_LOG_LEVEL` → `LOG_LEVEL` env var; old `RotatingFileHandler`/`json_format` setup removed
- `pyproject.toml` — `python-json-logger` → `structlog>=24.0.0`, version bumped `0.2.0` → `0.3.0`

**Added:**
- `settings/test.py` for standalone test execution (no edx-platform needed)
- 23 pytest tests covering processors, structlog config, log level env vars, tracking handler preservation, celery loggers, and idempotency
- `pyrightconfig.json` pointing Pyright at the workspace `.venv` for IDE type resolution

### How can this be tested?
Standalone (no Tutor required):
```bash
uv sync --dev
pip install -e src/ol_openedx_logging
cd src/ol_openedx_logging
DJANGO_SETTINGS_MODULE=ol_openedx_logging.settings.test pytest tests/ -v
```

Integration tests in Tutor container (same as other plugins):
```bash
./run_edx_integration_tests.sh --plugin ol_openedx_logging --skip-build
```

Key things to verify manually:
- JSON structured logs appear on stdout in a running LMS/CMS container
- The `tracking` logger still routes to its syslog handler (event tracking must not be disrupted)
- In a Celery worker, logs are also JSON-structured (not Celery's default plain-text format)

### Additional Context
The `tracking` logger preservation is the main edX-specific concern: `configure_structlog()` reads the existing `settings.LOGGING` in `AppConfig.ready()` to extract the `tracking` handler and any formatters it references, then re-includes them in the new `dictConfig`. This ensures event-tracking data continues to flow to its separate syslog facility.

OpenTelemetry (`opentelemetry-api`) remains a soft dependency — the plugin works without it, and the `inject_otel_context` processor is a no-op when the package is absent.