### PR TITLE
fix(askTim): always build transcript asset ID from edx_video_id

### DIFF
--- a/src/ol_openedx_chat/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/utils.py
@@ -140,24 +140,18 @@ def get_transcript_asset_id(block):
     course_language = LanguageCode(course.language).to_bcp47()
     try:
         if block.edx_video_id:
-            transcript_languages = get_available_transcript_languages(
-                block.edx_video_id
-            )
-
-            def get_asset_id(lang):
-                if lang not in transcript_languages:
-                    return None
-                return Transcript.asset_location(
-                    block.location, f"{block.edx_video_id}-{lang}.srt"
-                )
+            filenames = {
+                lang: f"{block.edx_video_id}-{lang}.srt"
+                for lang in get_available_transcript_languages(block.edx_video_id)
+            }
         else:
-            stored_transcripts = block.transcripts or {}
+            filenames = block.transcripts or {}
 
-            def get_asset_id(lang):
-                stored_filename = stored_transcripts.get(lang)
-                if not stored_filename:
-                    return None
-                return Transcript.asset_location(block.location, stored_filename)
+        def get_asset_id(lang):
+            filename = filenames.get(lang)
+            if not filename:
+                return None
+            return Transcript.asset_location(block.location, filename)
 
         if course_language == ENGLISH_LANG_CODE:
             return get_asset_id(course_language)

--- a/src/ol_openedx_chat/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/utils.py
@@ -153,9 +153,6 @@ def get_transcript_asset_id(block):
                 return None
             return Transcript.asset_location(block.location, filename)
 
-        if course_language == ENGLISH_LANG_CODE:
-            return get_asset_id(course_language)
-
         # Fallback to English transcript if the course language isn't available.
         return get_asset_id(course_language) or get_asset_id(ENGLISH_LANG_CODE)
 

--- a/src/ol_openedx_chat/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/utils.py
@@ -139,20 +139,29 @@ def get_transcript_asset_id(block):
     try:
         transcripts_info = block.get_transcripts_info()
         transcripts = transcripts_info.get("transcripts", {})
+        transcript_languages = None
 
         def get_asset_id(lang):
+            nonlocal transcript_languages
             stored_filename = transcripts.get(lang)
-            if not (
-                stored_filename
-                or lang in get_available_transcript_languages(block.edx_video_id)
-            ):
-                return None
+            if not stored_filename:
+                # Lazily fetch and cache so a course/English fallback pair
+                # never queries edx-val for the same edx_video_id twice.
+                if transcript_languages is None:
+                    transcript_languages = get_available_transcript_languages(
+                        block.edx_video_id
+                    )
+                if lang not in transcript_languages:
+                    return None
             filename = (
                 f"{block.edx_video_id}-{lang}.srt"
                 if block.edx_video_id
                 else stored_filename
             )
             return Transcript.asset_location(block.location, filename)
+
+        if course_language == ENGLISH_LANG_CODE:
+            return get_asset_id(course_language)
 
         # Fallback to English transcript if the course language isn't available.
         return get_asset_id(course_language) or get_asset_id(ENGLISH_LANG_CODE)

