### PR TITLE
chore: swap Teak for Verawood in CI and raise Django floor to >=5.2

### DIFF
--- a/.github/actions/setup-tutor/action.yml
+++ b/.github/actions/setup-tutor/action.yml
@@ -7,7 +7,7 @@ description: >-
   disagree about the cache tag.
 inputs:
   edx_branch:
-    description: Open edX branch under test, e.g. master or release/teak
+    description: Open edX branch under test, e.g. master or release/verawood
     required: true
   ghcr_owner:
     description: GitHub org that owns the openedx-dev-cache package
@@ -39,8 +39,8 @@ runs:
     env:
       EDX_BRANCH: ${{ inputs.edx_branch }}
     run: |
-      if [[ "$EDX_BRANCH" == "release/teak" ]]; then
-        pip install "tutor>=20.0.0,<21.0.0"
+      if [[ "$EDX_BRANCH" == "release/verawood" ]]; then
+        pip install "tutor>=22.0.0,<23.0.0"
       elif [[ "$EDX_BRANCH" == "master" ]]; then
         git clone --depth=1 --branch=main https://github.com/overhangio/tutor.git
         pip install -e "./tutor"

--- a/.github/actions/setup-tutor/action.yml
+++ b/.github/actions/setup-tutor/action.yml
@@ -44,8 +44,11 @@ runs:
       elif [[ "$EDX_BRANCH" == "master" ]]; then
         git clone --depth=1 --branch=main https://github.com/overhangio/tutor.git
         pip install -e "./tutor"
-      else
+      elif [[ "$EDX_BRANCH" == "release/ulmo" ]]; then
         pip install "tutor>=21.0.0,<22.0.0"
+      else
+        echo "No Tutor version mapping for edx_branch '$EDX_BRANCH'" >&2
+        exit 1
       fi
 
   - name: Derive image names

