### PR TITLE
chore(ver): Version bumped from 0.8.2 to 0.8.3

### DIFF
--- a/src/ol_openedx_git_auto_export/pyproject.toml
+++ b/src/ol_openedx_git_auto_export/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-git-auto-export"
-version = "0.8.2"
+version = "0.8.3"
 description = "A plugin that auto saves the course OLX to git when an author publishes it"
 authors = [{ name = "MIT Office of Digital Learning" }]
 license = "BSD-3-Clause"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12267

### Description (What does it do?)
This pull request updates the package version in the `pyproject.toml` file.

- Bumped the version of `ol-openedx-git-auto-export` from `0.8.2` to `0.8.3` to reflect recent changes.
