### PR TITLE
feat(ol_openedx_uai_content_customization): add gsheet link support

### DIFF
--- a/src/ol_openedx_uai_content_customization/CHANGELOG.rst
+++ b/src/ol_openedx_uai_content_customization/CHANGELOG.rst
@@ -9,7 +9,16 @@ Added
 - ``--processed-videos-csv`` now also accepts the URL of a publicly readable
   Google Sheet (share/edit link, or a direct CSV export link) in addition to
   a local file path, so the sheet can be read directly instead of manually
-  downloading a CSV first.
+  downloading a CSV first. Only ``docs.google.com`` links are rewritten to
+  their CSV export form; other URLs are fetched as-is and must already
+  resolve to CSV content.
+
+Fixed
+~~~~~
+- Failures reading the processed videos source (missing/unreadable local
+  file, network error, or an unparsable Google Sheets URL) now consistently
+  raise ``CommandError`` instead of letting a raw ``OSError`` traceback
+  through.
 
 [0.2.0] - 2026-07-07
 ---------------------

--- a/src/ol_openedx_uai_content_customization/CHANGELOG.rst
+++ b/src/ol_openedx_uai_content_customization/CHANGELOG.rst
@@ -9,9 +9,8 @@ Added
 - ``--processed-videos-csv`` now also accepts the URL of a publicly readable
   Google Sheet (share/edit link, or a direct CSV export link) in addition to
   a local file path, so the sheet can be read directly instead of manually
-  downloading a CSV first. Only ``docs.google.com`` links are rewritten to
-  their CSV export form; other URLs are fetched as-is and must already
-  resolve to CSV content.
+  downloading a CSV first. Only ``docs.google.com`` Google Sheets links are
+  supported; any other http(s) URL is rejected with an error.
 
 Fixed
 ~~~~~

--- a/src/ol_openedx_uai_content_customization/CHANGELOG.rst
+++ b/src/ol_openedx_uai_content_customization/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+[0.3.0] - 2026-07-24
+---------------------
+
+Added
+~~~~~
+- ``--processed-videos-csv`` now also accepts the URL of a publicly readable
+  Google Sheet (share/edit link, or a direct CSV export link) in addition to
+  a local file path, so the sheet can be read directly instead of manually
+  downloading a CSV first.
+
 [0.2.0] - 2026-07-07
 ---------------------
 

--- a/src/ol_openedx_uai_content_customization/README.rst
+++ b/src/ol_openedx_uai_content_customization/README.rst
@@ -129,7 +129,7 @@ shell):
 
 .. code-block:: bash
 
-    python manage.py generate_uai_course_versions \
+    python manage.py cms generate_uai_course_versions \
         --processed-videos-csv /path/to/processed_videos.csv \
         [--username studio_worker] \
         [--dry-run]
@@ -140,7 +140,7 @@ downloading a CSV first:
 
 .. code-block:: bash
 
-    python manage.py generate_uai_course_versions \
+    python manage.py cms generate_uai_course_versions \
         --processed-videos-csv "https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit#gid=0" \
         [--username studio_worker] \
         [--dry-run]

--- a/src/ol_openedx_uai_content_customization/README.rst
+++ b/src/ol_openedx_uai_content_customization/README.rst
@@ -146,9 +146,11 @@ downloading a CSV first:
         [--dry-run]
 
 The sheet must be shared as "Anyone with the link can view" (or published to
-the web). Any standard share/edit link works — the command derives the CSV
-export link automatically, using the ``gid`` from the URL to select the
-right tab.
+the web). Any standard ``docs.google.com`` share/edit link works — the
+command derives the CSV export link automatically, using the ``gid`` from
+the URL to select the right tab. Only ``docs.google.com`` links are rewritten
+this way; any other http(s) URL is fetched as-is and must already resolve to
+CSV content directly.
 
 Options
 ~~~~~~~

--- a/src/ol_openedx_uai_content_customization/README.rst
+++ b/src/ol_openedx_uai_content_customization/README.rst
@@ -148,16 +148,16 @@ downloading a CSV first:
 The sheet must be shared as "Anyone with the link can view" (or published to
 the web). Any standard ``docs.google.com`` share/edit link works — the
 command derives the CSV export link automatically, using the ``gid`` from
-the URL to select the right tab. Only ``docs.google.com`` links are rewritten
-this way; any other http(s) URL is fetched as-is and must already resolve to
-CSV content directly.
+the URL to select the right tab. Only ``docs.google.com`` Sheets links are
+accepted; any other http(s) URL is rejected with an error.
 
 Options
 ~~~~~~~
 
 ``--processed-videos-csv``
     Path to the processed video metadata CSV file, or the URL of a publicly
