### PR TITLE
fix: delete dangling assets from uai custom course

### DIFF
--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
@@ -310,6 +310,10 @@ class Command(BaseCommand):
                 )
                 delete_course_sections(course, user_id)
 
+            # Delete all course assets to prevent orphaned assets from
+            # the source course, which may be shared across multiple
+            # courses in a split modulestore setup.
+            store.contentstore.delete_all_course_assets(parsed_key)
             if course_intro:
                 intro_section = create_content_block(
                     course,

--- a/src/ol_openedx_uai_content_customization/pyproject.toml
+++ b/src/ol_openedx_uai_content_customization/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-uai-content-customization"
-version = "0.1.1"
+version = "0.1.2"
 description = "An Open edX plugin to generate industry/length-specific UAI custom courses from video CSV data."
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
@@ -409,6 +409,31 @@ def test_delete_sections_called_before_create_chapter(csv_files, mock_user):  # 
         )
 
 
+def test_delete_all_course_assets_called_for_new_courses(csv_files, mock_user):  # noqa: ARG001
+    """delete_all_course_assets must be called once per new course created."""
+    processed_videos_csv, edx_videos_csv = csv_files
+    store_mock = _modulestore_mock()
+
+    with (
+        mock.patch(f"{_CMD}.modulestore", store_mock),
+        mock.patch(f"{_CMD}.clone_course_in_modulestore", return_value=mock.Mock()),
+        mock.patch(f"{_CMD}.delete_course_sections"),
+        mock.patch(f"{_CMD}.create_content_block", return_value=mock.Mock()),
+        mock.patch(f"{_CMD}.save_video_block_with_edx_video_id"),
+    ):
+        call_command(
+            "generate_uai_course_versions",
+            processed_videos_csv=processed_videos_csv,
+            edx_videos_csv=edx_videos_csv,
+        )
+
+    delete_assets = store_mock.return_value.contentstore.delete_all_course_assets
+    assert delete_assets.call_count == EXPECTED_COURSE_COUNT
+
+    called_keys = {str(call.args[0]) for call in delete_assets.call_args_list}
+    assert called_keys == set(EXPECTED_NEW_COURSE_KEYS)
+
+
 def test_skips_introduction_when_course_intro_missing(tmp_path, mock_user):  # noqa: ARG001
     """If no intro resolves for a variant, no HTML intro block should be created."""
     processed_videos = tmp_path / "processed_videos.csv"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
 None

### Description (What does it do?)
<!--- Describe your changes in detail -->
We create uai custom courses by cloning the base UAI course like to create a short finance version of UAI.2, we clone UAI.2 and create UAI.2.S.F. The cloned course has the same course structure, settings, and static assets as the base course. We delete the course structure and generate new structure as per the CSV data. This resulted in dangling assets in the custom course. When we export the custom course for translations, it includes the dangling SRTs and we end up translating unnecessary SRTs. This PR deletes the assets from the custom course before creating the new structure.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Export UAI.2 from production https://studio.courses.learn.mit.edu/authoring/course/course-v1:UAI_SOURCE+UAI.2+1T2026
- Create a new course locally course-v1:UAI_SOURCE+UAI.102+1T2026 (Creating 102 just to keep it distinct)
- Import the UAI.2 TARGZ in the new course
- Install uai content customization plugin in CMS container.
- Restart cms
- Download the atttached CSVs in edx-platform base directory
- Open uai_edx_videos in editor
- Go to http://studio.local.openedx.io:8001/admin/edxval/videotranscript/
- Copy video ID of any 4 transcripts and replace it with the video ID in the uai_edx_videos for video files v005_h264.mp4, v006_h264.mp4, v009_h264.mp4, v010_h264.mp4
- Run command in cms shell `./manage.py cms generate_uai_course_versions --processed-videos-csv uai_processed_videos_module_2_3.csv --edx-videos-csv uai_edx_videos.csv --username edx`
- This will create 2 new courses UAI.102.S.F and UAI.102.S.E
- Export the new created courses and extract the TARGZ
- Verify that transcripts exist for only the video IDs we updated in the uai_edx_videos.csv in the static directory of the course TAR
[uai_edx_videos.csv](https://github.com/user-attachments/files/28999863/uai_edx_videos.csv)
[uai_processed_videos_module_2_3.csv](https://github.com/user-attachments/files/28999864/uai_processed_videos_module_2_3.csv)