--- a/.github/edx-branches.json
+++ b/.github/edx-branches.json
@@ -1,1 +1,1 @@
-["master", "release/teak", "release/ulmo"]
+["master", "release/verawood", "release/ulmo"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,18 +95,18 @@ jobs:
         fi
         echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-    # edx-platform's minimum Python version varies by branch (master moved
-    # to 3.12; the release branches are still on 3.11), so it can't be a
+    # edx-platform's minimum Python version varies by branch (master and
+    # verawood moved to 3.12; ulmo is still on 3.11), so it can't be a
     # single matrix-wide value the way it could when every branch agreed.
     - name: Resolve Python version for edx-platform
       id: python-version
       env:
         EDX_BRANCH: ${{ matrix.edx_branch }}
       run: |
-        if [[ "$EDX_BRANCH" == "master" ]]; then
-          echo "version=3.12" >> "$GITHUB_OUTPUT"
-        else
+        if [[ "$EDX_BRANCH" == "release/ulmo" ]]; then
           echo "version=3.11" >> "$GITHUB_OUTPUT"
+        else
+          echo "version=3.12" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Set up uv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository contains a collection of 17+ Open edX plugins that extend and en
 
 **Repository Type:** Python monorepo with multiple independent plugin packages
 **Size:** ~170 Python source files across 17 plugins
-**Languages/Frameworks:** Python 3.11+, Django 4.0+, Open edX platform
+**Languages/Frameworks:** Python 3.11+, Django 5.2+, Open edX platform
 **Build System:** UV (modern Python package manager), Hatchling backend
 **Target Runtime:** Open edX platform (tested against master, ulmo, and verawood releases)
 
@@ -154,7 +154,7 @@ cd /openedx/open-edx-plugins
 
 **1. CI Workflow (`.github/workflows/ci.yml`)**
 - **Triggers:** Push to main, all PRs
-- **Matrix:** Python 3.11 × 3 Open edX branches (master, ulmo, verawood)
+- **Matrix:** 3 Open edX branches (master, ulmo, verawood) — Python 3.12 for master and verawood, 3.11 for ulmo
 - **Steps:**
   1. Checkout code
   2. Setup UV with caching

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repository contains a collection of 17+ Open edX plugins that extend and en
 **Size:** ~170 Python source files across 17 plugins
 **Languages/Frameworks:** Python 3.11+, Django 4.0+, Open edX platform
 **Build System:** UV (modern Python package manager), Hatchling backend
-**Target Runtime:** Open edX platform (tested against master, sumac.master, and teak releases)
+**Target Runtime:** Open edX platform (tested against master, ulmo, and verawood releases)
 
 ## Repository Structure
 
@@ -108,8 +108,8 @@ cd open-edx-plugins
 uv build --all-packages
 
 # Install Tutor (version depends on Open edX release)
-pip install "tutor>=19.0.0,<20.0.0"  # For sumac.master
-# OR pip install "tutor>=20.0.0,<21.0.0"  # For teak release
+pip install "tutor>=21.0.0,<22.0.0"  # For ulmo release
+# OR pip install "tutor>=22.0.0,<23.0.0"  # For verawood release
 # OR install from main branch for master
 
 # Mount plugin directory
@@ -154,7 +154,7 @@ cd /openedx/open-edx-plugins
 
 **1. CI Workflow (`.github/workflows/ci.yml`)**
 - **Triggers:** Push to main, all PRs
-- **Matrix:** Python 3.11 × 3 Open edX branches (master, sumac.master, teak)
+- **Matrix:** Python 3.11 × 3 Open edX branches (master, ulmo, verawood)
 - **Steps:**
   1. Checkout code
   2. Setup UV with caching

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,12 @@ plugin_name = "plugin_name.apps:ConfigClass"
    - **CRITICAL:** Update version in `src/<plugin>/pyproject.toml` before merging to main
    - Version follows semantic versioning
    - Publishing to PyPI happens automatically on main branch merge
+   - **If this release changes which Open edX release(s) the plugin supports**
+     (e.g. a dependency-floor bump like the Django 5.2 floor raised for
+     Ulmo/Verawood), update the Open edX Release Compatibility table in
+     `docs/README.rst` with the new min/max version boundary, and update the
+     plugin's own `Version Compatibility` section in its `README.rst` if it
+     has release-specific notes beyond a link to that table.
 
 4. **Common issues:**
    - **Django not configured:** Tests need Open edX environment
@@ -248,6 +254,7 @@ plugin_name = "plugin_name.apps:ConfigClass"
 
 Before submitting changes:
 - [ ] Updated plugin version in `src/<plugin>/pyproject.toml` (if applicable)
+- [ ] Updated the Open edX Release Compatibility table in `docs/README.rst` (if this version changes which Open edX release the plugin supports)
 - [ ] Code formatted: `uv run ruff format .`
 - [ ] Linting passes: `uv run ruff check .`
 - [ ] Pre-commit hooks pass: `pre-commit run --all-files`

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -32,9 +32,9 @@ ol-openedx-course-export                  0.2.0                                 
 ol-openedx-course-outline-api             0.1.0                                     0.2.0
 ol-openedx-course-structure-api           0.2.0                                     0.3.0
 ol-openedx-course-sync                    1.0.1                                     1.1.0
-ol-openedx-course-translations            0.8.0                                     0.9.0
-ol-openedx-events-handler                 0.2.1                                     0.4.0
-ol-openedx-feedback                       0.2.0                                     0.3.0
+ol-openedx-course-translations            0.9.1                                     0.10.0
+ol-openedx-events-handler                 0.3.0                                     0.4.0
+ol-openedx-feedback                       0.2.2                                     0.3.0
 ol-openedx-git-auto-export                0.8.3                                     0.9.0
 ol-openedx-logging                        0.3.5                                     0.4.0
 ol-openedx-lti-utilities                  0.1.2                                     0.2.0

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -3,6 +3,50 @@ Open edX Plugins
 
 This repository contains a collection of Open edX plugins that provide various custom functionalities for the Open edX platform.
 
+Open edX Release Compatibility
+-------------------------------
+
+In August 2026 this repository raised its Django dependency floor from
+``Django>=4.0`` to ``Django>=5.2`` across every plugin, to match the
+``Ulmo`` (Django 5.2.11) and ``Verawood`` (Django 5.2.13) Open edX releases.
+Installing a plugin version below its listed minimum on Ulmo/Verawood (or
+``master``) - or above its listed maximum on Teak and earlier - can pull in
+a Django release the target edx-platform doesn't support.
+
+Individual plugins may have additional, feature-specific compatibility notes
+in their own ``README.rst`` (see each plugin's ``Version Compatibility``
+section) - the table below only tracks the Django 5.2 floor.
+
+========================================  ========================================  ===================================
+Plugin                                    Max version for Teak and earlier          Min version for Ulmo / Verawood+
+========================================  ========================================  ===================================
+edx-sysadmin                              0.4.2                                     0.5.0
+edx-username-changer                      0.5.0                                     0.6.0
+ol-openedx-ai-static-translations         0.1.1                                     0.2.0
+ol-openedx-auto-select-language           0.1.2                                     0.2.0
+ol-openedx-canvas-integration             0.8.2                                     0.9.0
+ol-openedx-chat                           0.5.10                                    0.6.0
+ol-openedx-chat-xblock                    0.4.6                                     0.5.0
+ol-openedx-checkout-external              0.2.0                                     0.3.0
+ol-openedx-course-export                  0.2.0                                     0.3.0
+ol-openedx-course-outline-api             0.1.0                                     0.2.0
+ol-openedx-course-structure-api           0.2.0                                     0.3.0
+ol-openedx-course-sync                    1.0.1                                     1.1.0
+ol-openedx-course-translations            0.8.0                                     0.9.0
+ol-openedx-events-handler                 0.2.1                                     0.4.0
+ol-openedx-feedback                       0.2.0                                     0.3.0
+ol-openedx-git-auto-export                0.8.3                                     0.9.0
+ol-openedx-logging                        0.3.5                                     0.4.0
+ol-openedx-lti-utilities                  0.1.2                                     0.2.0
+ol-openedx-otel-monitoring                0.2.0                                     0.3.0
+ol-openedx-rapid-response-reports         0.5.1                                     0.6.0
+ol-openedx-sentry                         0.4.0                                     0.5.0
+ol-openedx-uai-content-customization      0.3.0                                     0.4.0
+ol-social-auth                            0.2.2                                     0.3.0
+openedx-companion-auth                    1.2.0                                     1.3.0
+rapid-response-xblock                     0.11.0                                    0.12.0
+========================================  ========================================  ===================================
+
 Installation Guide
 ------------------
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -24,7 +24,7 @@ edx-sysadmin                              0.4.2                                 
 edx-username-changer                      0.5.0                                     0.6.0
 ol-openedx-ai-static-translations         0.1.1                                     0.2.0
 ol-openedx-auto-select-language           0.1.2                                     0.2.0
-ol-openedx-canvas-integration             0.8.2                                     0.9.0
+ol-openedx-canvas-integration             0.8.3                                     0.9.0
 ol-openedx-chat                           0.5.10                                    0.6.0
 ol-openedx-chat-xblock                    0.4.6                                     0.5.0
 ol-openedx-checkout-external              0.2.0                                     0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@ license = "BSD-3-Clause"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "Django>=4.0",
+    "Django>=5.2",
     "celery>=4.4.7",
-    "djangorestframework>=3.14.0",
+    "djangorestframework>=3.16.0",
     "edx-django-utils",
-    "edx-drf-extensions>=10.0.0",
+    "edx-drf-extensions>=10.6.0",
     "edx-opaque-keys",
     "gitpython>=3.1.37",
     "python-json-logger>=3.0.0",

--- a/src/edx_sysadmin/README.rst
+++ b/src/edx_sysadmin/README.rst
@@ -23,6 +23,9 @@ Use any version of edx-sysadmin plugin.
 
 You do not need edx-sysadmin plugin. Just enable ``ENABLE_SYSADMIN_DASHBOARD`` feature flag in environment files (e.g ``lms.yml`` or ``lms.env.json``) to access sysadmin dashboard features.
 
+For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
+
 
 Installing The Plugin
 ---------------------

--- a/src/edx_sysadmin/README.rst
+++ b/src/edx_sysadmin/README.rst
@@ -23,7 +23,7 @@ Use any version of edx-sysadmin plugin.
 
 You do not need edx-sysadmin plugin. Just enable ``ENABLE_SYSADMIN_DASHBOARD`` feature flag in environment files (e.g ``lms.yml`` or ``lms.env.json``) to access sysadmin dashboard features.
 
-For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+For this plugin's compatibility with Open edX, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 

--- a/src/edx_sysadmin/pyproject.toml
+++ b/src/edx_sysadmin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "edx-sysadmin"
-version = "0.4.2"
+version = "0.5.0"
 description = "An Open edX plugin to enable SysAdmin panel"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,10 +10,10 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "GitPython>=3.1.45",
   "edx-opaque-keys",
 ]

