### PR TITLE
feat: command to migrate v1 to v2 lib references

### DIFF
--- a/src/ol_openedx_course_sync/README.rst
+++ b/src/ol_openedx_course_sync/README.rst
@@ -48,6 +48,52 @@ Course Sync (CMS)
 * Target/rerun courses can be managed in the CMS admin model `CourseSyncMapping`.
 * Now, any changes made in the source course will be synced to the target courses.
 
+Legacy Library Migration (CMS)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The plugin provides a management command to migrate legacy (v1) ``library_content``
+blocks in course(s) to reference v2 library item bank blocks.
+
+**Command:** ``migrate_legacy_library_blocks_to_item_bank``
+
+**Syntax:**
+
+.. code-block:: bash
+
+    python manage.py cms migrate_legacy_library_blocks_to_item_bank [OPTIONS]
+
+**Options:**
+
+* ``--course-id COURSE_KEY``: Migrate legacy library content blocks for the given course key. Can be repeated to target multiple courses.
+* ``--all-source-courses``: Migrate legacy library content blocks for all source courses (i.e. all courses registered in the ``CourseSyncMapping`` admin model).
+* ``--persist-publish-state``: Re-publish migrated blocks that were already published prior to the migration.
+
+  * Exactly one of ``--course-id`` or ``--all-source-courses`` must be provided.
+  * Requires ``OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME`` to be configured; the migration task runs on behalf of this user.
+
+**Examples:**
+
+Migrate legacy library content blocks for two courses:
+
+.. code-block:: bash
+
+    python manage.py cms migrate_legacy_library_blocks_to_item_bank \
+        --course-id "course-v1:edX+DemoX.1+2014" \
+        --course-id "course-v1:edX+DemoX.2+2015"
+
+Migrate legacy library content blocks for all source courses:
+
+.. code-block:: bash
+
+    python manage.py cms migrate_legacy_library_blocks_to_item_bank --all-source-courses
+
+Migrate and also re-publish blocks that were already published before the migration:
+
+.. code-block:: bash
+
+    python manage.py cms migrate_legacy_library_blocks_to_item_bank --all-source-courses \
+        --persist-publish-state
+
 Problem Actions (LMS)
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/ol_openedx_course_sync/README.rst
+++ b/src/ol_openedx_course_sync/README.rst
@@ -64,11 +64,11 @@ blocks in course(s) to reference v2 library item bank blocks.
 
 **Options:**
 
-* ``--course-id COURSE_KEY``: Migrate legacy library content blocks for the given course key. Can be repeated to target multiple courses.
+* ``--course-ids COURSE_KEYS``: Migrate legacy library content blocks for the given comma-separated list of course keys.
 * ``--all-source-courses``: Migrate legacy library content blocks for all source courses (i.e. all courses registered in the ``CourseSyncMapping`` admin model).
 * ``--persist-publish-state``: Re-publish migrated blocks that were already published prior to the migration.
 
-  * Exactly one of ``--course-id`` or ``--all-source-courses`` must be provided.
+  * Exactly one of ``--course-ids`` or ``--all-source-courses`` must be provided.
   * Requires ``OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME`` to be configured; the migration task runs on behalf of this user.
 
 **Examples:**
@@ -78,8 +78,7 @@ Migrate legacy library content blocks for two courses:
 .. code-block:: bash
 
     python manage.py cms migrate_legacy_library_blocks_to_item_bank \
-        --course-id "course-v1:edX+DemoX.1+2014" \
-        --course-id "course-v1:edX+DemoX.2+2015"
+        --course-ids "course-v1:edX+DemoX.1+2014,course-v1:edX+DemoX.2+2015"
 
 Migrate legacy library content blocks for all source courses:
 

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -90,12 +90,12 @@ class Command(BaseCommand):
 
         if not course_ids and not all_source_courses:
             error_msg = (
-                "Either --course-ids or --all-courses argument should be provided."
+                "Either --course-ids or --all-source-courses argument should be provided."
             )
             raise CommandError(error_msg)
         if all_source_courses and course_ids:
             error_msg = (
-                "Only one of --course-ids or --all-courses argument should be provided."
+                "Only one of --course-ids or --all-source-courses argument should be provided."
             )
             raise CommandError(error_msg)
 
