### PR TITLE
fix: skip canvas due date overrides missing due_at during sync

### DIFF
--- a/src/ol_openedx_canvas_integration/CHANGELOG.rst
+++ b/src/ol_openedx_canvas_integration/CHANGELOG.rst
@@ -13,6 +13,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.8.2] - 2026-07-13
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fixed
+-----
+* Due date sync no longer crashes with ``TypeError: fromisoformat: argument must
+  be str`` when a Canvas assignment override sets only an "Until" date (``lock_at``)
+  with no "Due" date. Such overrides have ``due_at: None`` and are now skipped
+  instead of being passed to ``parse_datetime``.
+
 [0.8.1] - 2026-07-03
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/cms_tasks.py
@@ -252,6 +252,10 @@ def sync_canvas_due_date_extensions(client, course, block, overrides):
     canvas_course_id = get_canvas_course_id(course)
     for override in overrides:
         if "student_ids" in override:
+            if not override.get("due_at"):
+                # The override only sets an "Until" date (lock_at) with no
+                # "Due" date, so there is no due date extension to sync.
+                continue
             emails = client.get_emails_by_student_ids(override["student_ids"])
             students = User.objects.filter(email__in=emails)
             for student in students:

--- a/src/ol_openedx_canvas_integration/pyproject.toml
+++ b/src/ol_openedx_canvas_integration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-canvas-integration"
-version = "0.8.1"
+version = "0.8.2"
 description = "An Open edX plugin to add canvas integration support"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_canvas_integration/tests/test_cms_tasks.py
+++ b/src/ol_openedx_canvas_integration/tests/test_cms_tasks.py
@@ -292,6 +292,54 @@ class CanvasDueDateSyncTests(ModuleStoreTestCase):
                         reason="Synced from canvas course: 11",
                     )
 
+    def test_sync_canvas_due_date_extensions_with_only_until_date(self):
+        """
+        A Canvas override that sets only an "Until" date (lock_at) and no "Due"
+        date has `due_at: None`. Syncing such an override must not raise.
+        """
+        for uid in [1, 4]:
+            UserFactory.create(username=f"user{uid}", email=f"user{uid}@abc.xyz")
+        course, sequentials = self.create_course(
+            {
+                "canvas_id": 11,
+                "use_canvas_due_dates": True,
+            }
+        )
+
+        student_ids = [1, 4]
+
+        mock_canvas_assignments = {
+            str(sequentials[0].location): {
+                "due_at": None,
+                "overrides": [
+                    {
+                        "due_at": None,
+                        "lock_at": "2026-06-02T00:00:00Z",
+                        "student_ids": student_ids,
+                    }
+                ],
+            },
+        }
+
+        canvas_client_mock = MagicMock()
+        canvas_client_mock.get_canvas_assignments.return_value = mock_canvas_assignments
+        canvas_client_mock.get_emails_by_student_ids.side_effect = lambda ids: [
+            f"user{uid}@abc.xyz" for uid in ids
+        ]
+
+        with (
+            patch(
+                "ol_openedx_canvas_integration.cms_tasks.CanvasClient",
+                return_value=canvas_client_mock,
+            ),
+            patch(
+                "ol_openedx_canvas_integration.cms_tasks.set_due_date_extension"
+            ) as set_due_date_extension_mock,
+        ):
+            _sync_canvas_due_dates(str(course.id))
+
+        set_due_date_extension_mock.assert_not_called()
+
     def test_sync_canvas_due_dates_for_all_courses_enqueues_each_course(self):
         course_1, _ = self.create_course()
         course_2, _ = self.create_course()


### PR DESCRIPTION
When a Canvas assignment override only sets an "Until" date (lock_at) with no "Due" date, Canvas returns that override with due_at: None. parse_datetime(None) raises TypeError, crashing sync_canvas_due_dates for the whole block.

### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12282
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)

This pull request addresses a bug in the due date synchronization logic for Canvas assignment overrides that only set an "Until" date (`lock_at`) and have no "Due" date (`due_at`). The change prevents a `TypeError` and ensures that such overrides are safely skipped during sync. The update also includes a new test to verify this behavior and bumps the package version.

**Bug Fixes:**
* Updated `sync_canvas_due_date_extensions` to skip processing Canvas assignment overrides where `due_at` is `None`, preventing a `TypeError` when only an "Until" date is set (`lock_at`) and no "Due" date is present.

**Testing Improvements:**
* Added a test case `test_sync_canvas_due_date_extensions_with_only_until_date` to ensure that overrides with only a "lock_at" date and no "due_at" do not trigger errors or due date extensions.

**Documentation and Versioning:**
* Updated the `CHANGELOG.rst` with a new entry for version 0.8.2, describing the fix for the due date sync crash.
* Bumped the package version to `0.8.2` in `pyproject.toml`.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Set up a course with Canvas
- Sync your edX course assignment(s) with Canvas
- In Canvas, mark those assignments Published
- In Canvas, click on assignment settings and update the deadline for a user - NOTE: Don't set the `due` date -> Set the `Until` date
- Open Django Shell and run the `sync_canvas_due_dates(course_id="course-v1:ORG+Course+Run")` manually in shell and you should be able to repro this issue and then test on this PR.

<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