--- a/src/ol_openedx_chat/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/utils.py
@@ -116,6 +116,15 @@ def get_transcript_asset_id(block):
     """
     Get the transcript asset ID for a video block.
 
+    When the block has a current `edx_video_id`, Studio names transcripts
+    after it (`{edx_video_id}-{lang}.srt`), so the filename is always rebuilt
+    from `block.edx_video_id` rather than trusted from `get_transcripts_info()`.
+    That stored filename can reference a stale `edx_video_id` when authors swap
+    the video in Studio without reuploading the transcript, which would
+    otherwise point the chat at the wrong video's transcript. Blocks with no
+    `edx_video_id` (e.g. legacy videos with manually uploaded transcripts) use
+    the stored filename as-is, since there's no `edx_video_id` to rebuild from.
+
     Args:
         block (VideoBlock): The video block for which to get the transcript asset ID.
 
@@ -130,31 +139,23 @@ def get_transcript_asset_id(block):
     try:
         transcripts_info = block.get_transcripts_info()
         transcripts = transcripts_info.get("transcripts", {})
-        if transcripts and transcripts.get(course_language):
-            return Transcript.asset_location(
-                block.location,
-                transcripts_info["transcripts"][course_language],
-            )
 
-        transcript_languages = get_available_transcript_languages(block.edx_video_id)
-        if course_language in transcript_languages:
-            return Transcript.asset_location(
-                block.location,
-                f"{block.edx_video_id}-{course_language}.srt",
+        def get_asset_id(lang):
+            stored_filename = transcripts.get(lang)
+            if not (
+                stored_filename
+                or lang in get_available_transcript_languages(block.edx_video_id)
+            ):
+                return None
+            filename = (
+                f"{block.edx_video_id}-{lang}.srt"
+                if block.edx_video_id
+                else stored_filename
             )
+            return Transcript.asset_location(block.location, filename)
 
-        # Fallback to English transcript if available.
-        if transcripts and transcripts.get(ENGLISH_LANG_CODE):
-            return Transcript.asset_location(
-                block.location,
-                transcripts_info["transcripts"][ENGLISH_LANG_CODE],
-            )
-
-        if ENGLISH_LANG_CODE in transcript_languages:
-            return Transcript.asset_location(
-                block.location,
-                f"{block.edx_video_id}-{ENGLISH_LANG_CODE}.srt",
-            )
+        # Fallback to English transcript if the course language isn't available.
+        return get_asset_id(course_language) or get_asset_id(ENGLISH_LANG_CODE)
 
     except Exception:  # noqa: BLE001
         log.info(

--- a/src/ol_openedx_chat/ol_openedx_chat/utils.py
+++ b/src/ol_openedx_chat/ol_openedx_chat/utils.py
@@ -116,14 +116,16 @@ def get_transcript_asset_id(block):
     """
     Get the transcript asset ID for a video block.
 
-    When the block has a current `edx_video_id`, Studio names transcripts
-    after it (`{edx_video_id}-{lang}.srt`), so the filename is always rebuilt
-    from `block.edx_video_id` rather than trusted from `get_transcripts_info()`.
-    That stored filename can reference a stale `edx_video_id` when authors swap
-    the video in Studio without reuploading the transcript, which would
-    otherwise point the chat at the wrong video's transcript. Blocks with no
-    `edx_video_id` (e.g. legacy videos with manually uploaded transcripts) use
-    the stored filename as-is, since there's no `edx_video_id` to rebuild from.
+    When the block has a current `edx_video_id`, edx-val
+    (`get_available_transcript_languages`) is the sole source of truth for
+    which languages exist, and Studio names those transcripts after it
+    (`{edx_video_id}-{lang}.srt`). `get_transcripts_info()`'s locally stored
+    filename is never used, since it can reference a stale `edx_video_id`
+    when authors swap the video in Studio without reuploading the
+    transcript, which would otherwise point the chat at the wrong video's
+    transcript. Blocks with no `edx_video_id` (e.g. legacy videos with
+    manually uploaded transcripts) have nothing to look up in edx-val, so
+    they fall back to the block's stored `transcripts` filenames directly.
 
     Args:
         block (VideoBlock): The video block for which to get the transcript asset ID.
@@ -137,28 +139,25 @@ def get_transcript_asset_id(block):
 
     course_language = LanguageCode(course.language).to_bcp47()
     try:
-        transcripts_info = block.get_transcripts_info()
-        transcripts = transcripts_info.get("transcripts", {})
-        transcript_languages = None
+        if block.edx_video_id:
+            transcript_languages = get_available_transcript_languages(
+                block.edx_video_id
+            )
 
-        def get_asset_id(lang):
-            nonlocal transcript_languages
-            stored_filename = transcripts.get(lang)
-            if not stored_filename:
-                # Lazily fetch and cache so a course/English fallback pair
-                # never queries edx-val for the same edx_video_id twice.
-                if transcript_languages is None:
-                    transcript_languages = get_available_transcript_languages(
-                        block.edx_video_id
-                    )
+            def get_asset_id(lang):
                 if lang not in transcript_languages:
                     return None
-            filename = (
-                f"{block.edx_video_id}-{lang}.srt"
-                if block.edx_video_id
-                else stored_filename
-            )
-            return Transcript.asset_location(block.location, filename)
+                return Transcript.asset_location(
+                    block.location, f"{block.edx_video_id}-{lang}.srt"
+                )
+        else:
+            stored_transcripts = block.transcripts or {}
+
+            def get_asset_id(lang):
+                stored_filename = stored_transcripts.get(lang)
+                if not stored_filename:
+                    return None
+                return Transcript.asset_location(block.location, stored_filename)
 
         if course_language == ENGLISH_LANG_CODE:
             return get_asset_id(course_language)