--- a/src/edx_username_changer/README.rst
+++ b/src/edx_username_changer/README.rst
@@ -8,7 +8,7 @@ Version Compatibility
 
 It only supports koa and latest releases of Open edX.
 
-For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+For this plugin's compatibility with Open edX, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Forum Backend Support

--- a/src/edx_username_changer/README.rst
+++ b/src/edx_username_changer/README.rst
@@ -8,6 +8,9 @@ Version Compatibility
 
 It only supports koa and latest releases of Open edX.
 
+For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
+
 Forum Backend Support
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/edx_username_changer/pyproject.toml
+++ b/src/edx_username_changer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "edx-username-changer"
-version = "0.5.0"
+version = "0.6.0"
 description = "An edX plugin to change username of edx accounts through admin panel"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,10 +10,10 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "celery>=4.4.7",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
 ]
 
 [project.entry-points."lms.djangoapp"]

--- a/src/ol_openedx_ai_static_translations/README.rst
+++ b/src/ol_openedx_ai_static_translations/README.rst
@@ -11,9 +11,8 @@ This plugin provides the ``sync_and_translate_language`` management command for 
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Setup
 =====

--- a/src/ol_openedx_ai_static_translations/README.rst
+++ b/src/ol_openedx_ai_static_translations/README.rst
@@ -8,6 +8,13 @@ Purpose
 
 This plugin provides the ``sync_and_translate_language`` management command for syncing and translating Open edX static strings (frontend JSON and backend PO files) using LLM providers (OpenAI, Gemini, Mistral) with optional glossary support.
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Setup
 =====
 

--- a/src/ol_openedx_ai_static_translations/pyproject.toml
+++ b/src/ol_openedx_ai_static_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-ai-static-translations"
-version = "0.1.1"
+version = "0.2.0"
 description = "An Open edX plugin for AI-powered static translation management"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,7 +10,7 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "GitPython>=3.1.40",
   "litellm>=1.80.0",
   "polib>=1.2.0",

--- a/src/ol_openedx_auto_select_language/README.rst
+++ b/src/ol_openedx_auto_select_language/README.rst
@@ -8,6 +8,13 @@ Purpose
 
 Auto select the Open edX platform language based on the course language. When enabled, users will see the static site content in the course's configured language.
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Setup
 =====
 

--- a/src/ol_openedx_auto_select_language/README.rst
+++ b/src/ol_openedx_auto_select_language/README.rst
@@ -11,9 +11,8 @@ Auto select the Open edX platform language based on the course language. When en
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Setup
 =====

--- a/src/ol_openedx_auto_select_language/pyproject.toml
+++ b/src/ol_openedx_auto_select_language/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-auto-select-language"
-version = "0.1.2"
+version = "0.2.0"
 description = "An Open edX plugin to auto-select the language based on course language settings."
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,8 +10,8 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
   "edx-opaque-keys",
 ]
 

--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -65,6 +65,9 @@ Use ``0.2.4`` or a above version of this plugin
 
 Use ``0.1.1`` version of this plugin
 
+For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
+
 Installation
 ------------
 

--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -65,7 +65,7 @@ Use ``0.2.4`` or a above version of this plugin
 
 Use ``0.1.1`` version of this plugin
 
-For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+For this plugin's compatibility with Open edX, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation

--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -49,9 +49,10 @@ https://github.com/mitodl/edx-platform/commit/7a2edd5d29ead6845cb33d2001746207cf
 Version Compatibility
 ---------------------
 
-**For "Sumac" or more recent release of edX platform**
+**For "Sumac" through "Teak" release of edX platform**
 
-Use ``0.4.0`` or a above version of this plugin
+Use a version between ``0.4.0`` and ``0.8.2`` of this plugin. For Ulmo/Verawood+, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_ below.
 
 **For "Quince" to "Redwood" release of edX platform**
 

--- a/src/ol_openedx_canvas_integration/README.rst
+++ b/src/ol_openedx_canvas_integration/README.rst
@@ -51,7 +51,7 @@ Version Compatibility
 
 **For "Sumac" through "Teak" release of edX platform**
 
-Use a version between ``0.4.0`` and ``0.8.2`` of this plugin. For Ulmo/Verawood+, see the
+Use a version between ``0.4.0`` and ``0.8.3`` of this plugin. For Ulmo/Verawood+, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_ below.
 
 **For "Quince" to "Redwood" release of edX platform**

--- a/src/ol_openedx_canvas_integration/pyproject.toml
+++ b/src/ol_openedx_canvas_integration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-canvas-integration"
-version = "0.8.3"
+version = "0.9.0"
 description = "An Open edX plugin to add canvas integration support"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,11 +9,11 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "celery>=4.4.7",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
   "openedx-events",
 ]

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -12,9 +12,8 @@ MIT's AI chatbot for Open edX
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Setup
 =====

--- a/src/ol_openedx_chat/README.rst
+++ b/src/ol_openedx_chat/README.rst
@@ -9,6 +9,13 @@ Purpose
 
 MIT's AI chatbot for Open edX
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Setup
 =====
 

--- a/src/ol_openedx_chat/pyproject.toml
+++ b/src/ol_openedx_chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat"
-version = "0.5.10"
+version = "0.6.0"
 description = "An Open edX plugin to add Open Learning AI chat aside to xBlocks"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,9 +10,9 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
   "XBlock",
 ]
 

