### PR TITLE
feat: update perms for course lang view

### DIFF
--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/settings/common.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/settings/common.py
@@ -12,3 +12,5 @@ def apply_common_settings(settings):
     """
     settings.ENABLE_AUTO_LANGUAGE_SELECTION = False
     settings.AUTO_LANGUAGE_SELECTION_EXEMPT_PATHS = ["admin", "sysadmin", "instructor"]
+    settings.COURSE_LANGUAGE_ANON_THROTTLE_RATE = "30/min"
+    settings.COURSE_LANGUAGE_USER_THROTTLE_RATE = "30/min"

--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/urls.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/urls.py
@@ -13,11 +13,4 @@ urlpatterns = [
         CourseLanguageView.as_view(),
         name="ol_course_language",
     ),
-    # TODO: Remove the legacy endpoint in a  # noqa: FIX002, TD003, TD002
-    #  future release after updating all clients to use the new endpoint.
-    re_path(
-        rf"course-translations/api/course-language/{settings.COURSE_KEY_PATTERN}$",
-        CourseLanguageView.as_view(),
-        name="ol_course_language_legacy",
-    ),
 ]

--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
@@ -18,6 +18,18 @@ from ol_openedx_auto_select_language.utils import LanguageCode
 log = logging.getLogger(__name__)
 
 
+class CourseLanguageAnonRateThrottle(AnonRateThrottle):
+    """Throttle anonymous requests for course language endpoint."""
+
+    rate = "20/min"
+
+
+class CourseLanguageUserRateThrottle(UserRateThrottle):
+    """Throttle authenticated requests for course language endpoint."""
+
+    rate = "20/min"
+
+
 class CourseLanguageView(APIView):
     """
     API View to retrieve the language of a specified course.
@@ -47,7 +59,7 @@ class CourseLanguageView(APIView):
     """
 
     permission_classes = [AllowAny]
-    throttle_classes = [AnonRateThrottle, UserRateThrottle]
+    throttle_classes = [CourseLanguageAnonRateThrottle, CourseLanguageUserRateThrottle]
 
     def get(self, request, course_key_string):  # noqa: ARG002
         """

--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from rest_framework.views import APIView
+from django.conf import settings
 
 from ol_openedx_auto_select_language.utils import LanguageCode
 
@@ -22,14 +23,14 @@ class CourseLanguageAnonRateThrottle(AnonRateThrottle):
     """Throttle anonymous requests for course language endpoint."""
 
     scope = "course_language_anon"
-    rate = "20/min"
+    rate = settings.COURSE_LANGUAGE_ANON_THROTTLE_RATE
 
 
 class CourseLanguageUserRateThrottle(UserRateThrottle):
     """Throttle authenticated requests for course language endpoint."""
 
     scope = "course_language_user"
-    rate = "20/min"
+    rate = settings.COURSE_LANGUAGE_USER_THROTTLE_RATE
 
 
 class CourseLanguageView(APIView):

--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 class CourseLanguageAnonRateThrottle(AnonRateThrottle):
     """Throttle anonymous requests for course language endpoint."""
 
+    scope = "course_language_anon"
     rate = "20/min"
 
 

--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
@@ -4,6 +4,7 @@ API Views for ol_openedx_auto_select_language App
 
 import logging
 
+from django.conf import settings
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -12,7 +13,6 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from rest_framework.views import APIView
-from django.conf import settings
 
 from ol_openedx_auto_select_language.utils import LanguageCode
 

--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
@@ -8,8 +8,9 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from rest_framework.views import APIView
 
 from ol_openedx_auto_select_language.utils import LanguageCode
@@ -45,7 +46,8 @@ class CourseLanguageView(APIView):
         }
     """
 
-    permission_classes = [IsAuthenticated]
+    permission_classes = [AllowAny]
+    throttle_classes = [AnonRateThrottle, UserRateThrottle]
 
     def get(self, request, course_key_string):  # noqa: ARG002
         """

--- a/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
+++ b/src/ol_openedx_auto_select_language/ol_openedx_auto_select_language/views.py
@@ -28,6 +28,7 @@ class CourseLanguageAnonRateThrottle(AnonRateThrottle):
 class CourseLanguageUserRateThrottle(UserRateThrottle):
     """Throttle authenticated requests for course language endpoint."""
 
+    scope = "course_language_user"
     rate = "20/min"
 
 

--- a/src/ol_openedx_auto_select_language/pyproject.toml
+++ b/src/ol_openedx_auto_select_language/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-auto-select-language"
-version = "0.1.0"
+version = "0.1.1"
 description = "An Open edX plugin to auto-select the language based on course language settings."
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_auto_select_language/tests/test_views.py
+++ b/src/ol_openedx_auto_select_language/tests/test_views.py
@@ -4,8 +4,16 @@ import pytest
 from ol_openedx_auto_select_language.views import CourseLanguageView
 from opaque_keys import InvalidKeyError
 from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 MODULE = "ol_openedx_auto_select_language.views"