-    readable Google Sheet. **Required.**
+    readable Google Sheet (``docs.google.com`` share/edit or export link — no
+    other URL is accepted). **Required.**
 
 ``--username``
     Username of the platform user under whose authority the courses are

--- a/src/ol_openedx_uai_content_customization/README.rst
+++ b/src/ol_openedx_uai_content_customization/README.rst
@@ -134,11 +134,28 @@ shell):
         [--username studio_worker] \
         [--dry-run]
 
+``--processed-videos-csv`` also accepts the URL of a publicly readable
+Google Sheet, so you can point the command directly at the sheet instead of
+downloading a CSV first:
+
+.. code-block:: bash
+
+    python manage.py generate_uai_course_versions \
+        --processed-videos-csv "https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit#gid=0" \
+        [--username studio_worker] \
+        [--dry-run]
+
+The sheet must be shared as "Anyone with the link can view" (or published to
+the web). Any standard share/edit link works — the command derives the CSV
+export link automatically, using the ``gid`` from the URL to select the
+right tab.
+
 Options
 ~~~~~~~
 
 ``--processed-videos-csv``
-    Path to the processed video metadata CSV file. **Required.**
+    Path to the processed video metadata CSV file, or the URL of a publicly
+    readable Google Sheet. **Required.**
 
 ``--username``
     Username of the platform user under whose authority the courses are

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
@@ -80,26 +80,30 @@ def build_google_sheet_csv_export_url(sheet_url):
 
 def fetch_csv_text(source):
     """
-    Download CSV content from a URL.
+    Download CSV content from a Google Sheets URL.
 
     ``docs.google.com`` Sheets share/edit links are converted to their CSV
-    export link first. Any other URL is treated as already pointing at CSV
-    content (e.g. a direct CSV/export link) and is fetched as-is.
+    export link first (a link already pointing at the export/publish
+    endpoint is used as-is). Any other http(s) URL is rejected.
 
     Args:
-        source: A Google Sheets share/edit URL, or a direct CSV/export URL.
+        source: A ``docs.google.com`` Sheets share/edit or export URL.
 
     Returns:
         str: The raw CSV content fetched from the URL.
 
     Raises:
+        ValueError: if *source* is an http(s) URL that is not a
+            ``docs.google.com`` Sheets link.
         requests.RequestException: on network failure or a non-2xx response.
     """