--- a/src/ol_openedx_chat/pyproject.toml
+++ b/src/ol_openedx_chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat"
-version = "0.5.9"
+version = "0.5.10"
 description = "An Open edX plugin to add Open Learning AI chat aside to xBlocks"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_chat/tests/test_utils.py
+++ b/src/ol_openedx_chat/tests/test_utils.py
@@ -267,6 +267,38 @@ class OLChatUtilTests(OLChatTestCase):
             # There's no edx_video_id to query edx-val with.
             mock_get_transcript_languages.assert_not_called()
 
+    def test_get_transcript_asset_id_ignores_local_transcripts_with_edx_video_id(self):
+        """
+        Test that get_transcript_asset_id ignores the block's locally stored
+        `transcripts` dict once edx_video_id is set, even if it has an entry
+        for a language edx-val doesn't know about -- edx-val, not the local
+        dict, is authoritative once there's an edx_video_id to query. A
+        regression back to also checking the local dict in this case would
+        make this test return the stale entry instead of None.
+        """
+        with (
+            patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id,
+            patch(
+                "ol_openedx_chat.utils.get_available_transcript_languages"
+            ) as mock_get_transcript_languages,
+            patch(
+                "ol_openedx_chat.utils.Transcript.asset_location"
+            ) as mock_asset_location,
+        ):
+            self.course.language = "fr"
+            mock_get_course_by_id.return_value = self.course
+
+            self.video_block.edx_video_id = "video-id"
+            # A stale/local-only entry edx-val doesn't know about for this
+            # edx_video_id.
+            self.video_block.transcripts = {"fr": "old-transcript-fr.srt"}
+            mock_get_transcript_languages.return_value = []
+
+            result = get_transcript_asset_id(self.video_block)
+
+            mock_asset_location.assert_not_called()
+            assert result is None
+
     def test_get_transcript_asset_id_exception(self):
         """
         Test that get_transcript_asset_id returns None when

--- a/src/ol_openedx_chat/tests/test_utils.py
+++ b/src/ol_openedx_chat/tests/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for the util methods"""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from ddt import data, ddt, unpack
 from ol_openedx_chat.utils import (
@@ -181,71 +181,21 @@ class OLChatUtilTests(OLChatTestCase):
             assert course is None
 
     @data(
-        # (course_language, transcripts, edx_video_id_transcripts, expected_asset_id_suffix)  # noqa: ERA001,E501
-        # The asset filename is always built from `edx_video_id`, never from the
-        # (possibly stale) filename stored in `get_transcripts_info()`, so the
-        # `transcripts` dict below only signals language availability.
-        (
-            "en",
-            {"en": "transcript-en.srt", "es": "transcript-es.srt"},
-            [],
-            "video-id-en.srt",
-        ),  # Course language transcript
-        (
-            "es",
-            {"en": "transcript-en.srt", "es": "transcript-es.srt"},
-            [],
-            "video-id-es.srt",
-        ),  # Non-English course language
-        (
-            "es_419",
-            {
-                "en": "transcript-en.srt",
-                "es": "transcript-es.srt",
-                "es-419": "transcript-es-419.srt",
-            },
-            [],
-            "video-id-es-419.srt",
-        ),  # Non-English course language
-        (
-            "de_DE",
-            {
-                "en": "transcript-en.srt",
-                "es": "transcript-es.srt",
-                "de-DE": "transcript-de-DE.srt",
-            },
-            [],
-            "video-id-de-DE.srt",
-        ),  # Non-English course language
-        ("es", {}, ["es"], "video-id-es.srt"),  # Transcript from edx_video_id
-        (
-            "es_419",
-            {},
-            ["es-419"],
-            "video-id-es-419.srt",
-        ),  # Transcript from edx_video_id
-        ("de_DE", {}, ["de-DE"], "video-id-de-DE.srt"),  # Transcript from edx_video_id
-        (
-            "es",
-            {"en": "transcript-en.srt"},
-            ["es"],
-            "video-id-es.srt",
-        ),  # `transcripts` lacks the language but edx_video_id has it
-        (
-            "es",
-            {"en": "transcript-en.srt"},
-            [],
-            "video-id-en.srt",
-        ),  # Fallback to English transcript
-        ("es", {}, ["en"], "video-id-en.srt"),  # Fallback to English from edx_video_id
-        ("es", {}, [], None),  # No transcript available
+        # (course_language, transcript_languages, expected_id_suffix)  # noqa: ERA001
+        # edx-val's `get_available_transcript_languages` is the sole source
+        # of truth for which languages exist when edx_video_id is set.
+        ("en", ["en", "es"], "video-id-en.srt"),  # Course language transcript
+        ("es", ["en", "es"], "video-id-es.srt"),  # Non-English course language
+        ("es_419", ["en", "es", "es-419"], "video-id-es-419.srt"),
+        ("de_DE", ["en", "es", "de-DE"], "video-id-de-DE.srt"),
+        ("es", ["en"], "video-id-en.srt"),  # Fallback to English transcript
+        ("es", [], None),  # No transcript available
     )
     @unpack
     def test_get_transcript_asset_id(
         self,
         course_language,
-        transcripts,
-        edx_video_id_transcripts,
+        transcript_languages,
         expected_asset_id_suffix,
     ):
         """Test that get_transcript_asset_id returns the correct asset ID"""
@@ -253,24 +203,16 @@ class OLChatUtilTests(OLChatTestCase):
             patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id,
             patch(
                 "ol_openedx_chat.utils.get_available_transcript_languages"
-            ) as mock_get_transcripts,
+            ) as mock_get_transcript_languages,
             patch(
                 "ol_openedx_chat.utils.Transcript.asset_location"
             ) as mock_asset_location,
         ):