@@ -105,13 +105,16 @@ class Command(BaseCommand):
         ):
             error_msg = (
                 "OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME is not set. "
-                "Course sync will not be performed."
+                "Legacy library migration will not be performed."
             )
             raise CommandError(error_msg)
 
+        course_keys = get_all_source_courses() if all_source_courses else course_ids
+        if not course_keys:
+            log.info("No source courses found for migration. Nothing to do.")
+            return
         user = get_course_sync_service_user()
         store = modulestore()
-        course_keys = get_all_source_courses() if all_source_courses else course_ids
         for course_key in course_keys:
             try:
                 parsed_course_key = CourseKey.from_string(str(course_key))

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -17,6 +17,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
 
 from ol_openedx_course_sync.utils import (
     get_all_source_courses,
@@ -34,15 +35,24 @@ class Command(BaseCommand):
     Examples:
         # Migrate legacy library content blocks for two courses.
         $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank
-        --course-id course-v1:edX+DemoX.1+2014 --course-id course-v1:edX+DemoX.2+2015
+        --course-ids course-v1:edX+DemoX.1+2014,course-v1:edX+DemoX.2+2015
 
         # Migrate legacy library content blocks for all source courses.
-        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank --all-courses
+        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank all-source-courses
 
         # Also re-publish blocks that were already published before the migration.
-        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank --all-courses \
-        --persist-publish-state
+        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank \
+        --all-source-courses --persist-publish-state
     """
+
+    @staticmethod
+    def _parse_course_ids(value):
+        """
+        Parse a comma-separated list of course keys into a list of strings.
+        """
+        return [
+            course_id.strip() for course_id in value.split(",") if course_id.strip()
+        ]
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -51,14 +61,14 @@ class Command(BaseCommand):
             help=_("Migrate legacy library content blocks for all source courses."),
         )
         parser.add_argument(
-            "--course-id",
-            metavar=_("COURSE_KEY"),
-            action="append",
+            "--course-ids",
+            metavar=_("COURSE_KEYS"),
             dest="course_ids",
             default=[],
+            type=self._parse_course_ids,
             help=_(
                 "Migrate legacy library content blocks for the "
-                "given course key. Can be repeated."
+                "given comma-separated list of course keys."
             ),
         )
         parser.add_argument(
@@ -80,12 +90,12 @@ class Command(BaseCommand):
 
         if not course_ids and not all_source_courses:
             error_msg = (
-                "Either --course-id or --all-courses argument should be provided."
+                "Either --course-ids or --all-courses argument should be provided."
             )
             raise CommandError(error_msg)
         if all_source_courses and course_ids:
             error_msg = (
-                "Only one of --course-id or --all-courses argument should be provided."
+                "Only one of --course-ids or --all-courses argument should be provided."
             )
             raise CommandError(error_msg)
 
@@ -100,13 +110,18 @@ class Command(BaseCommand):
             raise CommandError(error_msg)
 
         user = get_course_sync_service_user()
+        store = modulestore()
         course_keys = get_all_source_courses() if all_source_courses else course_ids
         for course_key in course_keys:
             try:
-                CourseKey.from_string(str(course_key))
+                parsed_course_key = CourseKey.from_string(str(course_key))
             except InvalidKeyError:
                 error_msg = f"Invalid course key: {course_key}, skipping.."
                 log.error(error_msg)  # noqa: TRY400
+                continue
+            if not store.has_course(parsed_course_key):
+                error_msg = f"Course not found: {course_key}, skipping.."
+                log.error(error_msg)
                 continue
             msg = (
                 f"Queuing legacy library content block "

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -102,7 +102,7 @@ class Command(BaseCommand):
             raise CommandError(error_msg)
 
         user = get_course_sync_service_user()
-        if user:
+        if not user:
             error_msg = (
                 "OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME is not set. "
                 "Legacy library migration will not be performed."

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         --course-ids course-v1:edX+DemoX.1+2014,course-v1:edX+DemoX.2+2015
 
         # Migrate legacy library content blocks for all source courses.
-        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank all-source-courses
+        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank --all-source-courses
 
         # Also re-publish blocks that were already published before the migration.
         $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank \

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -1,0 +1,120 @@
+"""
+Management command to migrate legacy (v1) library_content blocks in course(s)
+to reference v2 library item bank blocks.
+
+This command can be run for all the source courses or for a given list of courses.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cms.djangoapps.contentstore.tasks import (
+    migrate_course_legacy_library_blocks_to_item_bank,
+)
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import gettext as _
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from ol_openedx_course_sync.utils import (
+    get_all_source_courses,
+    get_course_sync_service_user,
+)
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Migrate legacy library_content blocks in course(s) to reference v2 library
+    item bank blocks.
+
+    Examples:
+        # Migrate legacy library content blocks for two courses.
+        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank
+        --course-id course-v1:edX+DemoX.1+2014 --course-id course-v1:edX+DemoX.2+2015
+
+        # Migrate legacy library content blocks for all source courses.
+        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank --all-courses
+
+        # Also re-publish blocks that were already published before the migration.
+        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank --all-courses \
+        --publish-if-was-published
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--all-source-courses",
+            action="store_true",
+            help=_("Migrate legacy library content blocks for all source courses."),
+        )
+        parser.add_argument(
+            "--course-id",
+            metavar=_("COURSE_KEY"),
+            action="append",
+            dest="course_ids",
+            default=[],
+            help=_(
+                "Migrate legacy library content blocks for the "
+                "given course key. Can be repeated."
+            ),
+        )
+        parser.add_argument(
+            "--publish-if-was-published",
+            action="store_true",
+            help=_(
+                "Re-publish migrated blocks that were already "
+                "published prior to the migration."
+            ),
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """
+        Handle command
+        """
+        all_source_courses = options["all_source_courses"]
+        course_ids = options["course_ids"]
+        publish_if_was_published = options["publish_if_was_published"]
+
+        if not course_ids and not all_source_courses:
+            error_msg = (
+                "Either --course-id or --all-courses argument should be provided."
+            )
+            raise CommandError(error_msg)
+        if all_source_courses and course_ids:
+            error_msg = (
+                "Only one of --course-id or --all-courses argument should be provided."
+            )
+            raise CommandError(error_msg)
+
+        # Check if service worker username is configured
+        if not getattr(
+            settings, "OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME", None
+        ):
+            error_msg = (
+                "OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME is not set. "
+                "Course sync will not be performed."
+            )
+            raise CommandError(error_msg)
+
+        user = get_course_sync_service_user()
+        course_keys = get_all_source_courses() if all_source_courses else course_ids
+        for course_key in course_keys:
+            try:
+                CourseKey.from_string(str(course_key))
+            except InvalidKeyError:
+                error_msg = f"Invalid course key: {course_key}, skipping.."
+                log.error(error_msg)  # noqa: TRY400
+                continue
+            msg = (
+                f"Queuing legacy library content block "
+                f"migration for course: {course_key}"
+            )
+            log.info(msg)
+            migrate_course_legacy_library_blocks_to_item_bank.delay(
+                user.id,
+                str(course_key),
+                publish_if_was_published,
+            )

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -12,7 +12,6 @@ import logging
 from cms.djangoapps.contentstore.tasks import (
     migrate_course_legacy_library_blocks_to_item_bank,
 )
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext as _
 from opaque_keys import InvalidKeyError
@@ -102,10 +101,8 @@ class Command(BaseCommand):
             )
             raise CommandError(error_msg)
 
