### PR TITLE
fix(canvas-integration): only queue grade sync for Canvas-linked courses

### DIFF
--- a/src/ol_openedx_canvas_integration/CHANGELOG.rst
+++ b/src/ol_openedx_canvas_integration/CHANGELOG.rst
@@ -13,6 +13,28 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.8.3] - 2026-08-05
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Changed
+-------
+* ``sync_user_grade_with_canvas`` is now only queued for courses linked to
+  Canvas (``canvas_id`` set). The check moved from inside the Celery task to
+  the grade-save signal receiver, backed by a short cache
+  (``CANVAS_COURSE_ID_CACHE_TIMEOUT``, default 300 seconds) so it no longer
+  forces a full course lookup — or queues a task at all — for every graded
+  learner interaction on courses with no Canvas integration.
+* The cached linkage lookup now distinguishes a genuine "course not found"
+  from other lookup failures (e.g. a transient modulestore/DB error): only
+  the former is cached as "not linked," while the latter is retried on the
+  next grade save instead of being treated as an unlink.
+* The Celery task's own linkage check (``_sync_user_grade_with_canvas``) now
+  uses the same ``is None`` semantics as the signal receiver, so a
+  falsy-but-valid Canvas course id can't be queued by one and silently
+  dropped by the other.
+* ``CANVAS_COURSE_ID_CACHE_TIMEOUT`` is now coerced to an ``int`` in
+  production settings, so a ``null`` or string override from ops config
+  can't accidentally disable expiry or silently break caching.
+
 [0.8.2] - 2026-07-13
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -87,6 +87,12 @@ Configuration
     CANVAS_ACCESS_TOKEN: <some access token value>
     CANVAS_BASE_URL: <the base URL where Canvas is running>
 
+- (Optional) ``CANVAS_COURSE_ID_CACHE_TIMEOUT`` controls how long, in seconds, the
+  plugin caches whether a course is linked to Canvas. This avoids a full course
+  lookup on every graded learner interaction platform-wide. Defaults to ``300``
+  (5 minutes). Only needs to be set in the LMS config, since the grade-sync check
+  only runs in the LMS.
+
 - Add the following configuration to you CMS settings (depending on you deployment method). These values defined in the LMS settings and are used in `tasks.py`. Since Celery's auto-discovery imports this automatically in the CMS worker, these values need to be defined in the CMS settings to avoid Celery worker failure.
 
   .. code-block::
@@ -147,6 +153,16 @@ Whenever the course is **Published** from the Studio, the **graded subsections**
 """"""""""""""""""""""""""""""
 
 Whenever a learner interacts with a graded question in Open edX, the latest grades are automatically posted to Canvas, if it's a part of a synced assignment. If a grade in Open edX is past the canvas due date, it will not be synced.
+
+.. NOTE::
+
+  Whether a course is linked to Canvas is cached for
+  ``CANVAS_COURSE_ID_CACHE_TIMEOUT`` seconds (300, i.e. 5 minutes, by default) to
+  avoid a full course lookup for every graded learner interaction on the
+  platform. This means grades saved in the first few minutes right after linking
+  a course to Canvas may not sync automatically. Running ``Push all MITx grades
+  to Canvas`` once after linking a course will pick up any grades saved during
+  that window.
 
 3. Automatic Syncing of Due Dates
 """""""""""""""""""""""""""""""""

--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/receivers.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/receivers.py
@@ -3,6 +3,7 @@
 import logging
 
 from ol_openedx_canvas_integration.tasks import sync_user_grade_with_canvas
+from ol_openedx_canvas_integration.utils import get_cached_canvas_course_id
 
 log = logging.getLogger(__name__)
 
@@ -16,5 +17,12 @@ def update_grade_in_canvas(sender, instance, created, **kwargs):  # noqa: ARG001
     updates the Canvas course if the subsection is already synced to a Canvas
     course as an assignment.
     """