--- a/src/ol_openedx_chat_xblock/README.rst
+++ b/src/ol_openedx_chat_xblock/README.rst
@@ -15,9 +15,8 @@ MIT's AI chatbot xBlock for Open edX
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Setup
 =====

--- a/src/ol_openedx_chat_xblock/README.rst
+++ b/src/ol_openedx_chat_xblock/README.rst
@@ -12,6 +12,13 @@ Purpose
 
 MIT's AI chatbot xBlock for Open edX
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Setup
 =====
 

--- a/src/ol_openedx_chat_xblock/pyproject.toml
+++ b/src/ol_openedx_chat_xblock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat-xblock"
-version = "0.4.6"
+version = "0.5.0"
 description = "An Open edX xBlock to add Open Learning AI chat"
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}
@@ -11,11 +11,11 @@ keywords = ["Python", "edx"]
 requires-python = ">=3.11"
 
 dependencies = [
-  "django>=3.2",
-  "edx-django-utils>=1.3.0",
-  "djangorestframework>=3.14.0",
-  "xblock>=1.9.0",
-  "xblock-utils>=1.2.0",
+  "Django>=5.2",
+  "edx-django-utils>=8.0.0",
+  "djangorestframework>=3.16.0",
+  "xblock>=5.2.0",
+  "xblock-utils>=4.0.0",
 ]
 
 [project.urls]

--- a/src/ol_openedx_checkout_external/README.rst
+++ b/src/ol_openedx_checkout_external/README.rst
@@ -8,9 +8,8 @@ The plugin redirects the user the desired external ecommerce service upon clicki
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ------------

--- a/src/ol_openedx_checkout_external/README.rst
+++ b/src/ol_openedx_checkout_external/README.rst
@@ -5,6 +5,13 @@ A django app plugin to add a new API to Open edX for external checkouts.
 The plugin redirects the user the desired external ecommerce service upon clicking the **Upgrade** button in LMS dashboard or Learning MFE.
 
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ------------
 

--- a/src/ol_openedx_checkout_external/pyproject.toml
+++ b/src/ol_openedx_checkout_external/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-checkout-external"
-version = "0.2.0"
+version = "0.3.0"
 description = "An Open edX plugin to add API for external checkouts"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,10 +9,10 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
 ]
 

--- a/src/ol_openedx_course_export/README.rst
+++ b/src/ol_openedx_course_export/README.rst
@@ -4,6 +4,13 @@ Course Export S3 Plugin
 A django app plugin to add a new API to Open edX to export courses to S3 buckets.
 
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ------------
 

--- a/src/ol_openedx_course_export/README.rst
+++ b/src/ol_openedx_course_export/README.rst
@@ -7,9 +7,8 @@ A django app plugin to add a new API to Open edX to export courses to S3 buckets
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ------------

--- a/src/ol_openedx_course_export/pyproject.toml
+++ b/src/ol_openedx_course_export/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-export"
-version = "0.2.0"
+version = "0.3.0"
 description = "An Open edX plugin to add API for course export to s3"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,11 +9,11 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "celery>=4.4.7",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
 ]
 

--- a/src/ol_openedx_course_outline_api/README.rst
+++ b/src/ol_openedx_course_outline_api/README.rst
@@ -4,6 +4,13 @@ Course Outline API Plugin
 A django app plugin to add a new API to Open edX that returns a course outline summary (one entry
 per chapter) for a given course.
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ------------
 

--- a/src/ol_openedx_course_outline_api/README.rst
+++ b/src/ol_openedx_course_outline_api/README.rst
@@ -7,9 +7,8 @@ per chapter) for a given course.
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ------------

--- a/src/ol_openedx_course_outline_api/pyproject.toml
+++ b/src/ol_openedx_course_outline_api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-outline-api"
-version = "0.1.0"
+version = "0.2.0"
 description = "An Open edX plugin to add API for course outline (modules) for the Learn product page"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,10 +9,10 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
 ]
 

--- a/src/ol_openedx_course_structure_api/README.rst
+++ b/src/ol_openedx_course_structure_api/README.rst
@@ -4,6 +4,13 @@ Course Structure API Plugin
 A django app plugin to add a new API to Open edX to retrieve the JSON representation of course structure
 
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ------------
 

--- a/src/ol_openedx_course_structure_api/README.rst
+++ b/src/ol_openedx_course_structure_api/README.rst
@@ -7,9 +7,8 @@ A django app plugin to add a new API to Open edX to retrieve the JSON representa
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ------------

--- a/src/ol_openedx_course_structure_api/pyproject.toml
+++ b/src/ol_openedx_course_structure_api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-structure-api"
-version = "0.2.0"
+version = "0.3.0"
 description = "An Open edX plugin to add API for course structure"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,10 +9,10 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
 ]
 

--- a/src/ol_openedx_course_sync/README.rst
+++ b/src/ol_openedx_course_sync/README.rst
@@ -8,6 +8,9 @@ Version Compatibility
 
 It supports Open edX releases from `Sumac` and onwards.
 
+For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
+
 Installing The Plugin
 ---------------------
 

--- a/src/ol_openedx_course_sync/README.rst
+++ b/src/ol_openedx_course_sync/README.rst
@@ -8,7 +8,7 @@ Version Compatibility
 
 It supports Open edX releases from `Sumac` and onwards.
 
-For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+For this plugin's compatibility with Open edX, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installing The Plugin

--- a/src/ol_openedx_course_sync/pyproject.toml
+++ b/src/ol_openedx_course_sync/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-sync"
-version = "1.0.1"
+version = "1.1.0"
 description = "An Open edX plugin to sync course changes to its reruns."
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,9 +9,9 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
   "edx-opaque-keys",
   "openedx-events",
 ]

--- a/src/ol_openedx_course_translations/README.rst
+++ b/src/ol_openedx_course_translations/README.rst
@@ -11,9 +11,8 @@ Translate course content into multiple languages to enhance accessibility for a 
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Setup
 =====

