### PR TITLE
fix(chat): restore staff debug visibility on video units

### DIFF
--- a/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
@@ -1,8 +1,3 @@
-#app-root {
-    width: 450px;
-    height: 600px;
-}
-
 .problem-block-chat-button-container {
     display: flex;
     width: 100%;
@@ -21,15 +16,13 @@
         0 -40px 0 0 whitesmoke,
         0 10px 0 0 whitesmoke;
 }
+
 .ai-chat-button {
     all: unset;
     display: flex;
     flex-direction: row;
-    position: relative;
-    bottom: 70px;
     width: fit-content;
     cursor: pointer;
-    z-index: 1000;
     padding: 12px 24px;
     justify-content: center;
     align-items: center;
@@ -59,8 +52,6 @@
     }
 
     &.video-block-chat-button {
-        top: 0;
-
         p {
             line-height: 20px;
             margin-right: 20px;
@@ -88,24 +79,25 @@
     }
 }
 
+@media screen and (max-width: 1024px) {
+    .problem-block-chat-button-container {
+        margin-top: 12px;
+    }
+}
+
 @media screen and (max-width: 768px) {
     .video-block-chat-button-container,
     .problem-block-chat-button-container {
         justify-content: flex-start;
     }
 
-    .ai-chat-button {
-        top:0px;
-
-        &.video-block-chat-button {
-            margin-top: 10px;
-        }
+    .ai-chat-button.video-block-chat-button {
+        margin-top: 10px;
     }
 }
 
 @media screen and (max-width: 425px) {
     .ai-chat-button {
-        position: unset;
         margin-left: 0;
     }
 }
@@ -114,12 +106,23 @@
     margin: 0 0;
 }
 
-@media (min-width: 768px) {
-  .wrap-instructor-info {
+/* Keep transcript/download links above the AskTIM footer's upward box-shadow (learner view). */
+.xmodule_display.xmodule_VideoBlock {
+    position: relative;
+    z-index: 2;
+}
+
+.wrap-instructor-info {
     display: flex !important;
     flex-wrap: wrap;
+    justify-content: flex-start;
     gap: 10px;
     width: 100%;
     flex-shrink: 0;
-  }
+    position: relative;
+    z-index: 2;
+}
+
+.wrap-instructor-info .instructor-info-action {
+    float: none;
 }

--- a/src/ol_openedx_chat/pyproject.toml
+++ b/src/ol_openedx_chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat"
-version = "0.5.8"
+version = "0.5.9"
 description = "An Open edX plugin to add Open Learning AI chat aside to xBlocks"
 authors = [
   {name = "MIT Office of Digital Learning"}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11835

### Description (What does it do?)

- Removes AskTIM overlap hacks (`bottom: 70px`, `z-index: 1000`) that hid Staff Debug Info and transcript/download controls on video units
- Keeps the #803 vertical-only `whitesmoke` box-shadow band on the video footer (no change to the #10589 fix)
- Raises `.xmodule_VideoBlock` and `.wrap-instructor-info` above the AskTIM aside (`z-index: 2`) so learner download links and staff tools stay visible
- Applies PR #796 `.wrap-instructor-info` flex rules at all breakpoints (`justify-content: flex-start`, `float: none`) so problem submit / Show Answer no longer pushes staff buttons to the right
- Adds `margin-top: 12px` on `.problem-block-chat-button-container` at ≤1024px for tablet/iPad spacing after Submission History
- Removes unused `#app-root` CSS and redundant mobile position overrides left over from the old overlap hacks


### Screenshots (if appropriate):
Staff:
https://www.loom.com/share/efa828a9745945df9b51fe408266186e
Learner(Audit):
https://www.loom.com/share/e818d8054dcf4dbbbd7d96688a0dacb3

### How can this be tested?
To test this feature locally:

1. **Set up Tutor instance locally** as described in [this guide](https://docs.google.com/document/d/1kt_8VspC_SSU5zpmw8kyRQPWQaPtEbzTcDJeKYNBOfE/edit?tab=t.0)

2. **Mount frontend-app-learning locally**

3. **Enable AI Chatbot** by following the configuration steps in the [ol_openedx_chat plugin documentation](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat)
4. Install ol-openedx-chat from this branch.


## Test plan
- [ ] Video unit (staff): Staff Debug Info visible on the left, AskTIM on the right, grey footer band intact
- [ ] Video unit (learner): Download Text / transcript links not clipped by AskTIM footer
- [ ] Video unit (mobile): transcript/download links and staff tools not clipped
- [ ] Problem unit (staff): submit answer and open Show Answer — Staff Debug Info and Submission History stay left-aligned
- [ ] Problem unit (tablet ≤1024px): spacing between Submission History and AskTIM button
- [ ] Problem unit (learner): AskTIM button layout unchanged


Integration tests are failing due to missing django-autocomplete-light==4.0.1 on PyPI
