### PR TITLE
feat: key based course translations instead of TARGZ

### DIFF
--- a/src/ol_openedx_course_translations/README.rst
+++ b/src/ol_openedx_course_translations/README.rst
@@ -98,8 +98,8 @@ You can specify providers in two ways:
 .. code-block:: bash
 
     ./manage.py cms translate_course \
-        --source-course course-v1:TestOrg+Source+Run \
-        --target-course course-v1:TestOrg+Arabic+Run \
+        --source-course-id course-v1:TestOrg+Source+Run \
+        --target-course-id course-v1:TestOrg+Arabic+Run \
         --target-language ar \
         --content-translation-provider openai \
         --srt-translation-provider gemini
@@ -109,8 +109,8 @@ You can specify providers in two ways:
 .. code-block:: bash
 
     ./manage.py cms translate_course \
-        --source-course course-v1:TestOrg+Source+Run \
-        --target-course course-v1:TestOrg+Arabic+Run \
+        --source-course-id course-v1:TestOrg+Source+Run \
+        --target-course-id course-v1:TestOrg+Arabic+Run \
         --target-language ar \
         --content-translation-provider openai/gpt-5.2 \
         --srt-translation-provider gemini/gemini-3-pro-preview
@@ -130,8 +130,8 @@ file handling is required.
    .. code-block:: bash
 
         ./manage.py cms translate_course \
-            --source-course course-v1:TestOrg+Source+Run \
-            --target-course course-v1:TestOrg+Arabic+Run \
+            --source-course-id course-v1:TestOrg+Source+Run \
+            --target-course-id course-v1:TestOrg+Arabic+Run \
             --source-language en \
             --target-language ar \
             --content-translation-provider openai \
@@ -144,8 +144,8 @@ file handling is required.
 
 **Command Options:**
 
-- ``--source-course``: Course key of the source course to translate (required). Example: ``course-v1:Org+Course+Run``
-- ``--target-course``: Course key of the target course to import translated content into (required). The course is created automatically if it does not exist.
+- ``--source-course-id``: Course key of the source course to translate (required). Example: ``course-v1:Org+Course+Run``
+- ``--target-course-id``: Course key of the target course to import translated content into (required). The course is created automatically if it does not exist.
 - ``--source-language``: Source language code (default: en)
 - ``--target-language``: Target language code (required)
 - ``--content-translation-provider``: Translation provider for content (XML/HTML and text) (required).
@@ -170,24 +170,24 @@ translating each update item's ``content`` field as HTML.
 
     # Use OpenAI and Gemini with default models from settings
     ./manage.py cms translate_course \
-        --source-course course-v1:MyOrg+EnglishCourse+2024 \
-        --target-course course-v1:MyOrg+FrenchCourse+2024 \
+        --source-course-id course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course-id course-v1:MyOrg+FrenchCourse+2024 \
         --target-language fr \
         --content-translation-provider openai \
         --srt-translation-provider gemini
 
     # Use OpenAI with specific model for content, Gemini with default for subtitles
     ./manage.py cms translate_course \
-        --source-course course-v1:MyOrg+EnglishCourse+2024 \
-        --target-course course-v1:MyOrg+FrenchCourse+2024 \
+        --source-course-id course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course-id course-v1:MyOrg+FrenchCourse+2024 \
         --target-language fr \
         --content-translation-provider openai/gpt-5.2 \
         --srt-translation-provider gemini
 
     # Use Mistral with specific model and separate glossaries for content and SRT
     ./manage.py cms translate_course \
-        --source-course course-v1:MyOrg+EnglishCourse+2024 \
-        --target-course course-v1:MyOrg+SpanishCourse+2024 \
+        --source-course-id course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course-id course-v1:MyOrg+SpanishCourse+2024 \
         --target-language es \
         --content-translation-provider mistral/mistral-large-latest \
         --srt-translation-provider mistral/mistral-large-latest \
@@ -196,8 +196,8 @@ translating each update item's ``content`` field as HTML.
 
     # Use different glossaries for content vs subtitles
     ./manage.py cms translate_course \
-        --source-course course-v1:MyOrg+EnglishCourse+2024 \
-        --target-course course-v1:MyOrg+SpanishCourse+2024 \
+        --source-course-id course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course-id course-v1:MyOrg+SpanishCourse+2024 \
         --target-language es \
         --content-translation-provider openai \
         --srt-translation-provider gemini \

--- a/src/ol_openedx_course_translations/README.rst
+++ b/src/ol_openedx_course_translations/README.rst
@@ -98,8 +98,9 @@ You can specify providers in two ways:
 .. code-block:: bash
 
     ./manage.py cms translate_course \
+        --source-course course-v1:TestOrg+Source+Run \
+        --target-course course-v1:TestOrg+Arabic+Run \
         --target-language ar \
