### PR TITLE
feat: restyle per-block feedback trigger to match AskTIM + keyboard focus

### DIFF
--- a/src/ol_openedx_feedback/README.rst
+++ b/src/ol_openedx_feedback/README.rst
@@ -54,6 +54,9 @@ flag (default off). Enable it for the desired courses (or globally) to roll out.
 Configuration
 =============
 
+Excluded block types
+--------------------
+
 By default the trigger renders on every leaf block and is suppressed only on
 structural containers (``course`` / ``chapter`` / ``sequential`` / ``vertical``).
 To additionally exclude one or more block types (for example ``html``), override
@@ -71,3 +74,16 @@ the excluded set through ``ENV_TOKENS`` (e.g. in ``lms.yml``):
 The plugin reads this value via its ``settings.common`` ``plugin_settings`` hook
 and exposes it as the ``OL_OPENEDX_FEEDBACK_EXCLUDED_BLOCK_TYPES`` Django
 setting, defaulting to the structural set above when unset.
+
+Text label
+----------
+
+The trigger shows only the megaphone icon by default. To also render the
+"Feedback" text label beside it, enable it through ``ENV_TOKENS``:
+
+.. code-block:: yaml
+
+    OL_OPENEDX_FEEDBACK_SHOW_LABEL: true
+
+This is exposed as the ``OL_OPENEDX_FEEDBACK_SHOW_LABEL`` Django setting via the
+same ``plugin_settings`` hook, defaulting to ``false`` (icon-only) when unset.

--- a/src/ol_openedx_feedback/ol_openedx_feedback/block.py
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/block.py
@@ -19,6 +19,7 @@ except ImportError:
 from xmodule.x_module import STUDENT_VIEW
 
 from ol_openedx_feedback.compat import get_feedback_enabled_flag
+from ol_openedx_feedback.constants import DEFAULT_SHOW_LABEL
 from ol_openedx_feedback.utils import is_aside_applicable_to_block
 
 log = logging.getLogger(__name__)
@@ -57,7 +58,11 @@ class FeedbackAside(XBlockAside):
                 "static/html/student_view.html",
                 {
                     "block_id": block_id,
-                    "label": gettext("Send feedback"),
+                    "label": gettext("Feedback"),
+                    "aria_label": gettext("Send feedback"),
+                    "show_label": getattr(
+                        settings, "OL_OPENEDX_FEEDBACK_SHOW_LABEL", DEFAULT_SHOW_LABEL
+                    ),
                 },
             )
         )

--- a/src/ol_openedx_feedback/ol_openedx_feedback/constants.py
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/constants.py
@@ -5,3 +5,6 @@
 # ``OL_OPENEDX_FEEDBACK_EXCLUDED_BLOCK_TYPES`` Django setting (e.g. to also
 # exclude a content type like ``html``).
 DEFAULT_EXCLUDED_BLOCK_TYPES = {"course", "chapter", "sequential", "vertical"}
+
+# Show the "Feedback" text label next to the icon. Off by default (icon only).
+DEFAULT_SHOW_LABEL = False

--- a/src/ol_openedx_feedback/ol_openedx_feedback/settings/common.py
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/settings/common.py
@@ -2,7 +2,10 @@
 
 """Settings to provide to edX"""
 
-from ol_openedx_feedback.constants import DEFAULT_EXCLUDED_BLOCK_TYPES
+from ol_openedx_feedback.constants import (
+    DEFAULT_EXCLUDED_BLOCK_TYPES,
+    DEFAULT_SHOW_LABEL,
+)
 
 
 def plugin_settings(settings):
@@ -15,4 +18,8 @@ def plugin_settings(settings):
             "OL_OPENEDX_FEEDBACK_EXCLUDED_BLOCK_TYPES",
             DEFAULT_EXCLUDED_BLOCK_TYPES,
         )
+    )
+    settings.OL_OPENEDX_FEEDBACK_SHOW_LABEL = env_tokens.get(
+        "OL_OPENEDX_FEEDBACK_SHOW_LABEL",
+        DEFAULT_SHOW_LABEL,
     )

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
@@ -4,65 +4,61 @@
   margin: 8px 0 4px;
 }
 
+/* Anchor is relocated next to AskTIM in JS; drop the trailing space here. */
 .ol-feedback-container--relocated {
   margin: 0;
 }
 
 .ol-feedback-anchor {
-  --ol-fb-brand: #8a1e2d;
   position: relative;
   display: inline-flex;
   align-self: center;
 }
 
