### PR TITLE
fix(ol-openedx-logging): move otel import to module level to avoid logging reentrancy loop

### DIFF
--- a/src/ol_openedx_logging/ol_openedx_logging/processors.py
+++ b/src/ol_openedx_logging/ol_openedx_logging/processors.py
@@ -21,6 +21,20 @@ _K8S_CONTEXT: dict[str, str] = {
     if v
 }
 
+# Import otel at module load time, not inside the processor.  Lazy imports
+# inside a structlog processor are unsafe: importing otel triggers a
+# DeprecationWarning from importlib.metadata, that warning re-enters the
+# logging system, which calls this processor again before the first import
+# completes, producing a recursive error loop.
+try:
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.trace.span import format_span_id as _format_span_id
+    from opentelemetry.trace.span import format_trace_id as _format_trace_id
+
+    _OTEL_AVAILABLE = True
+except ImportError:
+    _OTEL_AVAILABLE = False
+
 
 def inject_otel_context(
     _logger: Any,
@@ -32,30 +46,14 @@ def inject_otel_context(
     Skips injection when ``opentelemetry`` is not installed (soft dependency),
     when trace/span IDs are already present, or when there is no active
     recording span.
-
-    ``opentelemetry`` is imported lazily inside the function so that the plugin
-    can be installed in environments without the OTel SDK.  Python caches
-    modules after the first import, so the per-call overhead is negligible.
-
-    Performance notes:
-    - Fast-path on ``ImportError`` (otel not installed).
-    - Skips when trace_id/span_id already present (bound via contextvars).
-    - Checks ``is_valid`` before ``is_recording`` for the fastest invalid-
-      context short-circuit.
     """
+    if not _OTEL_AVAILABLE:
+        return event_dict
+
     if "trace_id" in event_dict and "span_id" in event_dict:
         return event_dict
 
-    try:
-        from opentelemetry import trace  # noqa: PLC0415
-        from opentelemetry.trace.span import (  # noqa: PLC0415
-            format_span_id,
-            format_trace_id,
-        )
-    except ImportError:
-        return event_dict
-
-    span = trace.get_current_span()
+    span = _otel_trace.get_current_span()
     ctx = span.get_span_context()
 
     if not ctx.is_valid:
@@ -63,8 +61,8 @@ def inject_otel_context(
     if not span.is_recording():
         return event_dict
 
-    event_dict["trace_id"] = format_trace_id(ctx.trace_id)
-    event_dict["span_id"] = format_span_id(ctx.span_id)
+    event_dict["trace_id"] = _format_trace_id(ctx.trace_id)
+    event_dict["span_id"] = _format_span_id(ctx.span_id)
     return event_dict
 
 

--- a/src/ol_openedx_logging/pyproject.toml
+++ b/src/ol_openedx_logging/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-logging"
-version = "0.3.0"
+version = "0.3.1"
 description = "An Open edX plugin to customize the logging configuration used by the edx-platform application"
 readme = "README.rst"
 authors = [{ name = "MIT Office of Digital Learning" }]

--- a/src/ol_openedx_logging/tests/test_processors.py
+++ b/src/ol_openedx_logging/tests/test_processors.py
@@ -74,19 +74,9 @@ class TestInjectOtelContext:
         assert result["trace_id"] == "aaa"
         assert result["span_id"] == "bbb"
 
-    def test_otel_import_error_returns_unchanged(self):
+    def test_otel_unavailable_returns_unchanged(self):
         """Returns event dict unchanged when opentelemetry is not installed."""
-        import builtins  # noqa: PLC0415
-
-        real_import = builtins.__import__
-        err_msg = "not installed"
-
-        def mock_import(name, *args, **kwargs):
-            if name.startswith("opentelemetry"):
-                raise ImportError(err_msg)
-            return real_import(name, *args, **kwargs)
-
-        with patch("builtins.__import__", side_effect=mock_import):
+        with patch("ol_openedx_logging.processors._OTEL_AVAILABLE", new=False):
             result = self._call({"event": "hello"})
 
         assert result == {"event": "hello"}


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes noisy recursive errors in `ol_openedx_logging` caused by lazily importing `opentelemetry` inside the `inject_otel_context` structlog processor.

**Root cause:** Importing `opentelemetry` during log record processing triggered a `DeprecationWarning` from `importlib.metadata` (deprecated `SelectableGroups` dict interface). That warning re-entered the Python logging system before the `opentelemetry` import completed, which called `inject_otel_context` again and attempted the same in-progress import — producing a recursive traceback.

**Fix:** Move the `opentelemetry` import to module level with an `_OTEL_AVAILABLE` flag for the soft-dependency case. Since `opentelemetry` is now imported once at startup (outside any log pipeline), the reentrancy path no longer exists. Updated the corresponding test to patch `_OTEL_AVAILABLE` directly rather than `builtins.__import__`.

Bumps `ol-openedx-logging` from `0.3.0` → `0.3.1`.

### How can this be tested?
Run the plugin's test suite:

```
cd src/ol_openedx_logging
uv run pytest tests/test_processors.py -v
```

All 7 tests should pass. To verify the fix in a live environment, install the plugin in an Open edX devstack and observe that the `DeprecationWarning` / recursive traceback no longer appears in the LMS logs during startup.

### Additional Context
The full traceback from the original error is reproduced below for reference. The loop enters at `inject_otel_context` → `from opentelemetry import trace` → `opentelemetry/context/__init__.py:_load_runtime_context()` → `importlib.metadata.values()` → `DeprecationWarning` → `logging._showwarning` → `inject_otel_context`.

```
File ".../ol_openedx_logging/processors.py", line 50, in inject_otel_context
    from opentelemetry import trace
  ...
  File ".../opentelemetry/context/__init__.py", line 36, in _load_runtime_context
    entry_points(...)
  File ".../importlib/metadata/__init__.py", line 463, in values
    self._warn()   # DeprecationWarning: SelectableGroups dict interface is deprecated
```