-        --course-dir /path/to/course.tar.gz \
         --content-translation-provider openai \
         --srt-translation-provider gemini
 
@@ -108,8 +109,9 @@ You can specify providers in two ways:
 .. code-block:: bash
 
     ./manage.py cms translate_course \
+        --source-course course-v1:TestOrg+Source+Run \
+        --target-course course-v1:TestOrg+Arabic+Run \
         --target-language ar \
-        --course-dir /path/to/course.tar.gz \
         --content-translation-provider openai/gpt-5.2 \
         --srt-translation-provider gemini/gemini-3-pro-preview
 
@@ -117,29 +119,35 @@ You can specify providers in two ways:
 
 Translating a Course
 ====================
-1. Open the course in Studio.
-2. Go to Tools -> Export Course.
-3. Export the course as a .tar.gz file.
-4. Go to the CMS shell
-5. Run the management command to translate the course:
+
+The command reads the source course directly from the modulestore, translates its
+content, and imports the result into the target course. No manual export or TAR
+file handling is required.
+
+1. Open the CMS shell.
+2. Run the management command:
 
    .. code-block:: bash
 
         ./manage.py cms translate_course \
+            --source-course course-v1:TestOrg+Source+Run \
+            --target-course course-v1:TestOrg+Arabic+Run \
             --source-language en \
             --target-language ar \
-            --course-dir /path/to/course.tar.gz \
             --content-translation-provider openai \
             --srt-translation-provider gemini \
             --translation-validation-provider openai/gpt-5.2 \
             --content-glossary /path/to/content/glossary \
             --srt-glossary /path/to/srt/glossary
 
+   The target course is created automatically if it does not already exist.
+
 **Command Options:**
 
+- ``--source-course``: Course key of the source course to translate (required). Example: ``course-v1:Org+Course+Run``
+- ``--target-course``: Course key of the target course to import translated content into (required). The course is created automatically if it does not exist.
 - ``--source-language``: Source language code (default: en)
 - ``--target-language``: Target language code (required)
-- ``--course-dir``: Path to exported course tar.gz file (required)
 - ``--content-translation-provider``: Translation provider for content (XML/HTML and text) (required).
 
   Format:
@@ -162,22 +170,25 @@ translating each update item's ``content`` field as HTML.
 
     # Use OpenAI and Gemini with default models from settings
     ./manage.py cms translate_course \
+        --source-course course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course course-v1:MyOrg+FrenchCourse+2024 \
         --target-language fr \
-        --course-dir /path/to/course.tar.gz \
         --content-translation-provider openai \
         --srt-translation-provider gemini
 
     # Use OpenAI with specific model for content, Gemini with default for subtitles
     ./manage.py cms translate_course \
+        --source-course course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course course-v1:MyOrg+FrenchCourse+2024 \
         --target-language fr \
-        --course-dir /path/to/course.tar.gz \
         --content-translation-provider openai/gpt-5.2 \
         --srt-translation-provider gemini
 
     # Use Mistral with specific model and separate glossaries for content and SRT
     ./manage.py cms translate_course \
+        --source-course course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course course-v1:MyOrg+SpanishCourse+2024 \
         --target-language es \
-        --course-dir /path/to/course.tar.gz \
         --content-translation-provider mistral/mistral-large-latest \
         --srt-translation-provider mistral/mistral-large-latest \
         --content-glossary /path/to/content/glossary \
@@ -185,8 +196,9 @@ translating each update item's ``content`` field as HTML.
 
     # Use different glossaries for content vs subtitles
     ./manage.py cms translate_course \
+        --source-course course-v1:MyOrg+EnglishCourse+2024 \
+        --target-course course-v1:MyOrg+SpanishCourse+2024 \
         --target-language es \
-        --course-dir /path/to/course.tar.gz \
         --content-translation-provider openai \
         --srt-translation-provider gemini \
         --content-glossary /path/to/technical/glossary \

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -50,6 +50,8 @@ BATCH_SIZE = 20  # Process 20 tasks at a time
 # constants
 SRT_TRANSLATION_TASK_TYPE = "srt_translation"
 FILE_TRANSLATION_TASK_TYPE = "file_translation"
+SOURCE_COURSE_ID_ARG = "--source-course-id"
+TARGET_COURSE_ID_ARG = "--target-course-id"
 
 
 class TaskStatus(StrEnum):