-            # Setup course language
             self.course.language = course_language
             mock_get_course_by_id.return_value = self.course
 
-            # Setup video block
             self.video_block.edx_video_id = "video-id"
-            mock_transcripts_info = {"transcripts": transcripts}
-            self.video_block.get_transcripts_info = MagicMock(
-                return_value=mock_transcripts_info
-            )
-
-            # Setup edx_video_id transcripts
-            mock_get_transcripts.return_value = edx_video_id_transcripts
+            mock_get_transcript_languages.return_value = transcript_languages
 
             mock_asset_location.return_value = "mocked-asset-location"
 
@@ -279,8 +221,8 @@ class OLChatUtilTests(OLChatTestCase):
             if expected_asset_id_suffix:
                 # Assert on the filename actually passed to `asset_location`,
                 # not just that it was called, so a regression to building the
-                # asset ID from the (possibly stale) `get_transcripts_info()`
-                # filename instead of `edx_video_id` would fail this test.
+                # asset ID from a stored/stale filename instead of
+                # `edx_video_id` would fail this test.
                 mock_asset_location.assert_called_once_with(
                     self.video_block.location, expected_asset_id_suffix
                 )
@@ -289,17 +231,21 @@ class OLChatUtilTests(OLChatTestCase):
                 mock_asset_location.assert_not_called()
                 assert result is None
 
+            # edx-val is queried exactly once per call, regardless of
+            # whether the course-language or English-fallback branch matches.
+            mock_get_transcript_languages.assert_called_once_with("video-id")
+
     def test_get_transcript_asset_id_no_edx_video_id(self):
         """
-        Test that get_transcript_asset_id falls back to the stored transcript
-        filename when the block has no edx_video_id to rebuild it from (e.g.
-        legacy videos with manually uploaded transcripts).
+        Test that get_transcript_asset_id falls back to the block's stored
+        `transcripts` field when there's no edx_video_id to query edx-val
+        with (e.g. legacy videos with manually uploaded transcripts).
         """
         with (
             patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id,
             patch(
                 "ol_openedx_chat.utils.get_available_transcript_languages"
-            ) as mock_get_transcripts,
+            ) as mock_get_transcript_languages,
             patch(
                 "ol_openedx_chat.utils.Transcript.asset_location"
             ) as mock_asset_location,
@@ -308,11 +254,7 @@ class OLChatUtilTests(OLChatTestCase):
             mock_get_course_by_id.return_value = self.course
 
             self.video_block.edx_video_id = ""
-            self.video_block.get_transcripts_info = MagicMock(
-                return_value={"transcripts": {"en": "legacy-transcript.srt"}}
-            )
-            # A real edx_video_id-less lookup always returns no languages.
-            mock_get_transcripts.return_value = []
+            self.video_block.transcripts = {"en": "legacy-transcript.srt"}
 
             mock_asset_location.return_value = "mocked-asset-location"
 
@@ -322,19 +264,10 @@ class OLChatUtilTests(OLChatTestCase):
                 self.video_block.location, "legacy-transcript.srt"
             )
             assert result == "mocked-asset-location"