-    fetch_url = (
-        build_google_sheet_csv_export_url(source)
-        if is_google_sheets_url(source)
-        else source
-    )
+    if not is_google_sheets_url(source):
+        msg = (
+            f"Unsupported URL {source!r}: only docs.google.com Google Sheets "
+            "links are supported for --processed-videos-csv."
+        )
+        raise ValueError(msg)
+    fetch_url = build_google_sheet_csv_export_url(source)
     response = requests.get(fetch_url, timeout=GOOGLE_SHEET_REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.text
@@ -110,15 +114,18 @@ def parse_csv(source):
     Read CSV data from a local file path or a public Google Sheets URL.
 
     Args:
-        source: A filesystem path to a CSV file, or an http(s) URL — either
-            a ``docs.google.com`` Sheets share/edit link or a direct
-            CSV/export link.
+        source: A filesystem path to a CSV file, or a ``docs.google.com``
+            Sheets share/edit or export URL.
 
     Returns:
         tuple: A 2-tuple ``(rows, fieldnames)`` where *rows* is a list of
         ``dict`` objects (one per data row) and *fieldnames* is the list of
         column header strings as they appear in the source.  Both are empty
         lists when there is no header row at all.
+
+    Raises:
+        ValueError: if *source* is an http(s) URL that is not a
+            ``docs.google.com`` Sheets link.
     """
     if is_url(source):
         reader = csv.DictReader(io.StringIO(fetch_csv_text(source)))

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
@@ -64,8 +64,7 @@ def build_google_sheet_csv_export_url(sheet_url):
     gid = gid_match.group(1) if gid_match else "0"
 
     return (
-        f"https://docs.google.com/spreadsheets/d/{sheet_id}"
-        f"/export?format=csv&gid={gid}"
+        f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&gid={gid}"
     )
 
 

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
@@ -1,10 +1,13 @@
 """CSV parsing and video-mapping utilities for ol-openedx-uai-content-customization."""
 
 import csv
+import io
 import re
 from collections import defaultdict
 from pathlib import Path
+from urllib.parse import urlparse
 
+import requests
 from django.utils.html import escape
 from opaque_keys.edx.keys import CourseKey
 
@@ -17,21 +20,98 @@ from ol_openedx_uai_content_customization.constants import (
     INDUSTRY_CODES,
 )
 
+GOOGLE_SHEET_ID_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9-_]+)")
+GOOGLE_SHEET_GID_RE = re.compile(r"[#&?]gid=([0-9]+)")
+GOOGLE_SHEET_REQUEST_TIMEOUT = 30
 
-def parse_csv(path):
+
+def is_url(source):
+    """Return True if *source* is an http(s) URL rather than a local path."""
+    return urlparse(str(source)).scheme in ("http", "https")
+
+
+def build_google_sheet_csv_export_url(sheet_url):
     """
-    Read a CSV file and return a ``(rows, fieldnames)`` tuple.
+    Convert a public Google Sheets link into a CSV export link.
+
+    Accepts standard share/edit links copied from the browser, e.g.::
+
+        https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit#gid=<GID>
+        https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit?usp=sharing
+
+    Links that already point at a CSV export or "Publish to web" endpoint
+    (containing ``/export`` or ``output=csv``) are returned unchanged.
+
+    Args:
+        sheet_url: A Google Sheets URL as copied from the share dialog.
+
+    Returns:
+        A URL that returns CSV content when fetched.
+
+    Raises:
+        ValueError: if no spreadsheet ID can be found in the URL.
+    """
+    if "/export" in sheet_url or "output=csv" in sheet_url:
+        return sheet_url
+
+    match = GOOGLE_SHEET_ID_RE.search(sheet_url)
+    if not match:
+        msg = f"Could not find a spreadsheet ID in Google Sheets URL: {sheet_url!r}"
+        raise ValueError(msg)
+    sheet_id = match.group(1)
+
+    gid_match = GOOGLE_SHEET_GID_RE.search(sheet_url)
+    gid = gid_match.group(1) if gid_match else "0"
+
+    return (
+        f"https://docs.google.com/spreadsheets/d/{sheet_id}"
+        f"/export?format=csv&gid={gid}"
+    )
+
+
+def fetch_csv_text(sheet_url):
+    """
+    Download CSV content from a public Google Sheets link.
+
+    Args:
+        sheet_url: A Google Sheets share/edit URL, or a direct CSV/export URL.
+
+    Returns:
+        str: The raw CSV content of the sheet.
+
+    Raises:
+        requests.RequestException: on network failure or a non-2xx response.
+    """
+    export_url = build_google_sheet_csv_export_url(sheet_url)
+    response = requests.get(export_url, timeout=GOOGLE_SHEET_REQUEST_TIMEOUT)
+    response.raise_for_status()
+    return response.text
+
+
+def parse_csv(source):
+    """
+    Read CSV data from a local file path or a public Google Sheets URL.
+
+    Args:
+        source: A filesystem path to a CSV file, or an http(s) URL — either
+            a Google Sheets share/edit link or a direct CSV/export link.
 
     Returns:
         tuple: A 2-tuple ``(rows, fieldnames)`` where *rows* is a list of
         ``dict`` objects (one per data row) and *fieldnames* is the list of
-        column header strings as they appear in the file.  Both are empty
-        lists when the file contains no header row at all.
+        column header strings as they appear in the source.  Both are empty
+        lists when there is no header row at all.
     """
-    with Path(path).open(encoding="utf-8", newline="") as f:
-        reader = csv.DictReader(f)
+    if is_url(source):
+        reader = csv.DictReader(io.StringIO(fetch_csv_text(source)))
         fieldnames = list(reader.fieldnames or [])
         rows = list(reader)
+    else:
+        with Path(source).open(encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f)
+            fieldnames = list(reader.fieldnames or [])
+            rows = list(reader)
+
     fieldnames = [col.lower() for col in fieldnames]
     rows = [{col.lower(): value for col, value in row.items()} for row in rows]
     return rows, fieldnames

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/csv_utils.py
@@ -20,6 +20,7 @@ from ol_openedx_uai_content_customization.constants import (
     INDUSTRY_CODES,
 )
 
+GOOGLE_SHEETS_HOST = "docs.google.com"
 GOOGLE_SHEET_ID_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9-_]+)")
 GOOGLE_SHEET_GID_RE = re.compile(r"[#&?]gid=([0-9]+)")
 GOOGLE_SHEET_REQUEST_TIMEOUT = 30
@@ -28,6 +29,14 @@ GOOGLE_SHEET_REQUEST_TIMEOUT = 30
 def is_url(source):
     """Return True if *source* is an http(s) URL rather than a local path."""
     return urlparse(str(source)).scheme in ("http", "https")
+
+
+def is_google_sheets_url(source):
+    """Return True if *source* is a docs.google.com Sheets link."""
+    parsed = urlparse(str(source))
+    return (
+        parsed.netloc.lower() == GOOGLE_SHEETS_HOST and "/spreadsheets/" in parsed.path
+    )
 
 
 def build_google_sheet_csv_export_url(sheet_url):
@@ -43,7 +52,8 @@ def build_google_sheet_csv_export_url(sheet_url):
     (containing ``/export`` or ``output=csv``) are returned unchanged.
 
     Args:
-        sheet_url: A Google Sheets URL as copied from the share dialog.
+        sheet_url: A ``docs.google.com`` Sheets URL, as copied from the
+            share dialog.
 
     Returns:
         A URL that returns CSV content when fetched.
@@ -68,21 +78,29 @@ def build_google_sheet_csv_export_url(sheet_url):
     )
 
 
-def fetch_csv_text(sheet_url):
+def fetch_csv_text(source):
     """
-    Download CSV content from a public Google Sheets link.
+    Download CSV content from a URL.
+
+    ``docs.google.com`` Sheets share/edit links are converted to their CSV
+    export link first. Any other URL is treated as already pointing at CSV
+    content (e.g. a direct CSV/export link) and is fetched as-is.
 
     Args:
-        sheet_url: A Google Sheets share/edit URL, or a direct CSV/export URL.
+        source: A Google Sheets share/edit URL, or a direct CSV/export URL.
 
     Returns:
-        str: The raw CSV content of the sheet.
+        str: The raw CSV content fetched from the URL.
 
     Raises:
         requests.RequestException: on network failure or a non-2xx response.
     """
-    export_url = build_google_sheet_csv_export_url(sheet_url)
-    response = requests.get(export_url, timeout=GOOGLE_SHEET_REQUEST_TIMEOUT)
+    fetch_url = (
+        build_google_sheet_csv_export_url(source)
+        if is_google_sheets_url(source)
+        else source
+    )
+    response = requests.get(fetch_url, timeout=GOOGLE_SHEET_REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.text
 
@@ -93,7 +111,8 @@ def parse_csv(source):
 
     Args:
         source: A filesystem path to a CSV file, or an http(s) URL — either
-            a Google Sheets share/edit link or a direct CSV/export link.
+            a ``docs.google.com`` Sheets share/edit link or a direct
+            CSV/export link.
 
     Returns:
         tuple: A 2-tuple ``(rows, fieldnames)`` where *rows* is a list of

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
@@ -19,12 +19,12 @@ For each unique (course_key, industry, duration) combination the command:
                     └── <Video Title>  (video block)
 
 Usage:
-    python manage.py generate_uai_course_versions \\
+    python manage.py cms generate_uai_course_versions \\
         --processed-videos-csv /path/to/processed_videos.csv \\
         [--username studio_worker] \\
         [--dry-run]
 
-    python manage.py generate_uai_course_versions \\
+    python manage.py cms generate_uai_course_versions \\
         --processed-videos-csv \\
         "https://docs.google.com/spreadsheets/d/<ID>/edit#gid=0" \\
         [--username studio_worker] \\

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
@@ -25,7 +25,8 @@ Usage:
         [--dry-run]
 
     python manage.py generate_uai_course_versions \\
-        --processed-videos-csv "https://docs.google.com/spreadsheets/d/<ID>/edit#gid=0" \\
+        --processed-videos-csv \\
+        "https://docs.google.com/spreadsheets/d/<ID>/edit#gid=0" \\
         [--username studio_worker] \\
         [--dry-run]
 
@@ -111,7 +112,7 @@ class Command(BaseCommand):
             help="Log what would be created without writing to the modulestore.",
         )
 
-    def handle(self, *args, **options):  # noqa: ARG002, PLR0915
+    def handle(self, *args, **options):  # noqa: ARG002, PLR0915, C901
         processed_videos_csv = options["processed_videos_csv"]
         username = options["username"]
         dry_run = options["dry_run"]
@@ -132,7 +133,7 @@ class Command(BaseCommand):
                 processed_videos_csv
             )
         except (requests.RequestException, ValueError) as exc:
-            msg = f"Failed to read processed videos source {processed_videos_csv!r}: {exc}"
+            msg = f"Failed to read processed videos source {processed_videos_csv!r}: {exc}"  # noqa: E501
             raise CommandError(msg) from exc
 
         try:

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
@@ -2,7 +2,7 @@
 Management command: generate_uai_course_versions
 
 Reads processed video metadata — from a local CSV file or a publicly
-readable Google Sheets link — and uses Open edX modulestore APIs to build
+readable Google Sheets URL — and uses Open edX modulestore APIs to build
 industry- and length-specific variants of UAI courses by cloning a base
 course.
 
@@ -96,8 +96,8 @@ class Command(BaseCommand):
             required=True,
             help=(
                 "Path to the processed video metadata CSV file, or the URL of a "
-                "publicly readable Google Sheet (share/edit link, or a direct "
-                "CSV export link)."
+                "publicly readable Google Sheet (docs.google.com share/edit link, "
+                "or its CSV export link). No other URL is accepted."
             ),
         )
         parser.add_argument(

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
@@ -132,7 +132,7 @@ class Command(BaseCommand):
             processed_video_rows, processed_video_fieldnames = parse_csv(
                 processed_videos_csv
             )
-        except (requests.RequestException, ValueError) as exc:
+        except (requests.RequestException, ValueError, OSError) as exc:
             msg = f"Failed to read processed videos source {processed_videos_csv!r}: {exc}"  # noqa: E501
             raise CommandError(msg) from exc
 

--- a/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/ol_openedx_uai_content_customization/management/commands/generate_uai_course_versions.py
@@ -1,10 +1,10 @@
 """
 Management command: generate_uai_course_versions
 
-Reads a single CSV file and uses Open edX modulestore APIs to build industry-
-and length-specific variants of UAI courses by cloning a base course.
-
-  - Processed videos CSV  (produced by the video-generation workflow)
+Reads processed video metadata — from a local CSV file or a publicly
+readable Google Sheets link — and uses Open edX modulestore APIs to build
+industry- and length-specific variants of UAI courses by cloning a base
+course.
 
 For each unique (course_key, industry, duration) combination the command:
     1. Clones the source course (identified by the ``course_key`` CSV column)
@@ -24,6 +24,11 @@ Usage:
         [--username studio_worker] \\
         [--dry-run]
 
+    python manage.py generate_uai_course_versions \\
+        --processed-videos-csv "https://docs.google.com/spreadsheets/d/<ID>/edit#gid=0" \\
+        [--username studio_worker] \\
+        [--dry-run]
+
 Note: this command writes to the MongoDB-backed modulestore.  Django's
 transaction.atomic() does NOT cover MongoDB, so course creation is not
 atomic.  If a run fails partway through, already-created courses will remain
@@ -33,6 +38,7 @@ warning).
 
 import logging
 