+    if get_cached_canvas_course_id(instance.course_id) is None:
+        log.debug(
+            "Course %s has no linked Canvas course. Skipping grade sync.",
+            instance.course_id,
+        )
+        return
+
     log.debug("Grade updated, triggering background task")
     sync_user_grade_with_canvas.delay(instance.id)

--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/settings/lms/common.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/settings/lms/common.py
@@ -5,3 +5,4 @@ def plugin_settings(settings):
     """Settings for the canvas integration plugin."""  # noqa: D401
     settings.CANVAS_ACCESS_TOKEN = None
     settings.CANVAS_BASE_URL = None
+    settings.CANVAS_COURSE_ID_CACHE_TIMEOUT = 300

--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/settings/lms/production.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/settings/lms/production.py
@@ -17,6 +17,12 @@ def plugin_settings(settings):
     settings.CANVAS_BASE_URL = settings.ENV_TOKENS.get(
         "CANVAS_BASE_URL", settings.CANVAS_BASE_URL
     )
+    settings.CANVAS_COURSE_ID_CACHE_TIMEOUT = int(
+        settings.ENV_TOKENS.get(
+            "CANVAS_COURSE_ID_CACHE_TIMEOUT", settings.CANVAS_COURSE_ID_CACHE_TIMEOUT
+        )
+        or settings.CANVAS_COURSE_ID_CACHE_TIMEOUT
+    )
 
     # Re-register the instructor-dashboard tab filter. Production overwrites
     # OPEN_EDX_FILTERS_CONFIG wholesale from the deployment YAML, dropping the

--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/tasks.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/tasks.py
@@ -99,7 +99,7 @@ def _sync_user_grade_with_canvas(grade_id):  # noqa: PLR0911
     grade_instance = PersistentSubsectionGrade.objects.get(id=grade_id)
     course = get_course_by_id(grade_instance.course_id)
     canvas_course_id = get_canvas_course_id(course)
-    if not canvas_course_id:
+    if canvas_course_id is None:
         TASK_LOG.debug("Canvas course ID not found. Skipping grade sync.")
         return
 

--- a/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/utils.py
+++ b/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/utils.py
@@ -1,5 +1,17 @@
 """Utilities for Canvas plugin"""
 
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+from django.http import Http404
+from lms.djangoapps.courseware.courses import get_course_by_id
+
+log = logging.getLogger(__name__)
+
+CANVAS_COURSE_ID_CACHE_KEY_TEMPLATE = "canvas_course_id:{course_id}"
+_MISSING = object()
+
 
 def get_canvas_course_id(course=None):
     """Get the course Id from the course settings"""
@@ -9,6 +21,56 @@ def get_canvas_course_id(course=None):
 def is_canvas_dates_sync_enabled(course=None):
     """Get the canvas due dates setting from the course settings"""
     return course and course.other_course_settings.get("use_canvas_due_dates", False)
+
+
+def get_cached_canvas_course_id(course_id):
+    """
+    Return the Canvas course id linked to ``course_id``, using a short-lived cache.
+
+    Both outcomes (linked / not linked) are cached, so repeated grade saves for the
+    same course don't each force a full modulestore course load. Any failure in the
+    lookup or cache access is caught so it can never propagate out of the
+    ``post_save`` signal receiver that calls this. A failure to *read or write* the
+    cache is treated as a cache miss / no-op rather than "not linked", so a cache
+    outage can never cause a Canvas-linked course to be treated as unlinked. Only a
+    genuine "course not found" is treated as (and cached as) "not linked" -- any
+    other lookup failure (e.g. a transient modulestore/DB error) returns None
+    without caching, so it's retried on the next grade save instead of being
+    conflated with a real unlink.
+    """
+    cache_key = CANVAS_COURSE_ID_CACHE_KEY_TEMPLATE.format(course_id=course_id)
+
+    try:
+        cached_value = cache.get(cache_key, _MISSING)
+    except Exception:
+        log.warning(
+            "Could not read cached Canvas course id for %s", course_id, exc_info=True
+        )
+        cached_value = _MISSING
+
+    if cached_value is not _MISSING:
+        return cached_value
+
+    try:
+        course = get_course_by_id(course_id)
+    except Http404:
+        log.warning(
+            "Could not determine Canvas course id for %s: course not found",
+            course_id,
+        )
+        canvas_course_id = None
+    except Exception:
+        log.exception("Unexpected error determining Canvas course id for %s", course_id)
+        return None
+    else:
+        canvas_course_id = get_canvas_course_id(course)
+
+    try:
+        cache.set(cache_key, canvas_course_id, settings.CANVAS_COURSE_ID_CACHE_TIMEOUT)
+    except Exception:
+        log.warning("Could not cache Canvas course id for %s", course_id, exc_info=True)
+
+    return canvas_course_id
 
 
 def get_task_output_formatted_message(task_output):