+/* Docked next to AskTIM: positioning only; the button styling stays on
+   .ol-feedback-trigger so the megaphone looks the same docked or standalone. */
 .ol-feedback-anchor--docked {
-  /* Docked next to AskTIM: only positioning here (a gap before the AskTIM
-     button). The button appearance lives on .ol-feedback-trigger so the
-     megaphone always looks like a button, docked or standalone. */
   margin-right: 10px;
   z-index: 1;
 }
 
-/* Problem blocks draw a horizontal "saved/submit" notification line behind the
-   button row. Project an opaque white block across the gap to the AskTIM button
-   so the line is masked there too (invisible on the white problem-block
-   background). Not applied to video/html blocks, which have no such line.
-   Offset must match the docked gap (margin-right above) so the mask fills the
-   gap but stops at the AskTIM button's edge instead of overlapping its border. */
+/* Problem blocks draw a notification line behind the button row; mask it across
+   the docked gap to the AskTIM button (offset matches margin-right above). */
 .ol-feedback-anchor--line-masked {
   box-shadow: 10px 0 0 0 #fff;
 }
 
+/* Matches the AskTIM button's resting treatment and 50px height; box-sizing is
+   pinned so the height holds regardless of any LMS global. */
 .ol-feedback-trigger {
-  /* Always styled as a button (border + background), whether standalone or
-     docked next to the AskTIM button. */
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 52px;
+  height: 50px;
   padding: 0;
   border: 1px solid #b8c2cc;
-  border-radius: 6px;
+  border-radius: 4px;
   background: #fff;
-  color: #e0a106;
+  color: #5f6b7a;
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
-.ol-feedback-trigger:hover {
-  background: #fbf3dd;
-  color: #c98a00;
-}
-
-/* On click/focus the background fills the whole button and the border turns
-   red. */
+/* Hover, active, and mouse-focus share one look; keyboard focus is handled below. */
+.ol-feedback-trigger:hover,
 .ol-feedback-trigger:active,
 .ol-feedback-trigger:focus {
-  background: #e6e6e6;
-  border-color: var(--ol-fb-brand);
-  color: #c98a00;
-  outline: none;
+  background: #f0f1f4;
+  border-color: #b8c2cc;
+  color: #5f6b7a;
+}
+
+/* Visible keyboard-focus ring (WCAG 2.4.7); an outline also survives forced-colors mode. */
+.ol-feedback-trigger:focus-visible {
+  outline: 2px solid #005a9c;
+  outline-offset: 2px;
 }
 
 .ol-feedback-trigger .ol-fb-ic {
@@ -71,16 +67,28 @@
   display: block;
 }
 
-/* On video blocks the AskTIM chat container (.video-block-chat-button-container)
-   paints an opaque whitesmoke background plus an upward box-shadow inside its own
-   stacking context, which rides up over the platform's preceding "Staff Debug
-   Info" link (.wrap-instructor-info) and hides it for staff. Fix it here in the
-   feedback plugin so it holds regardless of the installed chat-plugin version.
-   The staff-info row is the adjacent sibling of the block's wrapper
-   (data-block-type="video"), so scope to video only: give the row its own
-   stacking context above the paint, and match the chat container's whitesmoke
-   background so it blends into the section instead of showing a white patch.
-   Problem/HTML rows are untouched. */
+/* Opt-in text label (OL_OPENEDX_FEEDBACK_SHOW_LABEL); icon-only by default. */
+.ol-feedback-trigger .ol-fb-label {
+  display: none;
+}
+
+/* With-text variant: widen into a pill (height stays 50px from the base rule). */
+.ol-feedback-trigger--with-text {
+  width: auto;
+  gap: 8px;
+  padding: 0 16px;
+}
+
+.ol-feedback-trigger--with-text .ol-fb-label {
+  display: inline;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* On video blocks the AskTIM chat container's paint rides up over the platform's
+   Staff Debug link (.wrap-instructor-info); lift that row above it and match its bg. */
 [data-block-type="video"] + .wrap-instructor-info {
   position: relative;
   z-index: 2;

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/html/student_view.html
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/html/student_view.html
@@ -1,8 +1,9 @@
 <div class="ol-feedback-container">
   <span class="ol-feedback-anchor">
-    <button class="ol-feedback-trigger" id="ol-feedback-trigger-{{ block_id }}" type="button"
-            aria-haspopup="dialog" aria-label="{{ label }}" title="{{ label }}">
-      <svg class="ol-fb-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 11 18-5v12L3 14v-3z"/><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6"/></svg>
+    <button class="ol-feedback-trigger{% if show_label %} ol-feedback-trigger--with-text{% endif %}" id="ol-feedback-trigger-{{ block_id }}" type="button"
+            aria-haspopup="dialog" aria-label="{{ aria_label }}" title="{{ aria_label }}">
+      <svg class="ol-fb-ic" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M9 17C9 17 16 18 19 21H20C20.5523 21 21 20.5523 21 20V13.937C21.8626 13.715 22.5 12.9319 22.5 12C22.5 11.0681 21.8626 10.285 21 10.063V4C21 3.44772 20.5523 3 20 3H19C16 6 9 7 9 7H5C3.89543 7 3 7.89543 3 9V15C3 16.1046 3.89543 17 5 17H6L7 22H9V17ZM11 8.6612C11.6833 8.5146 12.5275 8.31193 13.4393 8.04373C15.1175 7.55014 17.25 6.77262 19 5.57458V18.4254C17.25 17.2274 15.1175 16.4499 13.4393 15.9563C12.5275 15.6881 11.6833 15.4854 11 15.3388V8.6612ZM5 9H9V15H5V9Z"/></svg>
+      <span class="ol-fb-label" aria-hidden="true">{{ label }}</span>
     </button>
   </span>
 </div>

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
@@ -44,6 +44,10 @@
       var alignToChatButton = function () {
         $anchor.css("transform", "");
         var btnRect = $chatBtn[0].getBoundingClientRect();
+        // Match the megaphone's height to the AskTIM button so the two stay
+        // equal-height peers even when AskTIM's label wraps to two lines on
+        // narrow screens (the CSS height is a standalone default).
+        $trigger.css("height", btnRect.height + "px");
         var anchorRect = $anchor[0].getBoundingClientRect();
         var delta =
           (btnRect.top + btnRect.height / 2) -

--- a/src/ol_openedx_feedback/pyproject.toml
+++ b/src/ol_openedx_feedback/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-feedback"
-version = "0.1.0"
+version = "0.2.0"
 description = "An Open edX plugin to collect per-block learner feedback"
 authors = [{name = "MIT Office of Digital Learning"}]
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -2316,7 +2316,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-feedback"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "src/ol_openedx_feedback" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11629

### Description (What does it do?)

Restyles the `ol_openedx_feedback` per-block megaphone trigger to match the AskTIM button and improves accessibility:

- Docks the megaphone just left of the AskTIM button and sizes it to 52x50 so the two read as equal-height peers.
- Adopts the AskTIM resting treatment (1px `#b8c2cc` border, 4px radius, slate `#5f6b7a` RemixIcon megaphone) with a unified `#f0f1f4` hover/active fill.
- Adds a visible `:focus-visible` ring (2px `#005a9c`) for keyboard users instead of suppressing the outline; mouse clicks keep the hover look.
- Renames the label to "Feedback" and gates the opt-in text label on the `DEFAULT_SHOW_LABEL` constant (off by default, icon-only).
- Bumps the plugin version `0.1.0` -> `0.2.0` and registers it in `uv.lock` (the plugin was merged in #813 without a lockfile entry).

### Screenshots:
**Mobile:**
<img width="514" height="874" alt="Screenshot 2026-08-04 at 6 01 53 PM" src="https://github.com/user-attachments/assets/fd68850d-3039-4983-a295-5bd04eccd1c5" />

**Tablet:**
<img width="1168" height="758" alt="Screenshot 2026-08-04 at 6 01 35 PM" src="https://github.com/user-attachments/assets/04fac5a5-4443-4b60-b3a0-dc300a8dd1c3" />

**Desktop:**
<img width="1246" height="896" alt="Screenshot 2026-08-04 at 6 00 39 PM" src="https://github.com/user-attachments/assets/d9f90b8b-b40f-4302-88d6-17c608e4ee03" />

### How can this be tested?

- Install the plugin in the LMS and enable the `ol_openedx_feedback.feedback_enabled` CourseWaffleFlag (globally or per course).
- Open a courseware unit as a signed-in learner → the "Send feedback" megaphone renders on leaf blocks, docked next to AskTIM when present. Confirm it now matches the AskTIM button: 1px `#b8c2cc` border, 4px radius, slate `#5f6b7a` megaphone, and equal 50px height so the two read as peers; icon-only by default.
- Hover or click the trigger → light-gray `#f0f1f4` fill; tab to it with the keyboard → a clearly visible `#005a9c` focus ring appears (mouse clicks don't paint the ring).