### PR TITLE
ci: continue matrix jobs on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version:
         - 3.11


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Sets `fail-fast: false` on the integration-tests matrix strategy in `.github/workflows/ci.yml` so a failing `edx_branch` (e.g. `master`) doesn't cancel the other in-progress matrix jobs (`release/teak`, `release/ulmo`).

### Screenshots (if appropriate):

### How can this be tested?
Trigger the CI workflow on this branch and confirm all matrix jobs (`master`, `release/teak`, `release/ulmo`) continue running to completion even if one of them fails, instead of the others being cancelled.

### Additional Context