+import requests
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
@@ -79,15 +85,19 @@ class Command(BaseCommand):
     """Generate industry/length-specific UAI courses using Open edX modulestore APIs."""
 
     help = (
-        "Generate industry and length-specific UAI courses by reading a CSV file "
-        "and creating courses in the CMS modulestore."
+        "Generate industry and length-specific UAI courses by reading processed "
+        "video metadata and creating courses in the CMS modulestore."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--processed-videos-csv",
             required=True,
-            help="Path to the processed video metadata CSV file.",
+            help=(
+                "Path to the processed video metadata CSV file, or the URL of a "
+                "publicly readable Google Sheet (share/edit link, or a direct "
+                "CSV export link)."
+            ),
         )
         parser.add_argument(
             "--username",
@@ -117,9 +127,13 @@ class Command(BaseCommand):
         except User.DoesNotExist:
             msg = f"No user found with username {username!r}."
             raise CommandError(msg)  # noqa: B904
-        processed_video_rows, processed_video_fieldnames = parse_csv(
-            processed_videos_csv
-        )
+        try:
+            processed_video_rows, processed_video_fieldnames = parse_csv(
+                processed_videos_csv
+            )
+        except (requests.RequestException, ValueError) as exc:
+            msg = f"Failed to read processed videos source {processed_videos_csv!r}: {exc}"
+            raise CommandError(msg) from exc
 
         try:
             validate_csv_columns(

--- a/src/ol_openedx_uai_content_customization/pyproject.toml
+++ b/src/ol_openedx_uai_content_customization/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "Django>=4.0",
   "edx-django-utils>4.0.0",
   "edx-opaque-keys",
-  "requests>=2.31.0",
+  "requests",
 ]
 
 [project.entry-points."cms.djangoapp"]

--- a/src/ol_openedx_uai_content_customization/pyproject.toml
+++ b/src/ol_openedx_uai_content_customization/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-uai-content-customization"
-version = "0.2.0"
+version = "0.3.0"
 description = "An Open edX plugin to generate industry/length-specific UAI custom courses from video CSV data."
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -12,6 +12,7 @@ dependencies = [
   "Django>=4.0",
   "edx-django-utils>4.0.0",
   "edx-opaque-keys",
+  "requests>=2.31.0",
 ]
 
 [project.entry-points."cms.djangoapp"]

--- a/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
@@ -145,28 +145,26 @@ def test_is_google_sheets_url(source, expected):
     assert is_google_sheets_url(source) is expected
 
 
-def test_fetch_csv_text_direct_url_is_not_rewritten():
+def test_fetch_csv_text_non_google_sheets_url_raises():
     """
-    A non-Google direct CSV URL is fetched as-is, without raising ValueError.
+    A non-Google URL is rejected, even one shaped like a CSV export link.
 
     This is the case even when the URL happens to contain "/export" or
     "output=csv", proving such URLs are never mistaken for Google Sheets
     export links (which would let an operator target arbitrary hosts under
-    the guise of Google Sheets support).
+    the guise of Google Sheets support). Only ``docs.google.com`` Sheets
+    links are accepted.
     """
-    mock_response = mock.Mock()
-    mock_response.text = "a,b\n1,2\n"
-    mock_response.raise_for_status = mock.Mock()
-
     direct_url = "https://example.com/export?output=csv"
-    with mock.patch(
-        "ol_openedx_uai_content_customization.csv_utils.requests.get",
-        return_value=mock_response,
-    ) as mock_get:
-        text = fetch_csv_text(direct_url)
+    with (
+        mock.patch(
+            "ol_openedx_uai_content_customization.csv_utils.requests.get"
+        ) as mock_get,
+        pytest.raises(ValueError, match=r"only docs\.google\.com Google Sheets"),
+    ):
+        fetch_csv_text(direct_url)
 
-    mock_get.assert_called_once_with(direct_url, timeout=30)
-    assert text == "a,b\n1,2\n"
+    mock_get.assert_not_called()
 
 
 def test_parse_csv_from_google_sheet_url():
@@ -190,6 +188,12 @@ def test_parse_csv_from_google_sheet_url():
     )
     assert fieldnames == ["video_file_name", "edx_video_id"]
     assert rows == [{"video_file_name": "v004_h264.mp4", "edx_video_id": "abc-123"}]