--- a/src/ol_openedx_course_translations/README.rst
+++ b/src/ol_openedx_course_translations/README.rst
@@ -8,6 +8,13 @@ Purpose
 
 Translate course content into multiple languages to enhance accessibility for a global audience.
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Setup
 =====
 

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.9.1"
+version = "0.9.2"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,8 +10,8 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
   "litellm==1.83.0",
   "srt>=3.5.3",
   "edx-opaque-keys",

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.9.2"
+version = "0.10.0"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_events_handler/README.rst
+++ b/src/ol_openedx_events_handler/README.rst
@@ -28,6 +28,13 @@ Currently handled events:
   notifies an external system to create a certificate.
 
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ============
 

--- a/src/ol_openedx_events_handler/README.rst
+++ b/src/ol_openedx_events_handler/README.rst
@@ -31,9 +31,8 @@ Currently handled events:
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ============

--- a/src/ol_openedx_events_handler/pyproject.toml
+++ b/src/ol_openedx_events_handler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ol-openedx-events-handler"
-version = "0.3.0"
+version = "0.4.0"
 description = "Open edX plugin to handle Open edX signals and events for MIT OL"
 readme = "README.rst"
 requires-python = ">=3.11"

--- a/src/ol_openedx_events_handler/pyproject.toml
+++ b/src/ol_openedx_events_handler/pyproject.toml
@@ -10,10 +10,10 @@ readme = "README.rst"
 requires-python = ">=3.11"
 license = { file = "LICENSE.txt" }
 dependencies = [
-    "Django>=4.0",
+    "Django>=5.2",
     "celery>=4.4.7",
     "django-crum",
-    "edx-django-utils>4.0.0",
+    "edx-django-utils>=8.0.0",
     "openedx-events",
     "requests",
 ]

--- a/src/ol_openedx_feedback/README.rst
+++ b/src/ol_openedx_feedback/README.rst
@@ -20,6 +20,13 @@ The Learning MFE receives the message and opens the feedback drawer, which
 submits the learner's feedback directly to the **mit-learn** service.  This
 plugin does **not** persist anything in edx-platform and exposes no REST API.
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ============
 

--- a/src/ol_openedx_feedback/README.rst
+++ b/src/ol_openedx_feedback/README.rst
@@ -23,9 +23,8 @@ plugin does **not** persist anything in edx-platform and exposes no REST API.
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ============

--- a/src/ol_openedx_feedback/pyproject.toml
+++ b/src/ol_openedx_feedback/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-feedback"
-version = "0.2.2"
+version = "0.3.0"
 description = "An Open edX plugin to collect per-block learner feedback"
 authors = [{name = "MIT Office of Digital Learning"}]
 license = "BSD-3-Clause"
@@ -8,7 +8,7 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "XBlock",
 ]
 

--- a/src/ol_openedx_git_auto_export/README.rst
+++ b/src/ol_openedx_git_auto_export/README.rst
@@ -4,9 +4,8 @@ Git Auto Export Plugin
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ============

--- a/src/ol_openedx_git_auto_export/README.rst
+++ b/src/ol_openedx_git_auto_export/README.rst
@@ -1,6 +1,13 @@
 Git Auto Export Plugin
 ######################
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ============
 

--- a/src/ol_openedx_git_auto_export/pyproject.toml
+++ b/src/ol_openedx_git_auto_export/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "ol-openedx-git-auto-export"
-version = "0.8.3"
+version = "0.9.0"
 description = "A plugin that auto saves the course OLX to git when an author publishes it"
 authors = [{ name = "MIT Office of Digital Learning" }]
 license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "celery>=4.4.7",
-  "edx-django-utils>4.0.0",
+  "edx-django-utils>=8.0.0",
   "edx-opaque-keys",
   "gitpython>=3.1.37",
   "openedx-events",

--- a/src/ol_openedx_logging/README.rst
+++ b/src/ol_openedx_logging/README.rst
@@ -6,6 +6,5 @@ A django app plugin to standardize logging across Open edX.
 Version Compatibility
 ######################
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.

--- a/src/ol_openedx_logging/README.rst
+++ b/src/ol_openedx_logging/README.rst
@@ -2,3 +2,10 @@ OL OpenedX Logging
 ##################
 
 A django app plugin to standardize logging across Open edX.
+
+Version Compatibility
+######################
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).

--- a/src/ol_openedx_logging/pyproject.toml
+++ b/src/ol_openedx_logging/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "ol-openedx-logging"
-version = "0.3.5"
+version = "0.4.0"
 description = "An Open edX plugin to customize the logging configuration used by the edx-platform application"
 readme = "README.rst"
 authors = [{ name = "MIT Office of Digital Learning" }]
 license = "BSD-3-Clause"
 requires-python = ">=3.11"
-dependencies = ["Django>=4.0", "structlog>=24.0.0"]
+dependencies = ["Django>=5.2", "structlog>=24.0.0"]
 
 [project.entry-points."lms.djangoapp"]
 ol_openedx_logging = "ol_openedx_logging.app:EdxLoggingLMS"

--- a/src/ol_openedx_lti_utilities/README.rst
+++ b/src/ol_openedx_lti_utilities/README.rst
@@ -4,6 +4,13 @@ LTI Utilities Plugin
 A django app plugin to add LTI related utilities in Open edX platform.
 
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ------------
 

--- a/src/ol_openedx_lti_utilities/README.rst
+++ b/src/ol_openedx_lti_utilities/README.rst
@@ -7,9 +7,8 @@ A django app plugin to add LTI related utilities in Open edX platform.
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ------------

--- a/src/ol_openedx_lti_utilities/pyproject.toml
+++ b/src/ol_openedx_lti_utilities/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-lti-utilities"
-version = "0.1.2"
+version = "0.2.0"
 description = "An Open edX plugin to add utilities for LTI operations"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,10 +9,10 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
 ]
 

--- a/src/ol_openedx_otel_monitoring/README.rst
+++ b/src/ol_openedx_otel_monitoring/README.rst
@@ -4,6 +4,13 @@ Opentelemetry Django Plugin
 This Django plugin integrates Open Telemetry, offering both tracing and metric functionalities. It is built upon the `opentelemetry-instrumentation-django` package and adds the capability for manual instrumentation. Users can select different exporters for traces and metrics. Currently, it supports Console Exporter for local development and OTLP Exporter for exporting data to third-party platforms. A customizable blueprint middleware can be easily added via settings.
 
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ------------
 