--- a/src/ol_openedx_canvas_integration/pyproject.toml
+++ b/src/ol_openedx_canvas_integration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-canvas-integration"
-version = "0.8.2"
+version = "0.8.3"
 description = "An Open edX plugin to add canvas integration support"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_canvas_integration/tests/test_production_settings.py
+++ b/src/ol_openedx_canvas_integration/tests/test_production_settings.py
@@ -1,0 +1,44 @@
+"""Tests for the canvas integration plugin's production settings."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ol_openedx_canvas_integration.settings.lms import production
+
+
+def _app_settings(**env_tokens):
+    """Build a minimal settings namespace for ``plugin_settings``."""
+    return SimpleNamespace(
+        AUTH_TOKENS={},
+        ENV_TOKENS=env_tokens,
+        CANVAS_ACCESS_TOKEN=None,
+        CANVAS_BASE_URL=None,
+        CANVAS_COURSE_ID_CACHE_TIMEOUT=300,
+        OPEN_EDX_FILTERS_CONFIG={},
+        TEMPLATES=[{"DIRS": []}],
+    )
+
+
+class TestCanvasCourseIdCacheTimeout:
+    """Tests for ``CANVAS_COURSE_ID_CACHE_TIMEOUT`` coercion in production settings."""
+
+    def test_defaults_when_key_absent(self):
+        app_settings = _app_settings()
+        production.plugin_settings(app_settings)
+        assert app_settings.CANVAS_COURSE_ID_CACHE_TIMEOUT == 300  # noqa: PLR2004
+
+    def test_string_override_is_coerced_to_int(self):
+        app_settings = _app_settings(CANVAS_COURSE_ID_CACHE_TIMEOUT="600")
+        production.plugin_settings(app_settings)
+        assert app_settings.CANVAS_COURSE_ID_CACHE_TIMEOUT == 600  # noqa: PLR2004
+
+    def test_explicit_none_override_falls_back_to_default(self):
+        app_settings = _app_settings(CANVAS_COURSE_ID_CACHE_TIMEOUT=None)
+        production.plugin_settings(app_settings)
+        assert app_settings.CANVAS_COURSE_ID_CACHE_TIMEOUT == 300  # noqa: PLR2004
+
+    def test_int_override_is_kept(self):
+        app_settings = _app_settings(CANVAS_COURSE_ID_CACHE_TIMEOUT=900)
+        production.plugin_settings(app_settings)
+        assert app_settings.CANVAS_COURSE_ID_CACHE_TIMEOUT == 900  # noqa: PLR2004

--- a/src/ol_openedx_canvas_integration/tests/test_receivers.py
+++ b/src/ol_openedx_canvas_integration/tests/test_receivers.py
@@ -17,17 +17,33 @@ class StubSyncUserGradeTask:
         self.delay_calls.append(args)
 
 
-def test_update_grade_in_canvas_triggers_background_task(monkeypatch):
-    """Test that update grade in canvas triggers background task."""
-    instance = SimpleNamespace(id=321)
+def test_update_grade_in_canvas_triggers_background_task_when_canvas_linked(
+    monkeypatch,
+):
+    """Test that a Canvas-linked course's grade save dispatches the sync task."""
+    instance = SimpleNamespace(id=321, course_id="course-v1:MITx+1+2026")
     stub_task = StubSyncUserGradeTask()
 
     monkeypatch.setattr(receivers, "sync_user_grade_with_canvas", stub_task)
