### PR TITLE
docs: update canvas integration docs

### DIFF
--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -60,7 +60,7 @@ Configuration
 
 **1) edx-platform configuration**
 
-- Add the following configuration values to the config file in Open edX. For any release after Juniper, that config file is ``/edx/etc/lms.yml``. If you're using ``private.py``, add these values to ``lms/envs/private.py``. These should be added to the top level. **Ask a fellow developer or devops for these values.**
+- Add the following configuration values to the config files in Open edX. For any release after Juniper, that config file is ``/edx/etc/lms.yml`` for LMS and ``/edx/etc/cms.yml`` for CMS. If you're using ``private.py``, add these values to ``lms/envs/private.py`` and ``cms/envs/private.py``. These should be added to the top level. **Ask a fellow developer or devops for these values.**
 
   .. code-block::
 


### PR DESCRIPTION
### What are the relevant tickets?
None
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Noticed this while helping Asad test Canvas integration. The Canvas API key and URL should also be defined in CMS as well.

This pull request updates the configuration instructions in the `README.rst` for the Open edX Canvas integration. The main change is to clarify that configuration values need to be added for both LMS and CMS, reflecting the correct locations for each.

Documentation update:

* Updated the configuration instructions to specify that configuration values should be added to both `lms.yml` and `cms.yml` (and their respective `private.py` files) for LMS and CMS, instead of just LMS. This ensures proper setup for both components.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