--- a/src/ol_openedx_otel_monitoring/README.rst
+++ b/src/ol_openedx_otel_monitoring/README.rst
@@ -7,9 +7,8 @@ This Django plugin integrates Open Telemetry, offering both tracing and metric f
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ------------

--- a/src/ol_openedx_otel_monitoring/pyproject.toml
+++ b/src/ol_openedx_otel_monitoring/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-otel-monitoring"
-version = "0.2.0"
+version = "0.3.0"
 description = "OTel Monitoring"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "opentelemetry-distro",
   "opentelemetry-instrumentation-django",
   "opentelemetry-exporter-richconsole",

--- a/src/ol_openedx_rapid_response_reports/README.rst
+++ b/src/ol_openedx_rapid_response_reports/README.rst
@@ -4,9 +4,8 @@ Rapid Response Reports Plugin
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Overview
 --------

--- a/src/ol_openedx_rapid_response_reports/README.rst
+++ b/src/ol_openedx_rapid_response_reports/README.rst
@@ -15,7 +15,7 @@ A django app plugin for edx-platform to enable "Rapid Response Reports" function
 
 **NOTE:**
 
-If you are using `Nutmeg <https://github.com/openedx/edx-platform/tree/open-release/nutmeg.master>`_ or a more recent release of open edX, You can skip the cherry-picking step mentioned below and just use ``0.2.0`` or above version of the plugin. For any releases prior to ``Nutmeg`` please keep reading below.
+If you are using `Nutmeg <https://github.com/openedx/edx-platform/tree/open-release/nutmeg.master>`_ through Teak, you can skip the cherry-picking step mentioned below and just use a version between ``0.2.0`` and ``0.5.1`` of the plugin (see the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_ above for Ulmo/Verawood+). For any releases prior to ``Nutmeg`` please keep reading below.
 
 (For Open edX releases prior to `Nutmeg`) We had to make some changes to edx-platform itself in order to add the ``Rapid Responses`` tab to the instructor dashboard, so the ``edx-platform`` branch/tag you're using must include this commit for the plugin to work properly:
 

--- a/src/ol_openedx_rapid_response_reports/README.rst
+++ b/src/ol_openedx_rapid_response_reports/README.rst
@@ -1,6 +1,13 @@
 Rapid Response Reports Plugin
 =============================
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Overview
 --------
 

--- a/src/ol_openedx_rapid_response_reports/pyproject.toml
+++ b/src/ol_openedx_rapid_response_reports/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "edx-django-utils>=8.0.0",
   "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
-  "rapid-response-xblock>=0.11.0",
+  "rapid-response-xblock>=0.12.0",
 ]
 
 [project.entry-points."lms.djangoapp"]

--- a/src/ol_openedx_rapid_response_reports/pyproject.toml
+++ b/src/ol_openedx_rapid_response_reports/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-rapid-response-reports"
-version = "0.5.1"
+version = "0.6.0"
 description = "An Open edX plugin to add rapid response reports support"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,10 +9,10 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>4.0.0",
-  "edx-drf-extensions>=10.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
+  "edx-drf-extensions>=10.6.0",
   "edx-opaque-keys",
   "rapid-response-xblock>=0.11.0",
 ]

--- a/src/ol_openedx_sentry/README.rst
+++ b/src/ol_openedx_sentry/README.rst
@@ -17,9 +17,8 @@ noisy Sentry issues.
 Version Compatibility
 ======================
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installation
 ============

--- a/src/ol_openedx_sentry/README.rst
+++ b/src/ol_openedx_sentry/README.rst
@@ -14,6 +14,13 @@ with the structured logs shipped by ``ol_openedx_logging``, and configures the
 noisy Sentry issues.
 
 
+Version Compatibility
+======================
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Installation
 ============
 

--- a/src/ol_openedx_sentry/pyproject.toml
+++ b/src/ol_openedx_sentry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-sentry"
-version = "0.4.0"
+version = "0.5.0"
 description = "An Open edX plugin to enable error tracking with Sentry"
 readme = "README.rst"
 authors = [
@@ -9,7 +9,7 @@ authors = [
 license = "BSD-3-Clause"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.2",
+  "Django>=5.2",
   "sentry-sdk>=2.55.0",
 ]
 

--- a/src/ol_openedx_uai_content_customization/README.rst
+++ b/src/ol_openedx_uai_content_customization/README.rst
@@ -9,7 +9,7 @@ Version Compatibility
 
 Supports Open edX releases from **Sumac** and onwards.
 
-For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+For this plugin's compatibility with Open edX, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installing The Plugin

--- a/src/ol_openedx_uai_content_customization/README.rst
+++ b/src/ol_openedx_uai_content_customization/README.rst
@@ -9,6 +9,9 @@ Version Compatibility
 
 Supports Open edX releases from **Sumac** and onwards.
 
+For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
+
 Installing The Plugin
 ---------------------
 

--- a/src/ol_openedx_uai_content_customization/pyproject.toml
+++ b/src/ol_openedx_uai_content_customization/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-uai-content-customization"
-version = "0.3.0"
+version = "0.4.0"
 description = "An Open edX plugin to generate industry/length-specific UAI custom courses from video CSV data."
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -9,8 +9,8 @@ license = "BSD-3-Clause"
 readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
-  "Django>=4.0",
-  "edx-django-utils>4.0.0",
+  "Django>=5.2",
+  "edx-django-utils>=8.0.0",
   "edx-opaque-keys",
   "requests",
 ]

--- a/src/ol_social_auth/README.rst
+++ b/src/ol_social_auth/README.rst
@@ -8,7 +8,7 @@ Version Compatibility
 
 Compatible with all edx releases
 
-For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+For this plugin's compatibility with Open edX, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installing The Plugin