+            # There's no edx_video_id to query edx-val with.
+            mock_get_transcript_languages.assert_not_called()
 
     def test_get_transcript_asset_id_exception(self):
-        """Test that get_transcript_asset_id returns None when an exception occurs"""
-        with patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id:
-            mock_get_course_by_id.return_value = self.course
-            self.video_block.get_transcripts_info = MagicMock(
-                side_effect=Exception("Transcript error")
-            )
-
-            result = get_transcript_asset_id(self.video_block)
-            assert result is None
-
-    def test_get_transcript_asset_id_exception_from_available_languages(self):
         """
         Test that get_transcript_asset_id returns None when
         get_available_transcript_languages raises
@@ -343,13 +276,11 @@ class OLChatUtilTests(OLChatTestCase):
             patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id,
             patch(
                 "ol_openedx_chat.utils.get_available_transcript_languages"
-            ) as mock_get_transcripts,
+            ) as mock_get_transcript_languages,
         ):
             mock_get_course_by_id.return_value = self.course
-            self.video_block.get_transcripts_info = MagicMock(
-                return_value={"transcripts": {}}
-            )
-            mock_get_transcripts.side_effect = Exception("Transcript error")
+            self.video_block.edx_video_id = "video-id"
+            mock_get_transcript_languages.side_effect = Exception("Transcript error")
 
             result = get_transcript_asset_id(self.video_block)
             assert result is None

--- a/src/ol_openedx_chat/tests/test_utils.py
+++ b/src/ol_openedx_chat/tests/test_utils.py
@@ -182,17 +182,20 @@ class OLChatUtilTests(OLChatTestCase):
 
     @data(
         # (course_language, transcripts, edx_video_id_transcripts, expected_asset_id_suffix)  # noqa: ERA001,E501
+        # The asset filename is always built from `edx_video_id`, never from the
+        # (possibly stale) filename stored in `get_transcripts_info()`, so the
+        # `transcripts` dict below only signals language availability.
         (
             "en",
             {"en": "transcript-en.srt", "es": "transcript-es.srt"},
             [],
-            "transcript-en.srt",
+            "video-id-en.srt",
         ),  # Course language transcript
         (
             "es",
             {"en": "transcript-en.srt", "es": "transcript-es.srt"},
             [],
-            "transcript-es.srt",
+            "video-id-es.srt",
         ),  # Non-English course language
         (
             "es_419",
@@ -202,7 +205,7 @@ class OLChatUtilTests(OLChatTestCase):
                 "es-419": "transcript-es-419.srt",
             },
             [],
-            "transcript-es-419.srt",
+            "video-id-es-419.srt",
         ),  # Non-English course language
         (
             "de_DE",
@@ -212,7 +215,7 @@ class OLChatUtilTests(OLChatTestCase):
                 "de-DE": "transcript-de-DE.srt",
             },
             [],
-            "transcript-de-DE.srt",
+            "video-id-de-DE.srt",
         ),  # Non-English course language
         ("es", {}, ["es"], "video-id-es.srt"),  # Transcript from edx_video_id
         (
@@ -225,8 +228,14 @@ class OLChatUtilTests(OLChatTestCase):
         (
             "es",
             {"en": "transcript-en.srt"},
+            ["es"],
+            "video-id-es.srt",
+        ),  # `transcripts` lacks the language but edx_video_id has it
+        (
+            "es",
+            {"en": "transcript-en.srt"},
             [],
-            "transcript-en.srt",
+            "video-id-en.srt",
         ),  # Fallback to English transcript
         ("es", {}, ["en"], "video-id-en.srt"),  # Fallback to English from edx_video_id
         ("es", {}, [], None),  # No transcript available
@@ -263,19 +272,56 @@ class OLChatUtilTests(OLChatTestCase):
             # Setup edx_video_id transcripts
             mock_get_transcripts.return_value = edx_video_id_transcripts
 
-            # Setup mock return value
-            if expected_asset_id_suffix:
-                mock_asset_location.return_value = (
-                    f"asset-id-{expected_asset_id_suffix}"
-                )
+            mock_asset_location.return_value = "mocked-asset-location"
 
             result = get_transcript_asset_id(self.video_block)
 
             if expected_asset_id_suffix:
-                assert result == f"asset-id-{expected_asset_id_suffix}"
-                mock_asset_location.assert_called_once()
+                # Assert on the filename actually passed to `asset_location`,
+                # not just that it was called, so a regression to building the
+                # asset ID from the (possibly stale) `get_transcripts_info()`
+                # filename instead of `edx_video_id` would fail this test.
+                mock_asset_location.assert_called_once_with(
+                    self.video_block.location, expected_asset_id_suffix
+                )
+                assert result == "mocked-asset-location"
             else:
+                mock_asset_location.assert_not_called()
                 assert result is None
+
+    def test_get_transcript_asset_id_no_edx_video_id(self):
+        """
+        Test that get_transcript_asset_id falls back to the stored transcript
+        filename when the block has no edx_video_id to rebuild it from (e.g.
+        legacy videos with manually uploaded transcripts).
+        """
+        with (
+            patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id,
+            patch(
+                "ol_openedx_chat.utils.get_available_transcript_languages"
+            ) as mock_get_transcripts,
+            patch(
+                "ol_openedx_chat.utils.Transcript.asset_location"
+            ) as mock_asset_location,
+        ):
+            self.course.language = "en"
+            mock_get_course_by_id.return_value = self.course
+
+            self.video_block.edx_video_id = ""
+            self.video_block.get_transcripts_info = MagicMock(
+                return_value={"transcripts": {"en": "legacy-transcript.srt"}}
+            )
+            # A real edx_video_id-less lookup always returns no languages.
+            mock_get_transcripts.return_value = []
+
+            mock_asset_location.return_value = "mocked-asset-location"
+
+            result = get_transcript_asset_id(self.video_block)
+
+            mock_asset_location.assert_called_once_with(
+                self.video_block.location, "legacy-transcript.srt"
+            )
+            assert result == "mocked-asset-location"
 
     def test_get_transcript_asset_id_exception(self):
         """Test that get_transcript_asset_id returns None when an exception occurs"""
@@ -284,6 +330,26 @@ class OLChatUtilTests(OLChatTestCase):
             self.video_block.get_transcripts_info = MagicMock(
                 side_effect=Exception("Transcript error")
             )
+
+            result = get_transcript_asset_id(self.video_block)
+            assert result is None
+
+    def test_get_transcript_asset_id_exception_from_available_languages(self):
+        """
+        Test that get_transcript_asset_id returns None when
+        get_available_transcript_languages raises
+        """
+        with (
+            patch("ol_openedx_chat.utils.get_course_by_id") as mock_get_course_by_id,
+            patch(
+                "ol_openedx_chat.utils.get_available_transcript_languages"
+            ) as mock_get_transcripts,
+        ):
+            mock_get_course_by_id.return_value = self.course
+            self.video_block.get_transcripts_info = MagicMock(
+                return_value={"transcripts": {}}
+            )
+            mock_get_transcripts.side_effect = Exception("Transcript error")
 
             result = get_transcript_asset_id(self.video_block)
             assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -2118,7 +2118,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-chat"
-version = "0.5.9"
+version = "0.5.10"
 source = { editable = "src/ol_openedx_chat" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12776

### Description (What does it do?)
`get_transcript_asset_id` (in `ol_openedx_chat`'s video xBlock aside) builds the transcript asset ID sent to the chat backend for a video block. Studio names transcript files after a video's `edx_video_id` (`{edx_video_id}-{lang}.srt`), but the function was trusting the filename stored in `block.get_transcripts_info()`. When a course author swaps the video in Studio (updating `edx_video_id`) without reuploading the transcript, that stored filename still points at the *old* video's transcript, so the chat feature would build a transcript ID for the wrong video. This is an `openedx-platform` gap (Studio never keeps a video block's stored `transcripts` field in sync with its `edx_video_id`), previously reported and diagnosed the same way in mitodl/hq#8720.

This PR makes `get_transcript_asset_id` use edx-val (`get_available_transcript_languages()`) as the sole source of truth for which languages are available whenever the block has an `edx_video_id`, and always builds the filename from that `edx_video_id` — `get_transcripts_info()`'s locally stored filename is never consulted in that case. Legacy videos with no `edx_video_id` (manually uploaded transcripts, pre-VAL) have nothing to query in edx-val, so they fall back to the block's raw `transcripts` field directly.

### How can this be tested?
- Setup plugin following the readme
- Create a video block in a course and put a debugger/print to check the transcript_asset_id
- Publish video block
- Verify that transcript_asset_id is same video id.
- Now update the video block and change the video ID and verify the same.
- On main branch, it will still display the old video id in transcript asset ID

### Additional Context
Version bumped `0.5.9` -> `0.5.10` for this bugfix per repo convention.
