### PR TITLE
ci: add uv.lock drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
     - name: Set up Python ${{ matrix.python_version }}
       run: uv python install ${{ matrix.python_version }}
 
-    - name: Check uv.lock is up to date
-      run: uv lock --check
-
     - name: Build all packages
       run: uv build --all-packages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Set up Python ${{ matrix.python_version }}
       run: uv python install ${{ matrix.python_version }}
 
+    - name: Check uv.lock is up to date
+      run: uv lock --check
+
     - name: Build all packages
       run: uv build --all-packages
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,13 @@ repos:
   - id: actionlint
     name: actionlint
     description: Runs actionlint to lint GitHub Actions workflow files
+- repo: local
+  hooks:
+  - id: uv-lock
+    name: uv lock
+    description: Updates uv.lock to match pyproject.toml files, without upgrading
+      dependency versions
+    entry: uv lock --no-upgrade
+    language: system
+    files: ^(pyproject\.toml|src/.+/pyproject\.toml|uv\.lock)$
+    pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,13 +67,8 @@ repos:
   - id: actionlint
     name: actionlint
     description: Runs actionlint to lint GitHub Actions workflow files
-- repo: local
+- repo: https://github.com/astral-sh/uv-pre-commit
+  rev: '0.12.2'
   hooks:
   - id: uv-lock
-    name: uv lock
-    description: Updates uv.lock to match pyproject.toml files, without upgrading
-      dependency versions
-    entry: uv lock --no-upgrade
-    language: system
-    files: ^(pyproject\.toml|src/.+/pyproject\.toml|uv\.lock)$
-    pass_filenames: false
+    args: [--no-upgrade]

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ members = [
     "ol-openedx-course-sync",
     "ol-openedx-course-translations",
     "ol-openedx-events-handler",
+    "ol-openedx-feedback",
     "ol-openedx-git-auto-export",
     "ol-openedx-logging",
     "ol-openedx-lti-utilities",
@@ -751,9 +752,9 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version < '3.12'" },
-    { name = "sqlparse", marker = "python_full_version < '3.12'" },
-    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b9445fc0695b03746f355c05b2eecc54c34e05198c686f4fc4406b722b52/django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb", size = 10860574, upload-time = "2026-03-03T13:56:05.509Z" }
 wheels = [
@@ -769,9 +770,9 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version >= '3.12'" },
-    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
-    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/e1/894115c6bd70e2c8b66b0c40a3c367d83a5a48c034a4d904d31b62f7c53a/django-6.0.3.tar.gz", hash = "sha256:90be765ee756af8a6cbd6693e56452404b5ad15294f4d5e40c0a55a0f4870fe1", size = 10872701, upload-time = "2026-03-03T13:55:15.026Z" }
 wheels = [
@@ -2249,7 +2250,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-course-sync"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "src/ol_openedx_course_sync" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2314,8 +2315,24 @@ requires-dist = [
 ]
 
 [[package]]
+name = "ol-openedx-feedback"
+version = "0.1.0"
+source = { editable = "src/ol_openedx_feedback" }
+dependencies = [
+    { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "xblock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "django", specifier = ">=4.0" },
+    { name = "xblock" },
+]
+
+[[package]]
 name = "ol-openedx-git-auto-export"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "src/ol_openedx_git_auto_export" }
 dependencies = [
     { name = "celery" },
@@ -2439,7 +2456,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-uai-content-customization"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "src/ol_openedx_uai_content_customization" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/uv.lock
+++ b/uv.lock
@@ -2456,13 +2456,14 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-uai-content-customization"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "src/ol_openedx_uai_content_customization" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "edx-django-utils" },
     { name = "edx-opaque-keys" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -2470,6 +2471,7 @@ requires-dist = [
     { name = "django", specifier = ">=4.0" },
     { name = "edx-django-utils", specifier = ">4.0.0" },
     { name = "edx-opaque-keys" },
+    { name = "requests" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a `uv lock --check` step to CI so PRs that change dependencies without updating uv.lock fail fast. Also regenerate uv.lock to fix pre-existing drift (course-sync, git-auto-export, uai-content-customization version bumps and the missing ol-openedx-feedback entry) so the new check passes.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Add a `uv lock --check` step to CI (before `uv build --all-packages`) so any PR that changes a dependency in a `pyproject.toml` without updating `uv.lock` fails fast.
- Regenerate `uv.lock` to fix pre-existing drift that the new check surfaced: `ol-openedx-course-sync` 1.0.0→1.0.1, `ol-openedx-git-auto-export` 0.8.2→0.8.3, `ol-openedx-uai-content-customization` 0.1.2→0.2.0, and the missing `ol-openedx-feedback` 0.1.0 entry.

Note: pre-commit.ci was considered for this check too, but the `uv-lock` hook requires network access which pre-commit.ci's sandbox doesn't reliably provide, so this is enforced in GitHub Actions CI only.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- `uv lock --check` passes locally after the lock regeneration