--- a/src/ol_social_auth/README.rst
+++ b/src/ol_social_auth/README.rst
@@ -8,6 +8,9 @@ Version Compatibility
 
 Compatible with all edx releases
 
+For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
+
 Installing The Plugin
 ---------------------
 

--- a/src/ol_social_auth/pyproject.toml
+++ b/src/ol_social_auth/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-social-auth"
-version = "0.2.2"
+version = "0.3.0"
 description = "An Open edX plugin implementing MIT social auth backend"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,7 +10,7 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
+  "Django>=5.2",
   "django-oauth-toolkit",
   "social-auth-core>=4.5.4",
 ]

--- a/src/openedx_companion_auth/README.rst
+++ b/src/openedx_companion_auth/README.rst
@@ -8,7 +8,7 @@ Version Compatibility
 
 Compatible with the Nutmeg release of the Open edX and onwards. May work with prior releases as well.
 
-For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+For this plugin's compatibility with Open edX, see the
 `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Installing The Plugin

--- a/src/openedx_companion_auth/README.rst
+++ b/src/openedx_companion_auth/README.rst
@@ -8,6 +8,9 @@ Version Compatibility
 
 Compatible with the Nutmeg release of the Open edX and onwards. May work with prior releases as well.
 
+For the Django 5.2 dependency floor (Ulmo/Verawood and later), see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
+
 Installing The Plugin
 ---------------------
 

--- a/src/openedx_companion_auth/pyproject.toml
+++ b/src/openedx_companion_auth/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openedx-companion-auth"
-version = "1.2.0"
+version = "1.3.0"
 description = "A package to add login redirection from Open edX to MIT applications"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,9 +10,9 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
-  "edx-django-utils>3.0.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
+  "edx-django-utils>=8.0.0",
 ]
 
 [project.entry-points."lms.djangoapp"]

--- a/src/rapid_response_xblock/README.rst
+++ b/src/rapid_response_xblock/README.rst
@@ -3,6 +3,13 @@ Rapid Response xBlock
 
 A django app plugin for edx-platform
 
+Version Compatibility
+----------------------
+
+See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
+in the repository docs for the minimum plugin version required per Open edX
+release (Django 5.2 floor on Ulmo/Verawood and later).
+
 Setup
 -----
 

--- a/src/rapid_response_xblock/README.rst
+++ b/src/rapid_response_xblock/README.rst
@@ -6,9 +6,8 @@ A django app plugin for edx-platform
 Version Compatibility
 ----------------------
 
-See the `Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_
-in the repository docs for the minimum plugin version required per Open edX
-release (Django 5.2 floor on Ulmo/Verawood and later).
+For this plugin's compatibility with Open edX, see the
+`Open edX Release Compatibility table <../../docs#open-edx-release-compatibility>`_.
 
 Setup
 -----

--- a/src/rapid_response_xblock/pyproject.toml
+++ b/src/rapid_response_xblock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rapid-response-xblock"
-version = "0.11.0"
+version = "0.12.0"
 description = "An Open edX plugin to add rapid response aside for problem xBlocks"
 authors = [
   {name = "MIT Office of Digital Learning"}
@@ -10,8 +10,8 @@ readme = "README.rst"
 requires-python = ">=3.11"
 keywords = ["Python", "edx"]
 dependencies = [
-  "Django>=4.0",
-  "djangorestframework>=3.14.0",
+  "Django>=5.2",
+  "djangorestframework>=3.16.0",
   "XBlock",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "edx-sysadmin"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "src/edx_sysadmin" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -950,17 +950,17 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
     { name = "gitpython", specifier = ">=3.1.45" },
 ]
 
 [[package]]
 name = "edx-username-changer"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "src/edx_username_changer" }
 dependencies = [
     { name = "celery" },
@@ -973,9 +973,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = ">=4.4.7" },
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
 ]
 
 [[package]]
@@ -2052,7 +2052,7 @@ wheels = [
 
 [[package]]
 name = "ol-openedx-ai-static-translations"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "src/ol_openedx_ai_static_translations" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
+    { name = "django", specifier = ">=5.2" },
     { name = "gitpython", specifier = ">=3.1.40" },
     { name = "litellm", specifier = ">=1.80.0" },
     { name = "polib", specifier = ">=1.2.0" },
@@ -2074,7 +2074,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-auto-select-language"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "src/ol_openedx_auto_select_language" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2085,14 +2085,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
     { name = "edx-opaque-keys" },
 ]
 
 [[package]]
 name = "ol-openedx-canvas-integration"
-version = "0.8.3"
+version = "0.9.0"
 source = { editable = "src/ol_openedx_canvas_integration" }
 dependencies = [
     { name = "celery" },
@@ -2108,17 +2108,17 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = ">=4.4.7" },
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
     { name = "openedx-events" },
 ]
 
 [[package]]
 name = "ol-openedx-chat"
-version = "0.5.10"
+version = "0.6.0"
 source = { editable = "src/ol_openedx_chat" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2130,15 +2130,15 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
     { name = "xblock" },
 ]
 
 [[package]]
 name = "ol-openedx-chat-xblock"
-version = "0.4.6"
+version = "0.5.0"
 source = { editable = "src/ol_openedx_chat_xblock" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2151,16 +2151,16 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=3.2" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">=1.3.0" },
-    { name = "xblock", specifier = ">=1.9.0" },
-    { name = "xblock-utils", specifier = ">=1.2.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "xblock", specifier = ">=5.2.0" },
+    { name = "xblock-utils", specifier = ">=4.0.0" },
 ]
 
 [[package]]
 name = "ol-openedx-checkout-external"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "src/ol_openedx_checkout_external" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2173,16 +2173,16 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
 ]
 
 [[package]]
 name = "ol-openedx-course-export"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "src/ol_openedx_course_export" }
 dependencies = [
     { name = "celery" },
@@ -2197,16 +2197,16 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = ">=4.4.7" },
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
 ]
 
 [[package]]
 name = "ol-openedx-course-outline-api"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "src/ol_openedx_course_outline_api" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2219,16 +2219,16 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
 ]
 
 [[package]]
 name = "ol-openedx-course-structure-api"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "src/ol_openedx_course_structure_api" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2241,16 +2241,16 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
 ]
 
 [[package]]
 name = "ol-openedx-course-sync"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "src/ol_openedx_course_sync" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2263,16 +2263,16 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
     { name = "edx-opaque-keys" },
     { name = "openedx-events" },
 ]
 
 [[package]]
 name = "ol-openedx-course-translations"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "src/ol_openedx_course_translations" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2285,8 +2285,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
     { name = "edx-opaque-keys" },
     { name = "litellm", specifier = "==1.83.0" },
     { name = "srt", specifier = ">=3.5.3" },