+
+
+def test_parse_csv_non_google_sheets_url_raises():
+    """parse_csv rejects any http(s) URL that is not a docs.google.com Sheets link."""
+    with pytest.raises(ValueError, match=r"only docs\.google\.com Google Sheets"):
+        parse_csv("https://example.com/videos.csv")
 
 
 def test_parse_csv_from_google_sheet_url_raises_on_http_error():

--- a/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
@@ -1,10 +1,15 @@
 """Tests for ol_openedx_uai_content_customization csv_utils."""
 
+from unittest import mock
+
 import pytest
+import requests
 from ol_openedx_uai_content_customization.csv_utils import (
     build_course_intro_lookup,
+    build_google_sheet_csv_export_url,
     build_new_course_key,
     group_videos_by_course,
+    is_url,
     normalize_course_intro,
     parse_csv,
     resolve_course_intro,
@@ -77,6 +82,83 @@ def test_resolve_duration_code_unknown_raises():
     """An unrecognised duration string raises ValueError."""
     with pytest.raises(ValueError, match="Unrecognised duration value"):
         resolve_duration_code("unknown_value")
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("/path/to/file.csv", False),
+        ("file.csv", False),
+        ("https://docs.google.com/spreadsheets/d/abc123/edit", True),
+        ("http://example.com/videos.csv", True),
+    ],
+)
+def test_is_url(source, expected):
+    """Only http(s) sources are treated as URLs; everything else is a local path."""
+    assert is_url(source) is expected
+
+
+@pytest.mark.parametrize(
+    ("sheet_url", "expected"),
+    [
+        (
+            "https://docs.google.com/spreadsheets/d/abc123/edit#gid=456",
+            "https://docs.google.com/spreadsheets/d/abc123/export?format=csv&gid=456",
+        ),
+        (
+            "https://docs.google.com/spreadsheets/d/abc123/edit?usp=sharing",
+            "https://docs.google.com/spreadsheets/d/abc123/export?format=csv&gid=0",
+        ),
+        (
+            "https://docs.google.com/spreadsheets/d/abc123/export?format=csv&gid=9",
+            "https://docs.google.com/spreadsheets/d/abc123/export?format=csv&gid=9",
+        ),
+    ],
+)
+def test_build_google_sheet_csv_export_url(sheet_url, expected):
+    """Share/edit links are converted to CSV export links; export links pass through."""
+    assert build_google_sheet_csv_export_url(sheet_url) == expected
+
+
+def test_build_google_sheet_csv_export_url_invalid_raises():
+    """A URL without a recognisable spreadsheet ID raises ValueError."""
+    with pytest.raises(ValueError, match="Could not find a spreadsheet ID"):
+        build_google_sheet_csv_export_url("https://example.com/not-a-sheet")
+
+
+def test_parse_csv_from_google_sheet_url():
+    """parse_csv fetches and parses CSV content from a Google Sheets URL."""
+    csv_text = "video_file_name,edx_video_id\nv004_h264.mp4,abc-123\n"
+    mock_response = mock.Mock()
+    mock_response.text = csv_text
+    mock_response.raise_for_status = mock.Mock()
+
+    with mock.patch(
+        "ol_openedx_uai_content_customization.csv_utils.requests.get",
+        return_value=mock_response,
+    ) as mock_get:
+        rows, fieldnames = parse_csv(
+            "https://docs.google.com/spreadsheets/d/abc123/edit#gid=0"
+        )
+
+    mock_get.assert_called_once_with(
+        "https://docs.google.com/spreadsheets/d/abc123/export?format=csv&gid=0",
+        timeout=30,
+    )
+    assert fieldnames == ["video_file_name", "edx_video_id"]
+    assert rows == [{"video_file_name": "v004_h264.mp4", "edx_video_id": "abc-123"}]
+
+
+def test_parse_csv_from_google_sheet_url_raises_on_http_error():
+    """A non-2xx response while fetching the sheet propagates as a RequestException."""
+    mock_response = mock.Mock()
+    mock_response.raise_for_status.side_effect = requests.HTTPError("404")
+
+    with mock.patch(
+        "ol_openedx_uai_content_customization.csv_utils.requests.get",
+        return_value=mock_response,
+    ), pytest.raises(requests.HTTPError):
+        parse_csv("https://docs.google.com/spreadsheets/d/abc123/edit")
 
 
 @pytest.mark.parametrize(

--- a/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
@@ -8,7 +8,9 @@ from ol_openedx_uai_content_customization.csv_utils import (
     build_course_intro_lookup,
     build_google_sheet_csv_export_url,
     build_new_course_key,
+    fetch_csv_text,
     group_videos_by_course,
+    is_google_sheets_url,
     is_url,
     normalize_course_intro,
     parse_csv,
@@ -124,6 +126,47 @@ def test_build_google_sheet_csv_export_url_invalid_raises():
     """A URL without a recognisable spreadsheet ID raises ValueError."""
     with pytest.raises(ValueError, match="Could not find a spreadsheet ID"):
         build_google_sheet_csv_export_url("https://example.com/not-a-sheet")
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("https://docs.google.com/spreadsheets/d/abc123/edit#gid=0", True),
+        ("https://docs.google.com/spreadsheets/d/abc123/export?format=csv", True),
+        # Only the docs.google.com host is trusted, regardless of path shape.
+        ("https://example.com/spreadsheets/d/abc123/export?format=csv", False),
+        ("https://example.com/foo.csv", False),
+        ("https://evil.com/export?output=csv", False),
+        ("/path/to/file.csv", False),
+    ],
+)
+def test_is_google_sheets_url(source, expected):
+    """Only docs.google.com Sheets links are recognised — no other host."""
+    assert is_google_sheets_url(source) is expected
+
+
+def test_fetch_csv_text_direct_url_is_not_rewritten():
+    """
+    A non-Google direct CSV URL is fetched as-is, without raising ValueError.
+
+    This is the case even when the URL happens to contain "/export" or
+    "output=csv", proving such URLs are never mistaken for Google Sheets
+    export links (which would let an operator target arbitrary hosts under
+    the guise of Google Sheets support).
+    """
+    mock_response = mock.Mock()
+    mock_response.text = "a,b\n1,2\n"
+    mock_response.raise_for_status = mock.Mock()
+
+    direct_url = "https://example.com/export?output=csv"
+    with mock.patch(
+        "ol_openedx_uai_content_customization.csv_utils.requests.get",
+        return_value=mock_response,
+    ) as mock_get:
+        text = fetch_csv_text(direct_url)
+
+    mock_get.assert_called_once_with(direct_url, timeout=30)
+    assert text == "a,b\n1,2\n"
 
 
 def test_parse_csv_from_google_sheet_url():