-        # Check if service worker username is configured
-        if not getattr(
-            settings, "OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME", None
-        ):
+        user = get_course_sync_service_user()
+        if user:
             error_msg = (
                 "OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME is not set. "
                 "Legacy library migration will not be performed."
@@ -116,7 +113,7 @@ class Command(BaseCommand):
         if not course_keys:
             log.info("No source courses found for migration. Nothing to do.")
             return
-        user = get_course_sync_service_user()
+
         store = modulestore()
         for course_key in course_keys:
             try:

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
 
         # Also re-publish blocks that were already published before the migration.
         $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank --all-courses \
-        --publish-if-was-published
+        --persist-publish-state
     """
 
     def add_arguments(self, parser):
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
-            "--publish-if-was-published",
+            "--persist-publish-state",
             action="store_true",
             help=_(
                 "Re-publish migrated blocks that were already "
@@ -76,7 +76,7 @@ class Command(BaseCommand):
         """
         all_source_courses = options["all_source_courses"]
         course_ids = options["course_ids"]
-        publish_if_was_published = options["publish_if_was_published"]
+        persist_publish_state = options["persist_publish_state"]
 
         if not course_ids and not all_source_courses:
             error_msg = (
@@ -116,5 +116,5 @@ class Command(BaseCommand):
             migrate_course_legacy_library_blocks_to_item_bank.delay(
                 user.id,
                 str(course_key),
-                publish_if_was_published,
+                persist_publish_state,
             )

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/management/commands/migrate_legacy_library_blocks_to_item_bank.py
@@ -38,7 +38,8 @@ class Command(BaseCommand):
         --course-ids course-v1:edX+DemoX.1+2014,course-v1:edX+DemoX.2+2015
 
         # Migrate legacy library content blocks for all source courses.
-        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank --all-source-courses
+        $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank \
+        --all-source-courses
 
         # Also re-publish blocks that were already published before the migration.
         $ ./manage.py cms migrate_legacy_library_blocks_to_item_bank \
@@ -90,12 +91,14 @@ class Command(BaseCommand):
 
         if not course_ids and not all_source_courses:
             error_msg = (
-                "Either --course-ids or --all-source-courses argument should be provided."
+                "Either --course-ids or --all-source-courses "
+                "argument should be provided."
             )
             raise CommandError(error_msg)
         if all_source_courses and course_ids:
             error_msg = (
-                "Only one of --course-ids or --all-source-courses argument should be provided."
+                "Only one of --course-ids or --all-source-courses "
+                "argument should be provided."
             )
             raise CommandError(error_msg)
 

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/utils.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/utils.py
@@ -383,12 +383,13 @@ def get_all_source_courses():
     Get all source courses for which sync is enabled.
 
     Returns:
-        Queryset: QuerySet of CourseSyncMapping or None
+        list: Distinct list of active source course keys, or
+        None if no active mappings exist.
     """
     # Get active course sync mappings
     course_sync_mappings = CourseSyncMapping.objects.filter(is_active=True)
     if not course_sync_mappings:
-        log.info("No active course sync mappings found. Skipping sync.")
+        log.info("No active course sync mappings found.")
         return None
 
     return list(course_sync_mappings.values_list("source_course", flat=True).distinct())

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/utils.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/utils.py
@@ -376,3 +376,19 @@ def get_syncable_course_mappings(course_key):
         return None
 
     return course_sync_mappings
+
+
+def get_all_source_courses():
+    """
+    Get all source courses for which sync is enabled.
+
+    Returns:
+        Queryset: QuerySet of CourseSyncMapping or None
+    """
+    # Get active course sync mappings
+    course_sync_mappings = CourseSyncMapping.objects.filter(is_active=True)
+    if not course_sync_mappings:
+        log.info("No active course sync mappings found. Skipping sync.")
+        return None
+
+    return list(course_sync_mappings.values_list("source_course", flat=True).distinct())

--- a/src/ol_openedx_course_sync/ol_openedx_course_sync/utils.py
+++ b/src/ol_openedx_course_sync/ol_openedx_course_sync/utils.py
@@ -386,10 +386,13 @@ def get_all_source_courses():
         list: Distinct list of active source course keys, or
         None if no active mappings exist.
     """
-    # Get active course sync mappings
-    course_sync_mappings = CourseSyncMapping.objects.filter(is_active=True)
-    if not course_sync_mappings:
+    source_courses_qs = (
+        CourseSyncMapping.objects.filter(is_active=True)
+        .values_list("source_course", flat=True)
+        .distinct()
+    )
+    if not source_courses_qs.exists():
         log.info("No active course sync mappings found.")
         return None
 
-    return list(course_sync_mappings.values_list("source_course", flat=True).distinct())
+    return list(source_courses_qs)

--- a/src/ol_openedx_course_sync/pyproject.toml
+++ b/src/ol_openedx_course_sync/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-sync"
-version = "1.0.0"
+version = "1.0.1"
 description = "An Open edX plugin to sync course changes to its reruns."
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_course_sync/tests/test_migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/tests/test_migrate_legacy_library_blocks_to_item_bank.py
@@ -46,7 +46,7 @@ class TestMigrateLegacyLibraryBlocksToItemBank:
         with pytest.raises(
             CommandError,
             match=re.escape(
-                "Either --course-ids or --all-courses argument should be provided."
+                "Either --course-ids or --all-source-courses argument should be provided."
             ),
         ):
             call_command(COMMAND_NAME)
@@ -59,7 +59,7 @@ class TestMigrateLegacyLibraryBlocksToItemBank:
         with pytest.raises(
             CommandError,
             match=re.escape(
-                "Only one of --course-ids or --all-courses argument should be provided."
+                "Only one of --course-ids or --all-source-courses argument should be provided."
             ),
         ):
             call_command(

--- a/src/ol_openedx_course_sync/tests/test_migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/tests/test_migrate_legacy_library_blocks_to_item_bank.py
@@ -1,0 +1,266 @@
+"""
+Tests for the migrate_legacy_library_blocks_to_item_bank management command.
+"""
+
+import re
+from unittest import mock
+
+import pytest
+from common.djangoapps.student.tests.factories import UserFactory
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import override_settings
+from openedx.core.djangolib.testing.utils import skip_unless_cms
+
+COMMAND_NAME = "migrate_legacy_library_blocks_to_item_bank"
+COMMAND_MODULE = (
+    "ol_openedx_course_sync.management.commands."
+    "migrate_legacy_library_blocks_to_item_bank"
+)
+
+
+def _mock_modulestore(*, existing_course_keys=()):
+    """
+    Return a mock for the ``modulestore`` callable imported by the command.
+
+    ``has_course`` reports True only for keys in ``existing_course_keys``.
+    """
+    existing = {str(key) for key in existing_course_keys}
+    store = mock.Mock()
+    store.has_course.side_effect = lambda key: str(key) in existing
+    return mock.Mock(return_value=store)
+
+
+@skip_unless_cms
+@pytest.mark.django_db
+class TestMigrateLegacyLibraryBlocksToItemBank:
+    """
+    Tests for the migrate_legacy_library_blocks_to_item_bank command.
+    """
+
+    def test_requires_course_ids_or_all_source_courses(self):
+        """
+        Command should fail if neither --course-ids nor --all-source-courses
+        is provided.
+        """
+        with pytest.raises(
+            CommandError,
+            match=re.escape(
+                "Either --course-ids or --all-courses argument should be provided."
+            ),
+        ):
+            call_command(COMMAND_NAME)
+
+    def test_mutually_exclusive_course_ids_and_all_source_courses(self):
+        """
+        Command should fail if both --course-ids and --all-source-courses
+        are provided.
+        """
+        with pytest.raises(
+            CommandError,
+            match=re.escape(
+                "Only one of --course-ids or --all-courses argument should be provided."
+            ),
+        ):
+            call_command(
+                COMMAND_NAME,
+                "--course-ids",
+                "course-v1:edX+DemoX.1+2014",
+                "--all-source-courses",
+            )
+
+    def test_missing_service_worker_username_setting(self):
+        """
+        Command should fail if OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME
+        is not configured.
+        """
+        with (
+            override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME=None),
+            pytest.raises(
+                CommandError,
+                match=re.escape(
+                    "OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME is not set."
+                ),
+            ),
+        ):
+            call_command(COMMAND_NAME, "--course-ids", "course-v1:edX+DemoX.1+2014")
+
+    @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
+    def test_comma_separated_course_ids_are_queued(self):
+        """
+        A comma-separated --course-ids value should be split and each course
+        key should be queued for migration.
+        """
+        user = UserFactory.create(username="service_worker")
+        with (
+            mock.patch(
+                f"{COMMAND_MODULE}.modulestore",
+                _mock_modulestore(
+                    existing_course_keys=[
+                        "course-v1:edX+DemoX.1+2014",
+                        "course-v1:edX+DemoX.2+2015",
+                    ]
+                ),
+            ),
+            mock.patch(
+                f"{COMMAND_MODULE}.migrate_course_legacy_library_blocks_to_item_bank"
+            ) as mock_migrate_task,
+        ):
+            call_command(
+                COMMAND_NAME,
+                "--course-ids",
+                "course-v1:edX+DemoX.1+2014,course-v1:edX+DemoX.2+2015",
+            )
+
+        not_persisted = False
+        mock_migrate_task.delay.assert_has_calls(
+            [
+                mock.call(user.id, "course-v1:edX+DemoX.1+2014", not_persisted),
+                mock.call(user.id, "course-v1:edX+DemoX.2+2015", not_persisted),
+            ]
+        )
+        expected_call_count = 2
+        assert mock_migrate_task.delay.call_count == expected_call_count
+
+    @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
+    def test_course_ids_with_surrounding_whitespace_are_stripped(self):
+        """
+        Whitespace around comma-separated course keys should be stripped.
+        """
+        user = UserFactory.create(username="service_worker")
+        with (
+            mock.patch(
+                f"{COMMAND_MODULE}.modulestore",
+                _mock_modulestore(
+                    existing_course_keys=[
+                        "course-v1:edX+DemoX.1+2014",
+                        "course-v1:edX+DemoX.2+2015",
+                    ]
+                ),
+            ),
+            mock.patch(
+                f"{COMMAND_MODULE}.migrate_course_legacy_library_blocks_to_item_bank"
+            ) as mock_migrate_task,
+        ):
+            call_command(
+                COMMAND_NAME,
+                "--course-ids",
+                " course-v1:edX+DemoX.1+2014 , course-v1:edX+DemoX.2+2015 ",
+            )
+
+        not_persisted = False
+        mock_migrate_task.delay.assert_has_calls(
+            [
+                mock.call(user.id, "course-v1:edX+DemoX.1+2014", not_persisted),
+                mock.call(user.id, "course-v1:edX+DemoX.2+2015", not_persisted),
+            ]
+        )
+
+    @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
+    def test_invalid_course_key_is_skipped(self):
+        """
+        An invalid course key in --course-ids should be skipped, and valid
+        course keys should still be queued.
+        """
+        user = UserFactory.create(username="service_worker")
+        with (
+            mock.patch(
+                f"{COMMAND_MODULE}.modulestore",
+                _mock_modulestore(existing_course_keys=["course-v1:edX+DemoX.1+2014"]),
+            ),
+            mock.patch(
+                f"{COMMAND_MODULE}.migrate_course_legacy_library_blocks_to_item_bank"
+            ) as mock_migrate_task,
+        ):
+            call_command(
+                COMMAND_NAME,
+                "--course-ids",
+                "not-a-valid-course-key,course-v1:edX+DemoX.1+2014",
+            )
+
+        not_persisted = False
+        mock_migrate_task.delay.assert_called_once_with(
+            user.id, "course-v1:edX+DemoX.1+2014", not_persisted
+        )
+
+    @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
+    def test_course_not_in_modulestore_is_skipped(self):
+        """
+        A course key that parses but does not exist in the modulestore
+        should be skipped, and remaining valid course keys should still be
+        queued.
+        """
+        user = UserFactory.create(username="service_worker")
+        with (
+            mock.patch(
+                f"{COMMAND_MODULE}.modulestore",
+                _mock_modulestore(existing_course_keys=["course-v1:edX+DemoX.2+2015"]),
+            ),
+            mock.patch(
+                f"{COMMAND_MODULE}.migrate_course_legacy_library_blocks_to_item_bank"
+            ) as mock_migrate_task,
+        ):
+            call_command(
+                COMMAND_NAME,
+                "--course-ids",
+                "course-v1:edX+DemoX.1+2014,course-v1:edX+DemoX.2+2015",
+            )
+
+        not_persisted = False
+        mock_migrate_task.delay.assert_called_once_with(
+            user.id, "course-v1:edX+DemoX.2+2015", not_persisted
+        )
+
+    @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
+    def test_all_source_courses_uses_get_all_source_courses(self):
+        """
+        --all-source-courses should queue migration for every course
+        returned by get_all_source_courses.
+        """
+        user = UserFactory.create(username="service_worker")
+        with (
+            mock.patch(
+                f"{COMMAND_MODULE}.get_all_source_courses",
+                return_value=["course-v1:edX+DemoX.1+2014"],
+            ),
+            mock.patch(
+                f"{COMMAND_MODULE}.modulestore",
+                _mock_modulestore(existing_course_keys=["course-v1:edX+DemoX.1+2014"]),
+            ),
+            mock.patch(
+                f"{COMMAND_MODULE}.migrate_course_legacy_library_blocks_to_item_bank"
+            ) as mock_migrate_task,
+        ):
+            call_command(COMMAND_NAME, "--all-source-courses")
+
+        not_persisted = False
+        mock_migrate_task.delay.assert_called_once_with(
+            user.id, "course-v1:edX+DemoX.1+2014", not_persisted
+        )
+
+    @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
+    def test_persist_publish_state_flag_is_forwarded(self):
+        """
+        --persist-publish-state should be forwarded to the migration task.
+        """
+        user = UserFactory.create(username="service_worker")
+        with (
+            mock.patch(
+                f"{COMMAND_MODULE}.modulestore",
+                _mock_modulestore(existing_course_keys=["course-v1:edX+DemoX.1+2014"]),
+            ),
+            mock.patch(
+                f"{COMMAND_MODULE}.migrate_course_legacy_library_blocks_to_item_bank"
+            ) as mock_migrate_task,
+        ):
+            call_command(
+                COMMAND_NAME,
+                "--course-ids",
+                "course-v1:edX+DemoX.1+2014",
+                "--persist-publish-state",
+            )
+
+        persisted = True
+        mock_migrate_task.delay.assert_called_once_with(
+            user.id, "course-v1:edX+DemoX.1+2014", persisted
+        )

--- a/src/ol_openedx_course_sync/tests/test_migrate_legacy_library_blocks_to_item_bank.py
+++ b/src/ol_openedx_course_sync/tests/test_migrate_legacy_library_blocks_to_item_bank.py
@@ -46,7 +46,8 @@ class TestMigrateLegacyLibraryBlocksToItemBank:
         with pytest.raises(
             CommandError,
             match=re.escape(
-                "Either --course-ids or --all-source-courses argument should be provided."
+                "Either --course-ids or --all-source-courses "
+                "argument should be provided."
             ),
         ):
             call_command(COMMAND_NAME)
@@ -59,7 +60,8 @@ class TestMigrateLegacyLibraryBlocksToItemBank:
         with pytest.raises(
             CommandError,
             match=re.escape(
-                "Only one of --course-ids or --all-source-courses argument should be provided."
+                "Only one of --course-ids or --all-source-courses "
+                "argument should be provided."
             ),
         ):
             call_command(

--- a/src/ol_openedx_course_sync/tests/test_utils.py
+++ b/src/ol_openedx_course_sync/tests/test_utils.py
@@ -21,6 +21,7 @@ from ol_openedx_course_sync.models import (
 from ol_openedx_course_sync.utils import (
     copy_course_content,
     copy_static_tabs,
+    get_all_source_courses,
     get_course_sync_service_user,
     get_syncable_course_mappings,
     sync_course_handouts,
@@ -39,7 +40,7 @@ from xmodule.html_block import CourseInfoBlock
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
-from xmodule.modulestore.tests.factories import BlockFactory
+from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 from xmodule.tabs import StaticTab
 
 from tests.utils import OLOpenedXCourseSyncTestCase
@@ -415,6 +416,66 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
                 assert actual_sync_mappings is None
             else:
                 assert actual_sync_mappings.count() == expected_sync_mappings_count
+
+    @skip_unless_cms
+    def test_get_all_source_courses_no_mappings(self):
+        """
+        Test get_all_source_courses returns None when no mappings exist.
+        """
+        assert get_all_source_courses() is None
+
+    @skip_unless_cms
+    def test_get_all_source_courses_no_active_mappings(self):
+        """
+        Test get_all_source_courses returns None when no mapping is active.
+        """
+        source_key = self.source_course.usage_key.course_key
+        target_key = self.target_course.usage_key.course_key
+        CourseOverviewFactory.create(id=source_key)
+        CourseOverviewFactory.create(id=target_key)
+        CourseSyncMapping.objects.create(
+            source_course=source_key, target_course=target_key, is_active=False
+        )
+
+        assert get_all_source_courses() is None
+
+    @skip_unless_cms
+    def test_get_all_source_courses_returns_distinct_active_sources(self):
+        """
+        Test get_all_source_courses returns a distinct list of the active
+        source courses, ignoring inactive mappings and duplicate sources.
+        """
+        source_1 = self.source_course.usage_key.course_key
+        source_2 = self.target_course.usage_key.course_key
+        target_1 = CourseFactory.create(
+            default_store=ModuleStoreEnum.Type.split
+        ).usage_key.course_key
+        target_2 = CourseFactory.create(
+            default_store=ModuleStoreEnum.Type.split
+        ).usage_key.course_key
+        target_3 = CourseFactory.create(
+            default_store=ModuleStoreEnum.Type.split
+        ).usage_key.course_key
+
+        for course_key in (source_1, source_2, target_1, target_2, target_3):
+            CourseOverviewFactory.create(id=course_key)
+
+        # Two active mappings sharing the same source course.
+        CourseSyncMapping.objects.create(
+            source_course=source_1, target_course=target_1, is_active=True
+        )
+        CourseSyncMapping.objects.create(
+            source_course=source_1, target_course=target_2, is_active=True
+        )
+        # Another active mapping with a different source course.
+        CourseSyncMapping.objects.create(
+            source_course=source_2, target_course=target_3, is_active=True
+        )
+
+        result = get_all_source_courses()
+
+        assert set(result) == {source_1, source_2}
+        assert len(result) == 2  # noqa: PLR2004
 
     @data(
         # Test case: assets match completely


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/12148

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a command to update v1 library references to v2 library

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup plugin by following the readme.
- Checkout `asad/v1-v2-lib-migration-fixes-and-command` for edx-platform branch
- Create source and target courses and make sure the mapping exists.
- Create legacy library content in source course and publish it. Verify it exists in target course.
- Run the command `./manage.py cms migrate_legacy_library_blocks_to_item_bank --course-ids <SOURCE_COURSE_ID> --persist-publish-state`
- Verify the block is updated to V2 in both child and source course and published with --persist-publish-state flag.