@@ -112,8 +114,8 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
-            "--source-course",
-            dest="source_course",
+            SOURCE_COURSE_ID_ARG,
+            dest="source_course_id",
             required=True,
             help=(
                 "Course key for the source course to export and translate. "
@@ -121,8 +123,8 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
-            "--target-course",
-            dest="target_course",
+            TARGET_COURSE_ID_ARG,
+            dest="target_course_id",
             required=True,
             help=(
                 "Course key for the destination course where the translated content "
@@ -265,11 +267,17 @@ class Command(BaseCommand):
             start_time = time.perf_counter()
 
             source_course_key = self._parse_course_key(
-                options["source_course"], "--source-course"
+                options["source_course_id"], SOURCE_COURSE_ID_ARG
             )
             target_course_key = self._parse_course_key(
-                options["target_course"], "--target-course"
+                options["target_course_id"], TARGET_COURSE_ID_ARG
             )
+
+            if not self.confirm(source_course_key, target_course_key):
+                self.stdout.write(self.style.WARNING("Operation cancelled."))
+                return
+            self.stdout.write("Proceeding...")
+
             source_language = options["source_language"]
             target_language = options["target_language"]
 
@@ -452,6 +460,30 @@ class Command(BaseCommand):
             error_msg = f"Translation failed: {e}"
             raise CommandError(error_msg) from e
 
+    def confirm(
+        self, source_course_id: CourseLocator, target_course_id: CourseLocator
+    ) -> bool:
+        while True:
+            answer = (
+                input(
+                    f"You selected the source course ID {source_course_id}, "
+                    f"and the target course ID {target_course_id}. A new target course "
+                    f"will be created if it does not exist or existing course will be "
+                    f"updated with the translated content if it already exists. "
+                    f"Please confirm: y/n."
+                )
+                .strip()
+                .lower()
+            )
+
+            if answer in ("y", "yes"):
+                return True
+
+            if answer in ("", "n", "no"):
+                return False
+
+            self.stdout.write("Please enter 'y' or 'n'.")
+
     def _parse_course_key(self, key_str: str, arg_name: str) -> CourseLocator:
         """
         Parse a course key string into a CourseLocator.
@@ -489,7 +521,7 @@ class Command(BaseCommand):
         if course is None:
             error_msg = (
                 f"Source course not found: '{source_course_key}'. "
-                "Please verify the course key and that the course exists."
+                "Please verify that the course key and course exists."
             )
             raise CommandError(error_msg)
 
@@ -500,7 +532,8 @@ class Command(BaseCommand):
         Export the source course OLX into a temporary directory under base_dir.
 
         The exported directory will contain a 'course' subdirectory with the full
-        OLX tree, matching the structure that _translate_course_content_async expects.
+        OLX tree, matching the structure that (:meth:`_translate_course_content_async`)
+        expects.
 
         Args:
             source_course_key: Course key to export

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -466,11 +466,11 @@ class Command(BaseCommand):
         while True:
             answer = (
                 input(
-                    f"You selected the source course ID {source_course_id}, "
+                    f"\n\nYou selected the source course ID {source_course_id}, "
                     f"and the target course ID {target_course_id}. A new target course "
                     f"will be created if it does not exist or existing course will be "
                     f"updated with the translated content if it already exists. "
-                    f"Please confirm: y/n."
+                    f"\n\nPlease confirm: y/n."
                 )
                 .strip()
                 .lower()

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -10,21 +10,21 @@ import tempfile
 import time
 from enum import StrEnum
 from pathlib import Path
-from xmodule.modulestore.django import modulestore
-from xmodule.contentstore.django import contentstore
-from xmodule.modulestore.xml_exporter import (
-    export_course_to_xml,
-)
-from xmodule.modulestore import ModuleStoreEnum  # noqa: PLC0415
-from xmodule.modulestore.xml_importer import (  # noqa: PLC0415
-    import_course_from_xml,
-)
 
 from celery import group
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseLocator
+from xmodule.contentstore.django import contentstore
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.xml_exporter import (
+    export_course_to_xml,
+)
+from xmodule.modulestore.xml_importer import (
+    import_course_from_xml,
+)
 
 from ol_openedx_course_translations import tasks as translation_tasks
 from ol_openedx_course_translations.models import CourseTranslationLog

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import shutil
+import tempfile
 import time
 from enum import StrEnum
 from pathlib import Path
@@ -13,6 +14,7 @@ from pathlib import Path
 from celery import group
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseLocator
 
 from ol_openedx_course_translations import tasks as translation_tasks
@@ -22,15 +24,11 @@ from ol_openedx_course_translations.utils.constants import (
     PROVIDER_MISTRAL,
 )
 from ol_openedx_course_translations.utils.course_translations import (
-    create_translated_archive,
     create_translated_copy,
-    extract_course_archive,
-    generate_course_key_from_xml,
     get_translatable_file_paths,
     get_translation_provider,
     translate_grading_policy,
     update_course_language_attribute,
-    validate_course_inputs,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,6 +55,8 @@ class Command(BaseCommand):
 
     help = (
         "Translate course content to the specified language.\n\n"
+        "Exports the source course from the modulestore, translates its content,\n"
+        "then imports the translated version into the target course.\n\n"
         "Configuration:\n"
         "All translation providers should be configured in TRANSLATIONS_PROVIDERS:\n"
         "{\n"
@@ -103,10 +103,23 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
-            "--course-dir",
-            dest="course_archive_path",
+            "--source-course",
+            dest="source_course",
             required=True,
-            help="Specify the course directory (tar archive).",
+            help=(
+                "Course key for the source course to export and translate. "
+                "Format: course-v1:ORG+COURSE+RUN"
+            ),
+        )
+        parser.add_argument(
+            "--target-course",
+            dest="target_course",
+            required=True,
+            help=(
+                "Course key for the destination course where the translated content "
+                "will be imported. Format: course-v1:ORG+COURSE+RUN. "
+                "The course will be created automatically if it does not exist."
+            ),
         )
         parser.add_argument(
             "--content-translation-provider",
@@ -241,7 +254,13 @@ class Command(BaseCommand):
         """Handle the translate_course command."""
         try:
             start_time = time.perf_counter()
-            course_archive_path = Path(options["course_archive_path"])
+
+            source_course_key = self._parse_course_key(
+                options["source_course"], "--source-course"
+            )
+            target_course_key = self._parse_course_key(
+                options["target_course"], "--target-course"
+            )
             source_language = options["source_language"]
             target_language = options["target_language"]
 
@@ -294,6 +313,8 @@ class Command(BaseCommand):
                 )
 
             # Log the resolved configuration
+            self.stdout.write(f"Source course: {source_course_key}")
+            self.stdout.write(f"Target course: {target_course_key}")
             if content_model:
                 self.stdout.write(
                     f"Content provider: {content_provider_name}/{content_model}"
@@ -317,8 +338,8 @@ class Command(BaseCommand):
                         f"Content translation validation provider: {translation_validation_provider_name}"  # noqa: E501
                     )
 
-            # Validate inputs
-            validate_course_inputs(course_archive_path)
+            # Validate that the source course exists
+            self._validate_source_course(source_course_key)
 
             # Store provider names and models
             self.content_provider_name = content_provider_name
@@ -339,22 +360,25 @@ class Command(BaseCommand):
             course_translations_base_dir = Path(base_dir_setting)
             course_translations_base_dir.mkdir(parents=True, exist_ok=True)
 
-            # Extract course archive into fixed base directory
-            extracted_course_dir = extract_course_archive(
-                course_archive_path, extract_to_dir=course_translations_base_dir
+            # Export source course OLX directly into a temp directory.
+            # Using export_course_to_xml (the same underlying function that the
+            # export_olx management command calls) to avoid a tar/extract round-trip
+            # and to control the output directory name ("course") so that the
+            # existing translation pipeline (_translate_course_content_async) can
+            # find course_dir / "course" without additional discovery logic.
+            export_dir = self._export_source_course(
+                source_course_key, course_translations_base_dir
             )
 
-            # Create translated copy (also under fixed base directory)
-            translated_course_dir = create_translated_copy(
-                extracted_course_dir, target_language
-            )
+            # Create translated copy under the same base directory
+            translated_course_dir = create_translated_copy(export_dir, target_language)
 
             # Store for cleanup on failure
             self.translated_course_dir = translated_course_dir
 
-            # Delete extracted directory after copying
-            if extracted_course_dir.exists():
-                shutil.rmtree(extracted_course_dir)
+            # Remove the export directory now that we have a translated copy
+            if export_dir.exists():
+                shutil.rmtree(export_dir)
 
             # Translate content asynchronously
             self._translate_course_content_async(
@@ -369,9 +393,8 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(total_time_taken_msg))
             command_stats.append(total_time_taken_msg)
 
-            source_course_id = generate_course_key_from_xml(
-                course_dir_path=self.translated_course_dir
-            )
+            # The source course key is known directly from the argument
+            source_course_id = source_course_key
 
             # Add translation log entry
             self._add_translation_log_entry(
@@ -391,16 +414,16 @@ class Command(BaseCommand):
                 source_course_id=source_course_id,
             )
 
-            # Create final archive in the same fixed base directory
-            translated_archive_path = create_translated_archive(
-                translated_course_dir,
-                target_language,
-                course_archive_path.stem,
-                output_dir=course_translations_base_dir,
-            )
+            # Import translated content into the target course, creating it if needed
+            self._import_translated_course(translated_course_dir, target_course_key)
+
+            # Clean up the translated working directory
+            if self.translated_course_dir and self.translated_course_dir.exists():
+                shutil.rmtree(self.translated_course_dir)
+
             success_msg = (
-                f"Translation completed successfully. Translated archive created: "
-                f"{translated_archive_path}"
+                f"Translation completed successfully. "
+                f"Imported into target course: {target_course_key}"
             )
             self.stdout.write(self.style.SUCCESS(success_msg))
 
@@ -422,6 +445,155 @@ class Command(BaseCommand):
 
             error_msg = f"Translation failed: {e}"
             raise CommandError(error_msg) from e
+
+    def _parse_course_key(self, key_str: str, arg_name: str) -> CourseLocator:
+        """
+        Parse a course key string into a CourseLocator.
+
+        Args:
+            key_str: Course key string (e.g., course-v1:ORG+COURSE+RUN)
+            arg_name: Argument name for error messages
+
+        Returns:
+            Parsed CourseLocator
+
+        Raises:
+            CommandError: If the key string is invalid
+        """
+        try:
+            return CourseLocator.from_string(key_str)
+        except InvalidKeyError as e:
+            error_msg = (
+                f"Invalid course key for {arg_name}: '{key_str}'. "
+                "Expected format: course-v1:ORG+COURSE+RUN"
+            )
+            raise CommandError(error_msg) from e
+
+    def _validate_source_course(self, source_course_key: CourseLocator) -> None:
+        """
+        Validate that the source course exists in the modulestore.
+
+        Args:
+            source_course_key: Course key to validate
+
+        Raises:
+            CommandError: If the course does not exist
+        """
+        from xmodule.modulestore.django import modulestore  # noqa: PLC0415
+
+        course = modulestore().get_course(source_course_key)
+        if course is None:
+            error_msg = (
+                f"Source course not found: '{source_course_key}'. "
+                "Please verify the course key and that the course exists."
+            )
+            raise CommandError(error_msg)
+
+    def _export_source_course(
+        self, source_course_key: CourseLocator, base_dir: Path
+    ) -> Path:
+        """
+        Export the source course OLX into a temporary directory under base_dir.
+
+        The exported directory will contain a 'course' subdirectory with the full
+        OLX tree, matching the structure that _translate_course_content_async expects.
+
+        Args:
+            source_course_key: Course key to export
+            base_dir: Parent directory under which to create the export temp dir
+
+        Returns:
+            Path to the export directory (contains a 'course/' subdirectory inside)
+
+        Raises:
+            CommandError: If the export fails
+        """
+        from xmodule.contentstore.django import contentstore  # noqa: PLC0415
+        from xmodule.modulestore.django import modulestore  # noqa: PLC0415
+        from xmodule.modulestore.xml_exporter import (  # noqa: PLC0415
+            export_course_to_xml,
+        )
+
+        export_dir = Path(tempfile.mkdtemp(dir=base_dir))
+        try:
+            self.stdout.write(f"Exporting source course {source_course_key} ...")
+            # export_course_to_xml writes into export_dir/course/ so that
+            # the output directory name is always "course", consistent with
+            # what _translate_course_content_async expects.
+            export_course_to_xml(
+                modulestore(),
+                contentstore(),
+                source_course_key,
+                str(export_dir),
+                "course",
+            )
+        except Exception as e:
+            shutil.rmtree(export_dir, ignore_errors=True)
+            error_msg = f"Failed to export source course '{source_course_key}': {e}"
+            raise CommandError(error_msg) from e
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Course exported to: {export_dir / 'course'}")
+        )
+        return export_dir
+
+    def _import_translated_course(
+        self, translated_course_dir: Path, target_course_key: CourseLocator
+    ) -> None:
+        """
+        Import translated OLX into the target course, creating it if it does not exist.
+
+        Uses import_course_from_xml from xmodule directly so we can specify
+        target_id and create_if_not_present — capabilities not exposed by the
+        cms import management command.
+
+        Args:
+            translated_course_dir: Directory containing translated OLX under 'course/'
+            target_course_key: Destination course key
+
+        Raises:
+            CommandError: If the import fails
+        """
+        from xmodule.contentstore.django import contentstore  # noqa: PLC0415
+        from xmodule.modulestore import ModuleStoreEnum  # noqa: PLC0415
+        from xmodule.modulestore.django import modulestore  # noqa: PLC0415
+        from xmodule.modulestore.xml_importer import (  # noqa: PLC0415
+            import_course_from_xml,
+        )
+
+        self.stdout.write(
+            f"Importing translated content into target course {target_course_key} ..."
+        )
+        try:
+            course_items = import_course_from_xml(
+                modulestore(),
+                ModuleStoreEnum.UserID.mgmt_command,
+                str(translated_course_dir),  # data_dir
+                ["course"],  # source_dirs — matches the "course" subdir we exported
+                load_error_blocks=False,
+                static_content_store=contentstore(),
+                target_id=target_course_key,
+                verbose=True,
+                create_if_not_present=True,
+            )
+        except Exception as e:
+            error_msg = (
+                f"Failed to import translated content into '{target_course_key}': {e}"
+            )
+            raise CommandError(error_msg) from e
+
+        if not course_items:
+            error_msg = (
+                f"Import into '{target_course_key}' returned no course items. "
+                "The import may have failed silently — check the CMS logs."
+            )
+            raise CommandError(error_msg)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully imported translated content into: {target_course_key}"
+            )
+        )
 
     def _translate_course_content_async(
         self, course_dir: Path, source_language: str, target_language: str

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -10,6 +10,15 @@ import tempfile
 import time
 from enum import StrEnum
 from pathlib import Path
+from xmodule.modulestore.django import modulestore
+from xmodule.contentstore.django import contentstore
+from xmodule.modulestore.xml_exporter import (
+    export_course_to_xml,
+)
+from xmodule.modulestore import ModuleStoreEnum  # noqa: PLC0415
+from xmodule.modulestore.xml_importer import (  # noqa: PLC0415
+    import_course_from_xml,
+)
 
 from celery import group
 from django.conf import settings
@@ -393,15 +402,12 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(total_time_taken_msg))
             command_stats.append(total_time_taken_msg)
 
-            # The source course key is known directly from the argument
-            source_course_id = source_course_key
-
             # Add translation log entry
             self._add_translation_log_entry(
                 source_language=source_language,
                 target_language=target_language,
                 command_stats=command_stats,
-                source_course_id=source_course_id,
+                source_course_id=source_course_key,
             )
 
             # Write translations metadata into the translated course output
@@ -411,7 +417,7 @@ class Command(BaseCommand):
                 target_language=target_language,
                 command_stats=command_stats,
                 command_options=options,
-                source_course_id=source_course_id,
+                source_course_id=source_course_key,
             )
 
             # Import translated content into the target course, creating it if needed
@@ -479,8 +485,6 @@ class Command(BaseCommand):
         Raises:
             CommandError: If the course does not exist
         """
-        from xmodule.modulestore.django import modulestore  # noqa: PLC0415
-
         course = modulestore().get_course(source_course_key)
         if course is None:
             error_msg = (
@@ -508,12 +512,6 @@ class Command(BaseCommand):
         Raises:
             CommandError: If the export fails
         """
-        from xmodule.contentstore.django import contentstore  # noqa: PLC0415
-        from xmodule.modulestore.django import modulestore  # noqa: PLC0415
-        from xmodule.modulestore.xml_exporter import (  # noqa: PLC0415
-            export_course_to_xml,
-        )
-
         export_dir = Path(tempfile.mkdtemp(dir=base_dir))
         try:
             self.stdout.write(f"Exporting source course {source_course_key} ...")
@@ -561,13 +559,6 @@ class Command(BaseCommand):
         Raises:
             CommandError: If the import fails
         """
-        from xmodule.contentstore.django import contentstore  # noqa: PLC0415
-        from xmodule.modulestore import ModuleStoreEnum  # noqa: PLC0415
-        from xmodule.modulestore.django import modulestore  # noqa: PLC0415
-        from xmodule.modulestore.xml_importer import (  # noqa: PLC0415
-            import_course_from_xml,
-        )
-
         self.stdout.write(
             f"Importing translated content into target course {target_course_key} ..."
         )

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -527,6 +527,13 @@ class Command(BaseCommand):
                 str(export_dir),
                 "course",
             )
+
+            exported_course_dir = export_dir / "course"
+            if not exported_course_dir.is_dir():
+                error_msg = (
+                    f"Export did not create expected directory: {exported_course_dir}"
+                )
+                raise CommandError(error_msg)  # noqa: TRY301
         except Exception as e:
             shutil.rmtree(export_dir, ignore_errors=True)
             error_msg = f"Failed to export source course '{source_course_key}': {e}"

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/settings/common.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/settings/common.py
@@ -27,11 +27,6 @@ def apply_common_settings(settings):
         "static",
         "tabs",
     ]
-    settings.COURSE_TRANSLATIONS_SUPPORTED_ARCHIVE_EXTENSIONS = [
-        ".tar.gz",
-        ".tgz",
-        ".tar",
-    ]
     settings.COURSE_TRANSLATIONS_TRANSLATABLE_EXTENSIONS = [
         ".html",
         ".xml",

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/settings/common.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/settings/common.py
@@ -32,7 +32,7 @@ def apply_common_settings(settings):
         ".xml",
         ".srt",
     ]
-    # Relative to extracted ``course/`` directory in exported archive.
+    # Relative to ``course/`` directory.
     settings.COURSE_TRANSLATIONS_UPDATES_ITEMS_JSON_RELATIVE_PATH = (
         "info/updates.items.json"
     )
@@ -66,8 +66,7 @@ def apply_common_settings(settings):
         "retry_countdown": 1 * 60,  # wait 1m before retry
     }
 