--- a/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_csv_utils.py
@@ -154,10 +154,13 @@ def test_parse_csv_from_google_sheet_url_raises_on_http_error():
     mock_response = mock.Mock()
     mock_response.raise_for_status.side_effect = requests.HTTPError("404")
 
-    with mock.patch(
-        "ol_openedx_uai_content_customization.csv_utils.requests.get",
-        return_value=mock_response,
-    ), pytest.raises(requests.HTTPError):
+    with (
+        mock.patch(
+            "ol_openedx_uai_content_customization.csv_utils.requests.get",
+            return_value=mock_response,
+        ),
+        pytest.raises(requests.HTTPError),
+    ):
         parse_csv("https://docs.google.com/spreadsheets/d/abc123/edit")
 
 

--- a/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
@@ -244,7 +244,7 @@ def test_duplicate_course_is_skipped_with_warning(csv_file, mock_user):  # noqa:
 
 
 def test_missing_csv_raises_error(mock_user):  # noqa: ARG001
-    with pytest.raises((CommandError, FileNotFoundError)):
+    with pytest.raises(CommandError, match="Failed to read processed videos source"):
         call_command(
             "generate_uai_course_versions",
             processed_videos_csv="/nonexistent/path.csv",

--- a/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
@@ -302,6 +302,15 @@ def test_google_sheet_fetch_failure_raises_command_error(mock_user):  # noqa: AR
         )
 
 