-
-    receivers.update_grade_in_canvas(
-        sender="sender",
-        instance=instance,
-        created=False,
+    monkeypatch.setattr(
+        receivers, "get_cached_canvas_course_id", lambda _course_id: 12345
     )
 
+    receivers.update_grade_in_canvas(sender="sender", instance=instance, created=False)
+
     assert stub_task.delay_calls == [(321,)]
+
+
+def test_update_grade_in_canvas_skips_when_course_not_canvas_linked(monkeypatch):
+    """Test that a non-Canvas course's grade save does not dispatch the sync task."""
+    instance = SimpleNamespace(id=321, course_id="course-v1:MITx+1+2026")
+    stub_task = StubSyncUserGradeTask()
+
+    monkeypatch.setattr(receivers, "sync_user_grade_with_canvas", stub_task)
+    monkeypatch.setattr(
+        receivers, "get_cached_canvas_course_id", lambda _course_id: None
+    )
+
+    receivers.update_grade_in_canvas(sender="sender", instance=instance, created=False)
+
+    assert stub_task.delay_calls == []

--- a/src/ol_openedx_canvas_integration/tests/test_utils.py
+++ b/src/ol_openedx_canvas_integration/tests/test_utils.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 import pytest
+from django.http import Http404
 
 from ol_openedx_canvas_integration import utils
 
@@ -100,3 +102,220 @@ def test_get_canvas_course_id(course, expected):
 def test_get_task_output_formatted_message(task_output, expected):
     """Test that formatted message correctly reports grade and assignment counts."""
     assert utils.get_task_output_formatted_message(task_output) == expected
+
+
+_CACHE_MISS = object()
+
+
+class StubCache:
+    """Cache stub that captures get and set operations."""
+
+    def __init__(self, get_value=_CACHE_MISS):
+        """Initialize cache hit value (defaults to a miss) and call capture lists."""
+        self.get_value = get_value
+        self.get_calls = []
+        self.set_calls = []
+
+    def get(self, key, default=None):
+        """Record cache get lookups; return the configured value, or default on miss."""
+        self.get_calls.append(key)
+        return default if self.get_value is _CACHE_MISS else self.get_value
+
+    def set(self, key, value, timeout=None):
+        """Record cache set operations."""
+        self.set_calls.append((key, value, timeout))
+
+
+@pytest.mark.parametrize(
+    ("cache_get_value", "expected"),
+    [
+        pytest.param(54321, 54321, id="cache_hit_positive"),
+        pytest.param(None, None, id="cache_hit_negative"),
+    ],
+)
+def test_get_cached_canvas_course_id_uses_cache_hit_without_course_lookup(
+    monkeypatch, cache_get_value, expected
+):
+    """Test that a cache hit is returned without loading the course."""
+    stub_cache = StubCache(get_value=cache_get_value)
+    course_lookup_calls = []
+    monkeypatch.setattr(utils, "cache", stub_cache)
+
+    def _track_course_lookup(course_id):
+        course_lookup_calls.append(course_id)
+
+    monkeypatch.setattr(utils, "get_course_by_id", _track_course_lookup)
+
+    assert utils.get_cached_canvas_course_id("course-v1:MITx+1+2026") == expected
+    assert course_lookup_calls == []
+    assert stub_cache.set_calls == []
+
+
+@pytest.mark.parametrize(
+    ("course", "expected_cached_value", "expected_result"),
+    [
+        pytest.param(
+            SimpleNamespace(other_course_settings={"canvas_id": CANVAS_COURSE_ID_1}),
+            CANVAS_COURSE_ID_1,
+            CANVAS_COURSE_ID_1,
+            id="cache_miss_with_canvas_id",
+        ),
+        pytest.param(
+            SimpleNamespace(other_course_settings={}),
+            None,
+            None,
+            id="cache_miss_without_canvas_id",
+        ),
+    ],
+)
+def test_get_cached_canvas_course_id_caches_result_on_miss(
+    monkeypatch, course, expected_cached_value, expected_result
+):
+    """Test that a cache miss loads the course and caches the outcome.
+
+    ``None`` is cached directly for courses without Canvas IDs.
+    """
+    stub_cache = StubCache()
+    monkeypatch.setattr(utils, "cache", stub_cache)
+    monkeypatch.setattr(
+        utils, "settings", SimpleNamespace(CANVAS_COURSE_ID_CACHE_TIMEOUT=60)
+    )
+    monkeypatch.setattr(utils, "get_course_by_id", lambda _course_id: course)
+
+    result = utils.get_cached_canvas_course_id("course-v1:MITx+1+2026")
+
+    assert result == expected_result
+    assert stub_cache.set_calls == [
+        ("canvas_course_id:course-v1:MITx+1+2026", expected_cached_value, 60)
+    ]
+
+
+def test_get_cached_canvas_course_id_falls_back_to_lookup_when_cache_get_fails(
+    monkeypatch, caplog
+):
+    """Test that a cache.get failure (e.g. cache backend outage) is treated as a miss.
+
+    Logs a warning but still resolves and returns the Canvas course id via the
+    course lookup, rather than treating the course as unlinked.
+    """
+
+    class RaisingGetCache(StubCache):
+        """Cache stub whose get() simulates a cache backend outage."""
+
+        def get(self, _key, _default=None):
+            """Raise to simulate a cache backend outage."""
+            msg = "cache backend unavailable"
+            raise ConnectionError(msg)
+
+    stub_cache = RaisingGetCache()
+    monkeypatch.setattr(utils, "cache", stub_cache)
+    monkeypatch.setattr(
+        utils, "settings", SimpleNamespace(CANVAS_COURSE_ID_CACHE_TIMEOUT=60)
+    )
+    monkeypatch.setattr(
+        utils,
+        "get_course_by_id",
+        lambda _course_id: SimpleNamespace(
+            other_course_settings={"canvas_id": CANVAS_COURSE_ID_1}
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = utils.get_cached_canvas_course_id("course-v1:MITx+1+2026")
+
+    assert result == CANVAS_COURSE_ID_1
+    assert "Could not read cached Canvas course id" in caplog.text
+
+
+def test_get_cached_canvas_course_id_caches_none_when_course_not_found(
+    monkeypatch, caplog
+):
+    """Test that a "course not found" lookup failure is cached as "not linked".
+
+    Returns None and logs a warning. Unlike other lookup failures, this one is
+    a genuine "not linked" outcome, so it's cached like any other negative
+    result instead of being retried on every subsequent grade save.
+    """
+    stub_cache = StubCache()
+    monkeypatch.setattr(utils, "cache", stub_cache)
+    monkeypatch.setattr(
+        utils, "settings", SimpleNamespace(CANVAS_COURSE_ID_CACHE_TIMEOUT=60)
+    )
+
+    def _raise(_course_id):
+        msg = "course not found"
+        raise Http404(msg)
+
+    monkeypatch.setattr(utils, "get_course_by_id", _raise)
+
+    with caplog.at_level(logging.WARNING):
+        result = utils.get_cached_canvas_course_id("course-v1:MITx+1+2026")
+
+    assert result is None
+    assert stub_cache.set_calls == [
+        ("canvas_course_id:course-v1:MITx+1+2026", None, 60)
+    ]
+    assert "Could not determine Canvas course id" in caplog.text
+
+
+def test_get_cached_canvas_course_id_returns_none_and_skips_cache_on_unexpected_error(
+    monkeypatch, caplog
+):
+    """Test that an unexpected lookup error (not "course not found") isn't cached.
+
+    A transient failure (e.g. a modulestore timeout) should return None without
+    caching it as "not linked", so the next grade save retries the lookup instead
+    of treating the course as permanently unlinked.
+    """
+    stub_cache = StubCache()
+    monkeypatch.setattr(utils, "cache", stub_cache)
+
+    def _raise(_course_id):
+        msg = "modulestore timeout"
+        raise ConnectionError(msg)
+
+    monkeypatch.setattr(utils, "get_course_by_id", _raise)
+
+    with caplog.at_level(logging.ERROR):
+        result = utils.get_cached_canvas_course_id("course-v1:MITx+1+2026")
+
+    assert result is None
+    assert stub_cache.set_calls == []
+    assert "Unexpected error determining Canvas course id" in caplog.text
+
+
+def test_get_cached_canvas_course_id_returns_id_when_cache_set_fails(
+    monkeypatch, caplog
+):
+    """Test that a cache.set failure (e.g. cache backend outage) is handled.
+
+    Logs a warning but still returns the resolved Canvas course id, so a cache
+    outage can't cause a Canvas-linked course to be treated as unlinked.
+    """
+
+    class RaisingCache(StubCache):
+        """Cache stub whose set() simulates a cache backend outage."""
+
+        def set(self, _key, _value, _timeout=None):
+            """Raise to simulate a cache backend outage."""
+            msg = "cache backend unavailable"
+            raise ConnectionError(msg)
+
+    stub_cache = RaisingCache()
+    monkeypatch.setattr(utils, "cache", stub_cache)
+    monkeypatch.setattr(
+        utils, "settings", SimpleNamespace(CANVAS_COURSE_ID_CACHE_TIMEOUT=60)
+    )
+    monkeypatch.setattr(
+        utils,
+        "get_course_by_id",
+        lambda _course_id: SimpleNamespace(
+            other_course_settings={"canvas_id": CANVAS_COURSE_ID_1}
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = utils.get_cached_canvas_course_id("course-v1:MITx+1+2026")
+
+    assert result == CANVAS_COURSE_ID_1
+    assert "Could not cache Canvas course id" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-canvas-integration"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "src/ol_openedx_canvas_integration" }
 dependencies = [
     { name = "celery" },


### PR DESCRIPTION
### Related ticket
None, Related to [This Slack Thread](https://mitodl.slack.com/archives/C02649X2P1V/p1783689691874519)

## Description
- `sync_user_grade_with_canvas` was being queued as a Celery task for **every** subsection-grade save on the entire platform, even for courses with no Canvas integration — the only Canvas-linkage check happened inside the task itself, after it was already queued and picked up by a worker.
- The `post_save` receiver (`update_grade_in_canvas`) now checks Canvas linkage *before* deciding whether to queue the task, via a new cached helper `get_cached_canvas_course_id()` (60s TTL by default, configurable via `CANVAS_COURSE_ID_CACHE_TIMEOUT`) that caches both "linked" and "not linked" outcomes, so non-Canvas courses stop enqueuing the task at all instead of just short-circuiting inside it.
- The lookup is fully guarded against failures (cache backend outage, missing course, etc.) so nothing can propagate out of the signal receiver into whatever code path saved the grade.
- Documented the setting and a caveat: a grade saved in the ~60s right after linking a course to Canvas may not auto-sync (cached negative result); the plugin's existing "Push all MITx grades to Canvas" instructor action is the documented recovery path.
- Version bumped 0.8.2 → 0.8.3 with a changelog entry.

## Testing Instructions
-  Setup a canvas Course 
- Make sure that there is a `"canvas_id": <value>` set in `Other course settings` in Advanced course settings in Studio
- Now submit any grade and the task `sync_user_grade_with_canvas` should be called.
-  Now test it on a course where the `canvas_id` is not set. The task `sync_user_grade_with_canvas` should not be called. (This is the step that you should reproduce first on main branch in order to test because on main branch this task sync_user_grade_with_canvas will be called for all the courses where a grade is submitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)