### PR TITLE
fix: canvas integration template path

### DIFF
--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/settings/lms/production.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/settings/lms/production.py
@@ -2,7 +2,7 @@
 
 from path import Path as path  # noqa: N813
 
-PLUGIN_TEMPLATES_ROOT = path(__file__).abspath().dirname().dirname()
+PLUGIN_TEMPLATES_ROOT = path(__file__).abspath().dirname().dirname().dirname()
 
 
 def plugin_settings(settings):

--- a/src/ol_openedx_canvas_integration/pyproject.toml
+++ b/src/ol_openedx_canvas_integration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-canvas-integration"
-version = "0.7.0"
+version = "0.7.1"
 description = "An Open edX plugin to add canvas integration support"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
None
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
In https://github.com/mitodl/open-edx-plugins/pull/788/ we moved the settings files inside the `lms/cms` directories, respectively, which broke the template path for the Canvas Integration tab in the instructor dashboard. This PR adds another level of directory in the path because of this file movement in the respective directories.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<img width="1040" height="605" alt="Screenshot 2026-06-17 at 4 25 14 PM" src="https://github.com/user-attachments/assets/dede63ef-f035-411d-8111-993910d41ec2" />

<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Make sure the `Canvas` tab shows in the Instructor Dashboard.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