+def test_non_google_sheets_url_raises_error(mock_user):  # noqa: ARG001
+    """A non-Google-Sheets URL is rejected instead of being fetched as CSV."""
+    with pytest.raises(CommandError, match="Failed to read processed videos source"):
+        call_command(
+            "generate_uai_course_versions",
+            processed_videos_csv="https://example.com/videos.csv",
+        )
+
+
 def test_invalid_user_id_raises_error(csv_file, db):  # noqa: ARG001
     """Passing a non-existent username should raise CommandError before any writes."""
     processed_videos_csv = csv_file

--- a/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
+++ b/src/ol_openedx_uai_content_customization/tests/test_generate_uai_course_versions.py
@@ -4,6 +4,7 @@ from io import StringIO
 from unittest import mock
 
 import pytest
+import requests
 from common.djangoapps.student.tests.factories import UserFactory
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -247,6 +248,57 @@ def test_missing_csv_raises_error(mock_user):  # noqa: ARG001
         call_command(
             "generate_uai_course_versions",
             processed_videos_csv="/nonexistent/path.csv",
+        )
+
+
+def test_google_sheet_source_is_used_when_url_provided(mock_user):  # noqa: ARG001
+    """A Google Sheets URL is fetched over HTTP and parsed like a local CSV."""
+    mock_response = mock.Mock()
+    mock_response.text = PROCESSED_VIDEOS_CSV_CONTENT
+    mock_response.raise_for_status = mock.Mock()
+    out = StringIO()
+
+    with (
+        mock.patch(f"{_CMD}.modulestore", _modulestore_mock()),
+        mock.patch(f"{_CMD}.clone_course_in_modulestore") as mock_clone,
+        mock.patch(
+            "ol_openedx_uai_content_customization.csv_utils.requests.get",
+            return_value=mock_response,
+        ) as mock_get,
+    ):
+        call_command(
+            "generate_uai_course_versions",
+            processed_videos_csv=(
+                "https://docs.google.com/spreadsheets/d/abc123/edit#gid=0"
+            ),
+            dry_run=True,
+            stdout=out,
+        )
+        mock_clone.assert_not_called()
+
+    mock_get.assert_called_once_with(
+        "https://docs.google.com/spreadsheets/d/abc123/export?format=csv&gid=0",
+        timeout=30,
+    )
+    assert "DRY RUN" in out.getvalue()
+
+
+def test_google_sheet_fetch_failure_raises_command_error(mock_user):  # noqa: ARG001
+    """A network failure fetching the sheet surfaces as a CommandError."""
+    mock_response = mock.Mock()
+    mock_response.raise_for_status.side_effect = requests.HTTPError("404")
+
+    with (
+        mock.patch(f"{_CMD}.modulestore", _modulestore_mock()),
+        mock.patch(
+            "ol_openedx_uai_content_customization.csv_utils.requests.get",
+            return_value=mock_response,
+        ),
+        pytest.raises(CommandError, match="Failed to read processed videos source"),
+    ):
+        call_command(
+            "generate_uai_course_versions",
+            processed_videos_csv="https://docs.google.com/spreadsheets/d/abc123/edit",
         )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Enhance the use of the uai content customization command by adding support for a Google Sheets URL. It still supports the CSV file.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup plugin and use a google sheet to run the command:
```
    python manage.py cms generate_uai_course_versions \\
        --processed-videos-csv "https://docs.google.com/spreadsheets/d/<ID>/edit#gid=0" \\
        [--username studio_worker] \\
        [--dry-run]

```