@@ -2309,16 +2309,16 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = ">=4.4.7" },
-    { name = "django", specifier = ">=4.0" },
+    { name = "django", specifier = ">=5.2" },
     { name = "django-crum" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
     { name = "openedx-events" },
     { name = "requests" },
 ]
 
 [[package]]
 name = "ol-openedx-feedback"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "src/ol_openedx_feedback" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2328,13 +2328,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
+    { name = "django", specifier = ">=5.2" },
     { name = "xblock" },
 ]
 
 [[package]]
 name = "ol-openedx-git-auto-export"
-version = "0.8.3"
+version = "0.9.0"
 source = { editable = "src/ol_openedx_git_auto_export" }
 dependencies = [
     { name = "celery" },
@@ -2349,8 +2349,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = ">=4.4.7" },
-    { name = "django", specifier = ">=4.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
     { name = "edx-opaque-keys" },
     { name = "gitpython", specifier = ">=3.1.37" },
     { name = "openedx-events" },
@@ -2358,7 +2358,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-logging"
-version = "0.3.5"
+version = "0.4.0"
 source = { editable = "src/ol_openedx_logging" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2368,13 +2368,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
+    { name = "django", specifier = ">=5.2" },
     { name = "structlog", specifier = ">=24.0.0" },
 ]
 
 [[package]]
 name = "ol-openedx-lti-utilities"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "src/ol_openedx_lti_utilities" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2387,16 +2387,16 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
 ]
 
 [[package]]
 name = "ol-openedx-otel-monitoring"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "src/ol_openedx_otel_monitoring" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
+    { name = "django", specifier = ">=5.2" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-exporter-richconsole" },
@@ -2418,7 +2418,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-rapid-response-reports"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "src/ol_openedx_rapid_response_reports" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2432,17 +2432,17 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
     { name = "rapid-response-xblock", editable = "src/rapid_response_xblock" },
 ]
 
 [[package]]
 name = "ol-openedx-sentry"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/ol_openedx_sentry" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2452,13 +2452,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.2" },
+    { name = "django", specifier = ">=5.2" },
     { name = "sentry-sdk", specifier = ">=2.55.0" },
 ]
 
 [[package]]
 name = "ol-openedx-uai-content-customization"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "src/ol_openedx_uai_content_customization" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2470,15 +2470,15 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "edx-django-utils", specifier = ">4.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
     { name = "edx-opaque-keys" },
     { name = "requests" },
 ]
 
 [[package]]
 name = "ol-social-auth"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "src/ol_social_auth" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
+    { name = "django", specifier = ">=5.2" },
     { name = "django-oauth-toolkit" },
     { name = "social-auth-core", specifier = ">=4.5.4" },
 ]
@@ -2535,10 +2535,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = ">=4.4.7" },
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
     { name = "edx-django-utils" },
-    { name = "edx-drf-extensions", specifier = ">=10.0.0" },
+    { name = "edx-drf-extensions", specifier = ">=10.6.0" },
     { name = "edx-opaque-keys" },
     { name = "gitpython", specifier = ">=3.1.37" },
     { name = "openedx-events" },
@@ -2587,7 +2587,7 @@ wheels = [
 
 [[package]]
 name = "openedx-companion-auth"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "src/openedx_companion_auth" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -2598,9 +2598,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
-    { name = "edx-django-utils", specifier = ">3.0.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "edx-django-utils", specifier = ">=8.0.0" },
 ]
 
 [[package]]
@@ -3433,7 +3433,7 @@ wheels = [
 
 [[package]]
 name = "rapid-response-xblock"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "src/rapid_response_xblock" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -3444,8 +3444,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "djangorestframework", specifier = ">=3.14.0" },
+    { name = "django", specifier = ">=5.2" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
     { name = "xblock" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2272,7 +2272,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-course-translations"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "src/ol_openedx_course_translations" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-events-handler"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "src/ol_openedx_events_handler" }
 dependencies = [
     { name = "celery" },


### PR DESCRIPTION
## Related ticket
Closes #841

## Summary

- Swap `release/teak` for `release/verawood` in the CI integration-test matrix (now `master`, `release/ulmo`, `release/verawood`), shifting Tutor version pins accordingly (`ulmo` → `tutor>=21.0.0,<22.0.0`, `verawood` → `tutor>=22.0.0,<23.0.0`), mirroring the pattern from the earlier Sumac→Ulmo swap (#801)
- Resolve the Python version used for edx-platform per branch: 3.11 for `release/ulmo`, 3.12 for `master` and `release/verawood` (Verawood moved to 3.12, same as master)
- Update `AGENTS.md` release-matrix docs to match (also fixes stale `sumac.master` mentions left over from #801)
- Raise the Django dependency floor from `Django>=4.0` (one plugin was `>=4.2`, one was a stray lowercase `django>=3.2`) to `Django>=5.2` across the root workspace and all 25 plugin packages, matching the Django versions shipped by `release/ulmo` (5.2.11) and `release/verawood` (5.2.13)
- Bump each affected plugin's version by one minor version (e.g. `0.4.2` → `0.5.0`), following the convention established in #617 when the Django floor was last raised
- Regenerate `uv.lock` for the new dependency floor

## Testing Instructions
- The CI should pass across all three matrix legs (`master`, `release/ulmo`, `release/verawood`)
- The plugin build should work fine, i.e., `uv build --all-packages`
- Test the plugin's functionality, and it should work fine in `master`, `Ulmo` and specifically in `Verawood`

🤖 Generated with [Claude Code](https://claude.com/claude-code)