-    # Base directory where translate_course extracts archives and writes
-    # translated .tar.gz output. Directory is created at runtime if missing.
+    # Base directory for course translations.
     settings.COURSE_TRANSLATIONS_BASE_DIR = "/openedx/data/course_translations/"
 
     settings.COURSE_TRANSLATIONS_SUPPORTED_LANGUAGES = {

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
@@ -39,9 +39,6 @@ from ol_openedx_course_translations.utils.constants import (
 
 logger = logging.getLogger(__name__)
 
-# Archive and file size limits
-TAR_FILE_SIZE_LIMIT = 512 * 1024 * 1024  # 512MB
-
 
 def get_translation_provider(
     provider_name: str,

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
@@ -11,7 +11,6 @@ import json
 import logging
 import re
 import shutil
-import tarfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -365,43 +364,6 @@ def get_srt_output_filename(input_filename: str, target_language: str) -> str:
         filename_parts = input_filename.rsplit("-", 1)
         return f"{filename_parts[0]}-{target_language}.srt"
     return input_filename
-
-
-def get_supported_archive_extension(filename: str) -> str | None:
-    """
-    Return the supported archive extension if filename ends with one, else None.
-
-    Args:
-        filename: Name of the archive file
-
-    Returns:
-        Archive extension if supported, None otherwise
-    """
-    for ext in settings.COURSE_TRANSLATIONS_SUPPORTED_ARCHIVE_EXTENSIONS:
-        if filename.endswith(ext):
-            return ext
-    return None
-
-
-def validate_tar_file(tar_file: tarfile.TarFile) -> None:
-    """
-    Validate tar file contents for security.
-
-    Args:
-        tar_file: Open tarfile object
-
-    Raises:
-        CommandError: If tar file contains unsafe members or excessively large files
-    """
-    for tar_member in tar_file.getmembers():
-        # Check for directory traversal attacks
-        if tar_member.name.startswith("/") or ".." in tar_member.name:
-            error_msg = f"Unsafe tar member: {tar_member.name}"
-            raise CommandError(error_msg)
-        # Check for excessively large files (512MB limit)
-        if tar_member.size > TAR_FILE_SIZE_LIMIT:
-            error_msg = f"File too large: {tar_member.name}"
-            raise CommandError(error_msg)
 
 
 def create_translated_copy(source_course_dir: Path, target_language: str) -> Path:

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
@@ -14,7 +14,6 @@ import shutil
 import tarfile
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from xml.etree.ElementTree import Element
 
@@ -23,7 +22,6 @@ from defusedxml import ElementTree
 from django.conf import settings
 from django.core.management.base import CommandError
 from lxml import etree
-from opaque_keys.edx.locator import CourseLocator
 
 from ol_openedx_course_translations.providers.llm_providers import (
     GeminiProvider,
@@ -406,46 +404,6 @@ def validate_tar_file(tar_file: tarfile.TarFile) -> None:
             raise CommandError(error_msg)
 
 
-def extract_course_archive(course_archive_path: Path, extract_to_dir: Path) -> Path:
-    """
-    Extract course archive to the specified directory.
-
-    Args:
-        course_archive_path: Path to the course archive file
-        extract_to_dir: Directory to extract the course archive to
-
-    Returns:
-        Path to extracted course directory
-
-    Raises:
-        CommandError: If extraction fails
-    """
-    extraction_base_dir = extract_to_dir
-
-    # Get base name without extension
-    archive_extension = get_supported_archive_extension(course_archive_path.name)
-    archive_base_name = (
-        course_archive_path.name[: -len(archive_extension)]
-        if archive_extension
-        else course_archive_path.name
-    )
-
-    extracted_course_dir = extraction_base_dir / archive_base_name
-
-    if not extracted_course_dir.exists():
-        try:
-            with tarfile.open(course_archive_path, "r:*") as tar_file:
-                # Validate tar file before extraction
-                validate_tar_file(tar_file)
-                tar_file.extractall(path=extracted_course_dir, filter="data")
-        except (tarfile.TarError, OSError) as e:
-            error_msg = f"Failed to extract archive: {e}"
-            raise CommandError(error_msg) from e
-
-    logger.info("Extracted course to: %s", extracted_course_dir)
-    return extracted_course_dir
-
-
 def create_translated_copy(source_course_dir: Path, target_language: str) -> Path:
     """
     Create a copy of the course for translation.
@@ -471,55 +429,6 @@ def create_translated_copy(source_course_dir: Path, target_language: str) -> Pat
     shutil.copytree(source_course_dir, translated_course_dir)
     logger.info("Created translation copy: %s", translated_course_dir)
     return translated_course_dir
-
-
-def create_translated_archive(
-    translated_course_dir: Path,
-    target_language: str,
-    original_archive_name: str,
-    output_dir: Path,
-) -> Path:
-    """
-    Create tar.gz archive of translated course.
-
-    Args:
-        translated_course_dir: Path to translated course directory
-        target_language: Target language code
-        original_archive_name: Original archive filename
-        output_dir: Path to the output directory
-
-    Returns:
-        Path to created archive
-    """
-    # Remove all archive extensions from the original name
-    archive_extension = get_supported_archive_extension(original_archive_name)
-    clean_archive_name = (
-        original_archive_name[: -len(archive_extension)]
-        if archive_extension
-        else original_archive_name
-    )
-
-    generated_at = datetime.now(UTC).strftime("%Y%m%d_%H%MZ")
-    translated_archive_name = (
-        f"{target_language}_{clean_archive_name}_{generated_at}.tar.gz"
-    )
-    translated_archive_path = output_dir / translated_archive_name
-
-    # Remove existing archive
-    if translated_archive_path.exists():
-        translated_archive_path.unlink()
-
-    # Create tar.gz archive containing only the 'course' directory
-    course_directory_path = translated_course_dir / "course"
-    with tarfile.open(translated_archive_path, "w:gz") as tar_archive:
-        tar_archive.add(course_directory_path, arcname="course")
-
-    # Delete extracted directory after archiving
-    if translated_course_dir.exists():
-        shutil.rmtree(translated_course_dir)
-
-    logger.info("Created tar.gz archive: %s", translated_archive_path)
-    return translated_archive_path
 
 
 def update_video_xml_complete(xml_content: str, target_language: str) -> str:  # noqa: C901
@@ -596,30 +505,6 @@ def update_video_xml_complete(xml_content: str, target_language: str) -> str:  #
         return xml_content
 
 
-def validate_course_inputs(
-    course_archive_path: Path,
-) -> None:
-    """
-    Validate command inputs for course translation.
-
-    Args:
-        course_archive_path: Path to course archive file
-
-    Raises:
-        CommandError: If validation fails
-    """
-    if not course_archive_path.exists():
-        error_msg = f"Course archive not found: {course_archive_path}"
-        raise CommandError(error_msg)
-
-    if get_supported_archive_extension(course_archive_path.name) is None:
-        supported_extensions = ", ".join(
-            settings.COURSE_TRANSLATIONS_SUPPORTED_ARCHIVE_EXTENSIONS
-        )
-        error_msg = f"Course archive must be a tar file: {supported_extensions}"
-        raise CommandError(error_msg)
-
-
 def get_translatable_file_paths(
     directory_path: Path,
     *,
@@ -651,32 +536,6 @@ def get_translatable_file_paths(
         ]
 
     return translatable_file_paths
-
-
-def generate_course_key_from_xml(course_dir_path: Path) -> str:
-    """
-    Generate the course id of the source course
-    """
-    try:
-        about_file_path = course_dir_path / "course" / "course.xml"
-        xml_content = about_file_path.read_text(encoding="utf-8")
-        xml_root = ElementTree.fromstring(xml_content)
-
-        org = xml_root.get("org", "")
-        course = xml_root.get("course", "")
-        url_name = xml_root.get("url_name", "")
-
-        if not all([org, course, url_name]):
-            error_msg = (
-                "Missing required attributes in course.xml: org, course, url_name"
-            )
-            raise CommandError(error_msg)
-    except (OSError, ElementTree.ParseError) as e:
-        error_msg = f"Failed to read course id from about.xml: {e}"
-        raise CommandError(error_msg) from e
-    else:
-        # URL name is the run ID of the course
-        return CourseLocator(org=org, course=course, run=url_name)
 
 
 @dataclass(frozen=True)

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.7.0"
+version = "0.8.0"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11668

### Description (What does it do?)
<!--- Describe your changes in detail -->
Enhances the usage of course translations management command as per the requirements in the issue. translate_course was based on the course TAR, and now it is shifted to the course keys. It will auto export and import courses.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Create a course in studio to translate
- Go to CMS shell
- Run command `./manage.py cms translate_course --source-course course-v1:TestOrg+Source+Run --target-course course-v1:TestOrg+Arabic+Run --target-language ar --content-translation-provider openai --srt-translation-provider openai --translation-validation-provider openai`
- Replace the source and target keys as required in the command.
- Command should translate the source course and load the translated version in the target course.
- Test different versions like where source and target do not exist, redo translations to test target has updated translations.
- Any other edge cases if you feel if there are any