+
+
+def test_view_is_public_and_throttled():
+    """Test view uses public access with basic DRF throttling."""
+    assert CourseLanguageView.permission_classes == [AllowAny]
+    assert CourseLanguageView.throttle_classes == [AnonRateThrottle, UserRateThrottle]
 
 
 @pytest.mark.parametrize(

--- a/src/ol_openedx_auto_select_language/tests/test_views.py
+++ b/src/ol_openedx_auto_select_language/tests/test_views.py
@@ -20,6 +20,8 @@ def test_view_is_public_and_throttled():
         CourseLanguageAnonRateThrottle,
         CourseLanguageUserRateThrottle,
     ]
+    assert CourseLanguageAnonRateThrottle.scope == "course_language_anon"
+    assert CourseLanguageUserRateThrottle.scope == "course_language_user"
     assert CourseLanguageAnonRateThrottle.rate == "20/min"
     assert CourseLanguageUserRateThrottle.rate == "20/min"
 

--- a/src/ol_openedx_auto_select_language/tests/test_views.py
+++ b/src/ol_openedx_auto_select_language/tests/test_views.py
@@ -1,11 +1,14 @@
 """Tests for CourseLanguageView API view."""
 
 import pytest
-from ol_openedx_auto_select_language.views import CourseLanguageView
+from ol_openedx_auto_select_language.views import (
+    CourseLanguageAnonRateThrottle,
+    CourseLanguageUserRateThrottle,
+    CourseLanguageView,
+)
 from opaque_keys import InvalidKeyError
 from rest_framework import status
 from rest_framework.permissions import AllowAny
-from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 MODULE = "ol_openedx_auto_select_language.views"
 
@@ -13,7 +16,12 @@ MODULE = "ol_openedx_auto_select_language.views"
 def test_view_is_public_and_throttled():
     """Test view uses public access with basic DRF throttling."""
     assert CourseLanguageView.permission_classes == [AllowAny]
-    assert CourseLanguageView.throttle_classes == [AnonRateThrottle, UserRateThrottle]
+    assert CourseLanguageView.throttle_classes == [
+        CourseLanguageAnonRateThrottle,
+        CourseLanguageUserRateThrottle,
+    ]
+    assert CourseLanguageAnonRateThrottle.rate == "20/min"
+    assert CourseLanguageUserRateThrottle.rate == "20/min"
 
 
 @pytest.mark.parametrize(

--- a/src/ol_openedx_auto_select_language/tests/test_views.py
+++ b/src/ol_openedx_auto_select_language/tests/test_views.py
@@ -1,6 +1,7 @@
 """Tests for CourseLanguageView API view."""
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from ol_openedx_auto_select_language.views import (
     CourseLanguageAnonRateThrottle,
     CourseLanguageUserRateThrottle,
@@ -13,17 +14,44 @@ from rest_framework.permissions import AllowAny
 MODULE = "ol_openedx_auto_select_language.views"
 
 
-def test_view_is_public_and_throttled():
-    """Test view uses public access with basic DRF throttling."""
-    assert CourseLanguageView.permission_classes == [AllowAny]
+def test_course_language_view_is_throttled():
+    """Test that throttling classes are configured."""
     assert CourseLanguageView.throttle_classes == [
         CourseLanguageAnonRateThrottle,
         CourseLanguageUserRateThrottle,
     ]
     assert CourseLanguageAnonRateThrottle.scope == "course_language_anon"
     assert CourseLanguageUserRateThrottle.scope == "course_language_user"
-    assert CourseLanguageAnonRateThrottle.rate == "20/min"
-    assert CourseLanguageUserRateThrottle.rate == "20/min"
+
+
+@pytest.mark.parametrize(
+    "user_type",
+    [
+        ("authenticated", "mock_user"),
+        ("anonymous", AnonymousUser()),
+    ],
+)
+def test_course_language_view_is_public(request_factory, mock_user, mocker, user_type):
+    """Test view uses public access and both user and anonymous users can access."""
+    assert CourseLanguageView.permission_classes == [AllowAny]
+
+    # Mock the CourseOverview
+    mock_overview_cls = mocker.patch(f"{MODULE}.CourseOverview")
+    mock_course = mocker.Mock()
+    mock_course.language = "es"
+    mock_overview_cls.get_from_id.return_value = mock_course
+
+    # Get the user for this test run
+    user_name, user_fixture = user_type
+    user = mock_user if user_name == "authenticated" else user_fixture
+
+    request = request_factory.get("/")
+    request.user = user
+    view = CourseLanguageView()
+    response = view.get(request, course_key_string="course-v1:edX+DemoX+2024")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == {"language": "es"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11650

### Description (What does it do?)
<!--- Describe your changes in detail -->
Remove auth required permission from the API for course language. Adds basic throttling for authenticated and unauthenticate users.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Hit http://local.openedx.io:8000/course-translations/api/course-language/<COURSE_KEY> with both authenticated and unauthenticated users. Response should be course language code with 200.
- Try to hit more than 20 requests per minute and see the rate limit error.