### PR TITLE
ci: cache the openedx-dev image to speed up Tutor integration tests

### DIFF
--- a/.github/actions/setup-tutor/action.yml
+++ b/.github/actions/setup-tutor/action.yml
@@ -1,0 +1,109 @@
+---
+name: Set up Tutor
+description: >-
+  Install the Tutor release matching an Open edX branch and derive the
+  openedx-dev image names. Shared by ci.yml (which pulls the cached image)
+  and ci-image-cache.yml (which builds and pushes it) so the two can never
+  disagree about the cache tag.
+inputs:
+  edx_branch:
+    description: Open edX branch under test, e.g. master or release/teak
+    required: true
+  ghcr_owner:
+    description: GitHub org that owns the openedx-dev-cache package
+    required: true
+outputs:
+  branch_slug:
+    description: edx_branch with slashes replaced, safe for use in an image tag
+    value: ${{ steps.names.outputs.branch_slug }}
+  version_tag:
+    description: Installed Tutor version, sanitised for use in an image tag
+    value: ${{ steps.names.outputs.version_tag }}
+  openedx_dev_image:
+    description: Local image name Tutor expects, from DOCKER_IMAGE_OPENEDX_DEV
+    value: ${{ steps.names.outputs.openedx_dev_image }}
+  cache_image_tag:
+    description: Fully qualified GHCR tag holding the cached openedx-dev image
+    value: ${{ steps.names.outputs.cache_image_tag }}
+  tutor_root:
+    description: TUTOR_ROOT as Tutor itself reports it, holding env/
+    value: ${{ steps.names.outputs.tutor_root }}
+  compose_project:
+    description: Docker Compose project name for the Tutor dev environment
+    value: ${{ steps.names.outputs.compose_project }}
+runs:
+  using: composite
+  steps:
+  - name: Install Tutor
+    shell: bash
+    env:
+      EDX_BRANCH: ${{ inputs.edx_branch }}
+    run: |
+      if [[ "$EDX_BRANCH" == "release/teak" ]]; then
+        pip install "tutor>=20.0.0,<21.0.0"
+      elif [[ "$EDX_BRANCH" == "master" ]]; then
+        git clone --depth=1 --branch=main https://github.com/overhangio/tutor.git
+        pip install -e "./tutor"
+      else
+        pip install "tutor>=21.0.0,<22.0.0"
+      fi
+
+  - name: Derive image names
+    id: names
+    shell: bash
+    env:
+      EDX_BRANCH: ${{ inputs.edx_branch }}
+      GHCR_OWNER: ${{ inputs.ghcr_owner }}
+    run: |
+      set -euo pipefail
+
+      version=$(tutor --version | awk '{print $NF}')
+      if [[ -d "./tutor/.git" ]]; then
+        # Installed from git main, where the reported version stands still
+        # across commits. Tag by UTC date, not the exact commit SHA: this
+        # job and the nightly cache-build workflow each clone main
+        # independently, so an exact-SHA tag only matches if upstream
+        # main had zero commits in between - a date-based tag instead
+        # matches the once-a-day rebuild cadence this cache already relies
+        # on (see ci-image-cache.yml), so same-day runs reliably hit.
+        version="${version}+git.$(date -u +%Y-%m-%d)"
+      fi
+      version_tag=${version//[^A-Za-z0-9_.-]/-}
+      branch_slug=${EDX_BRANCH//\//-}
+
+      # The openedx-dev image bakes in its own edx-platform checkout (via a
+      # Dockerfile ADD of $EDX_PLATFORM_REPOSITORY#$EDX_PLATFORM_VERSION),
+      # separate from the source this job resolves and mounts at test time.
+      # Without this override, EDX_PLATFORM_VERSION/OPENEDX_COMMON_VERSION
+      # falls back to Tutor's own default, which does not necessarily match
+      # $EDX_BRANCH - e.g. a Tutor install from git main defaults to its own
+      # upcoming release branch (release/verawood.1 as of this writing), not
+      # edx-platform's actual master, so the image's baked-in dependencies
+      # (e.g. openedx-filters) can silently drift out of sync with the
+      # mounted code. Pin it so the image always tracks the exact branch
+      # under test. Also renders env/, which the test step's docker compose
+      # invocation reads.
+      tutor config save --set OPENEDX_COMMON_VERSION="$EDX_BRANCH"
+
+      openedx_dev_image="$(tutor config printvalue DOCKER_IMAGE_OPENEDX_DEV)"
+      if [ -z "$openedx_dev_image" ]; then
+        echo "Failed to read DOCKER_IMAGE_OPENEDX_DEV from tutor config" >&2
+        exit 1
+      fi
+
+      # Ask Tutor where its root is rather than assuming. The directory is
+      # named after __app__, which picks up __version_suffix__ ("tutor-main"
+      # when the main branch carries a suffix, plain "tutor" when it does not
+      # — as happens on release day, when the suffix is reset). Hardcoding
+      # either spelling breaks the moment upstream flips it.
+      tutor_root="$(tutor config printroot)"
+      compose_project="$(basename "$tutor_root" | tr '-' '_')_dev"
+
+      {
+        echo "branch_slug=$branch_slug"
+        echo "version_tag=$version_tag"
+        echo "openedx_dev_image=$openedx_dev_image"
+        echo "cache_image_tag=ghcr.io/${GHCR_OWNER}/openedx-dev-cache:${branch_slug}-${version_tag}"
+        echo "tutor_root=$tutor_root"
+        echo "compose_project=$compose_project"
+      } >> "$GITHUB_OUTPUT"

--- a/.github/edx-branches.json
+++ b/.github/edx-branches.json
@@ -1,0 +1,1 @@
+["master", "release/teak", "release/ulmo"]

--- a/.github/workflows/ci-image-cache.yml
+++ b/.github/workflows/ci-image-cache.yml
@@ -1,0 +1,97 @@
+---
+name: Refresh CI image cache
+# Builds the openedx-dev image for each Open edX branch under test and pushes
+# it to GHCR, where ci.yml pulls it instead of spending ~13 minutes per matrix
+# leg rebuilding it.
+#
+# This lives in its own workflow, off the critical path, for two reasons:
+#
+# 1. Least privilege. packages:write is granted only here, and this job runs
+#    no pull request code: no plugin build, no edx-platform checkout, no test
+#    run. ci.yml needs only read access to the cache.
+# 2. Freshness. The image pins the Python dependencies of whatever edx-platform
+#    release branch it was built against. A pinned Tutor range is stable for
+#    months, so a build-on-demand cache would go stale as the release branches
+#    move underneath it. Rebuilding nightly bounds that drift to a day.
+on:
+  schedule:
+  - cron: '0 4 * * *'
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    # Refresh immediately when the Tutor install or tagging logic changes, or
+    # when a branch joins or leaves the matrix, rather than waiting for the
+    # next nightly run. A newly added branch has no cached image at all, so
+    # without this every ci.yml run would pay for a local build until the
+    # nightly caught up.
+    paths:
+    - .github/workflows/ci-image-cache.yml
+    - .github/actions/setup-tutor/action.yml
+    - .github/edx-branches.json
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+env:
+  GHCR_CACHE_OWNER: mitodl
+jobs:
+  resolve-matrix:
+    # Single source of truth for the edx_branch list, shared with ci.yml via
+    # .github/edx-branches.json so the two workflows can't drift apart.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      edx_branches: ${{ steps.branches.outputs.edx_branches }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - id: branches
+      run: echo "edx_branches=$(cat .github/edx-branches.json)" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    # Forks have no access to the upstream package, and pushing to their own
+    # namespace would populate a cache nothing reads.
+    if: github.repository_owner == 'mitodl'
+    needs: resolve-matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        edx_branch: ${{ fromJson(needs.resolve-matrix.outputs.edx_branches) }}
+    steps:
+    # This job only reads the checkout to run the composite action below; it
+    # performs no authenticated git operations, so the token has no reason to
+    # stay behind in .git/config where later steps could leak it.
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up Tutor
+      id: tutor
+      uses: ./.github/actions/setup-tutor
+      with:
+        edx_branch: ${{ matrix.edx_branch }}
+        ghcr_owner: ${{ env.GHCR_CACHE_OWNER }}
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build openedx-dev image
+      run: tutor images build openedx-dev
+
+    - name: Push image to GHCR cache
+      env:
+        LOCAL_IMAGE: ${{ steps.tutor.outputs.openedx_dev_image }}
+        CACHE_IMAGE: ${{ steps.tutor.outputs.cache_image_tag }}
+      run: |
+        set -euo pipefail
+        docker tag "$LOCAL_IMAGE" "$CACHE_IMAGE"
+        docker push "$CACHE_IMAGE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,23 +9,31 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  GHCR_CACHE_OWNER: mitodl
 jobs:
-  integration-tests:
+  resolve-matrix:
+    # Single source of truth for the edx_branch list, shared with
+    # ci-image-cache.yml via .github/edx-branches.json so the two workflows
+    # can't drift apart.
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version:
-        - 3.11
-        edx_branch:
-        - master
-        - release/teak
-        - release/ulmo
+    outputs:
+      edx_branches: ${{ steps.branches.outputs.edx_branches }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - id: branches
+      run: echo "edx_branches=$(cat .github/edx-branches.json)" >> "$GITHUB_OUTPUT"
 
-          # Add more branches as needed
-
+  build-packages:
+    # Built once and shared via artifact so the 3 integration-tests matrix
+    # legs, which all need the identical dist/ output, don't each rebuild it.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -36,49 +44,176 @@ jobs:
       with:
         enable-cache: true
 
-    - name: Set up Python ${{ matrix.python_version }}
-      run: uv python install ${{ matrix.python_version }}
+    - name: Cache built packages
+      id: cache-dist
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: dist/
+        key: dist-${{ hashFiles('src/**', 'pyproject.toml', 'uv.lock') }}
 
     - name: Build all packages
+      if: steps.cache-dist.outputs.cache-hit != 'true'
       run: uv build --all-packages
 
-    - name: Install tutor
-      run: |
-        if [[ "${{ matrix.edx_branch }}" == "release/teak" ]]; then
-          pip install "tutor>=20.0.0,<21.0.0"
-        elif [[ "${{ matrix.edx_branch }}" == "master" ]]; then
-          git clone --branch=main https://github.com/overhangio/tutor.git
-          pip install -e "./tutor"
-        else
-          pip install "tutor>=21.0.0,<22.0.0"
-        fi
-    - name: clone edx-platform and add mounts
-      run: |
-        cd ..
-        git clone https://github.com/openedx/edx-platform
-        cd edx-platform
-        git checkout ${{ matrix.edx_branch }}
-        tutor mounts add .
+    - name: Upload built packages
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: dist
+        path: dist/
 
+  integration-tests:
+    needs: [resolve-matrix, build-packages]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Read-only. The openedx-dev image is built and pushed by
+      # ci-image-cache.yml, which is the only workflow holding packages:write.
+      # This job runs pull request code and third party code (edx-platform's
+      # setup.py, Tutor from git main, the image's pip installs), so it must
+      # never hold a credential that can write to the registry.
+      packages: read
+    strategy:
+      # One branch breaking upstream shouldn't hide the state of the others.
+      fail-fast: false
+      matrix:
+        edx_branch: ${{ fromJson(needs.resolve-matrix.outputs.edx_branches) }}
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Resolve edx-platform tip SHA
+      id: edx-sha
+      env:
+        EDX_BRANCH: ${{ matrix.edx_branch }}
+      run: |
+        SHA=$(git ls-remote https://github.com/openedx/edx-platform "refs/heads/$EDX_BRANCH" | cut -f1)
+        if [ -z "$SHA" ]; then
+          echo "Failed to resolve SHA for branch $EDX_BRANCH. git ls-remote returned empty output."
+          exit 1
+        fi
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+    # edx-platform's minimum Python version varies by branch (master moved
+    # to 3.12; the release branches are still on 3.11), so it can't be a
+    # single matrix-wide value the way it could when every branch agreed.
+    - name: Resolve Python version for edx-platform
+      id: python-version
+      env:
+        EDX_BRANCH: ${{ matrix.edx_branch }}
+      run: |
+        if [[ "$EDX_BRANCH" == "master" ]]; then
+          echo "version=3.12" >> "$GITHUB_OUTPUT"
+        else
+          echo "version=3.11" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python ${{ steps.python-version.outputs.version }}
+      run: uv python install ${{ steps.python-version.outputs.version }}
+
+    - name: Download built packages
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: dist
+        path: dist/
+
+    - name: Set up Tutor
+      id: tutor
+      uses: ./.github/actions/setup-tutor
+      with:
+        edx_branch: ${{ matrix.edx_branch }}
+        ghcr_owner: ${{ env.GHCR_CACHE_OWNER }}
+
+    # Deliberately not cached. The checkout has to be a sibling of the
+    # workspace (the test step passes EDX_WORKSPACE="$PWD/.." to docker
+    # compose), and actions/cache rejects a path containing "..", so the
+    # cache step this replaced always missed and never saved. Caching it
+    # properly would store a very large repo under a key that changes on
+    # every upstream commit, to avoid a shallow fetch that takes ~5s.
+    - name: Clone edx-platform
+      run: |
+        set -euo pipefail
+        EDX_DIR="${{ github.workspace }}/../edx-platform"
+        git init "$EDX_DIR"
+        git -C "$EDX_DIR" remote add origin https://github.com/openedx/edx-platform
+        git -C "$EDX_DIR" fetch --depth=1 origin "${{ steps.edx-sha.outputs.sha }}"
+        git -C "$EDX_DIR" checkout --detach FETCH_HEAD
+
+    # Only the .egg-info written into the edx-platform source tree matters
+    # here; the venv is a throwaway target that keeps the install off the
+    # runner's system Python. It lives in RUNNER_TEMP rather than the
+    # workspace because the workspace is bind-mounted into the test container
+    # and is not covered by .gitignore.
+    - name: Generate edx-platform egg-info (registers Django app entry points)
+      env:
+        EGG_INFO_VENV: ${{ runner.temp }}/venv-edx-platform
+      run: |
+        set -euo pipefail
+        uv venv --python ${{ steps.python-version.outputs.version }} "$EGG_INFO_VENV"
+        uv pip install --python "$EGG_INFO_VENV/bin/python" --no-deps -e ${{ github.workspace }}/../edx-platform
+
+    # Only needed while the openedx-dev-cache package is private. Once it is
+    # made public this step is a no-op for pulls, and fork PRs get cache hits
+    # too. Never fatal: on failure the build below runs instead.
+    - name: Log in to GitHub Container Registry
+      continue-on-error: true
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Pull cached openedx-dev image
+      id: pull-image
+      env:
+        LOCAL_IMAGE: ${{ steps.tutor.outputs.openedx_dev_image }}
+        CACHE_IMAGE: ${{ steps.tutor.outputs.cache_image_tag }}
+      run: |
+        if docker pull "$CACHE_IMAGE"; then
+          docker tag "$CACHE_IMAGE" "$LOCAL_IMAGE"
+          echo "cache_hit=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No cached image at $CACHE_IMAGE, falling back to a local build."
+          echo "cache_hit=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Fallback only. The cache is populated by ci-image-cache.yml; this job
+    # never pushes what it builds.
     - name: Build Tutor images
+      if: steps.pull-image.outputs.cache_hit != 'true'
       run: |
         tutor images build openedx-dev
 
-    - name: Launch Tutor
+    # Tests below run each plugin's own pytest suite against Django TEST
+    # settings; pytest-django creates and migrates its own throwaway test
+    # database per run, independent of the persistent dev environment. So,
+    # unlike a real `tutor dev launch`, no `tutor dev launch -I`/`dev stop`
+    # init step is needed here before `docker compose run`.
+    - name: Add edx-platform tutor mounts
       run: |
-        tutor dev launch -I --skip-build
-        tutor dev stop
+        cd "${{ github.workspace }}/../edx-platform"
+        tutor mounts add .
 
     - name: Run tests on tutor
+      env:
+        TUTOR_ROOT_DIR: ${{ steps.tutor.outputs.tutor_root }}
+        COMPOSE_PROJECT: ${{ steps.tutor.outputs.compose_project }}
       run: |
-        if [[ "${{ matrix.edx_branch }}" == "master" ]]; then
-          DEV="tutor_main_dev"
-          DIRECTORY="tutor-main"
-        else
-          DEV="tutor_dev"
-          DIRECTORY="tutor"
-        fi
-        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/$DIRECTORY/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
+        set -euo pipefail
+        EDX_WORKSPACE="$PWD/.." docker compose \
+          -f "$TUTOR_ROOT_DIR/env/local/docker-compose.yml" \
+          -f "$TUTOR_ROOT_DIR/env/dev/docker-compose.yml" \
+          --project-name "$COMPOSE_PROJECT" \
+          run -v "$PWD:/openedx/open-edx-plugins" \
+          lms /openedx/open-edx-plugins/run_edx_integration_tests.sh \
+          --mount-dir /openedx/open-edx-plugins
+
     - name: Upload coverage to CodeCov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,31 @@
+---
+name: Cleanup GHCR CI cache images
+on:
+  schedule:
+    # Daily at 05:00 UTC, an hour after ci-image-cache.yml refreshes the
+    # openedx-dev-cache image for each (edx_branch, tutor version) pair. Each
+    # nightly push orphans the version it replaces, so untagged leftovers
+    # accrue daily; stale tagged versions accrue whenever Tutor bumps.
+  - cron: '0 5 * * *'
+  workflow_dispatch: {}
+jobs:
+  cleanup:
+    if: github.repository_owner == 'mitodl'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+    - name: Delete untagged openedx-dev-cache versions
+      uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
+      with:
+        package-name: openedx-dev-cache
+        package-type: container
+        min-versions-to-keep: 0
+        delete-only-untagged-versions: true
+
+    - name: Trim old tagged openedx-dev-cache versions
+      uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
+      with:
+        package-name: openedx-dev-cache
+        package-type: container
+        min-versions-to-keep: 15

--- a/run_edx_integration_tests.sh
+++ b/run_edx_integration_tests.sh
@@ -62,6 +62,17 @@ pwd
 
 mkdir -p reports
 
+echo "===== Installing uv ====="
+pip install uv
+
+# Inert under GitHub Actions: the workflow reaches this script through
+# `docker compose run`, which does not forward the runner's CI variable into
+# the container, so this branch is never taken there. It is kept for anyone
+# invoking the script by hand with CI set, and it only makes sense from
+# /openedx/edx-platform, the container's working directory, where these
+# relative paths resolve. Enabling it in CI would mean passing `-e CI` in
+# ci.yml, which the openedx-dev image and the workflow's egg-info step
+# already make unnecessary.
 if [ $CI ]; then
 	pip install -r ./requirements/edx/testing.txt
 
@@ -82,13 +93,10 @@ if [ -n "$MOUNT_DIR" ]; then
 fi
 
 if [ "$SKIP_BUILD" != true ]; then
-	# Installing test dependencies using UV (this includes pytest-mock, responses, codecov, etc.)
-	echo "===== Installing uv ====="
-	curl -LsSf https://astral.sh/uv/install.sh | sh
-	source $HOME/.local/bin/env
+	# Installing test dependencies (this includes pytest-mock, responses, codecov, etc.)
 	echo "===== Installing Packages ====="
 	uv export --only-dev --no-hashes --no-annotate >ol_test_requirements.txt
-	pip install -r ol_test_requirements.txt
+	uv pip install -r ol_test_requirements.txt
 
 	# output the packages which are installed for logging
 	echo "===== Installed Python Packages ====="
@@ -136,10 +144,10 @@ run_plugin_tests() {
 
 	if [ -n "$tarball" ]; then
 		echo "Installing $plugin_name from dist/$tarball"
-		pip install "dist/$tarball"
+		uv pip install "dist/$tarball"
 	else
 		echo "No built package found for $plugin_name, installing in development mode"
-		pip install -e "$plugin_dir"
+		uv pip install -e "$plugin_dir"
 	fi
 
 	# Copying test_root only if it doesn't exist


### PR DESCRIPTION
### What are the relevant tickets?

None

### Description (What does it do?)

Every `integration-tests` matrix leg rebuilt the `openedx-dev` image from scratch, spending ~13 minutes of a 25–40 minute job on work that is identical across runs. This builds the image nightly and pulls it from GHCR instead.

- **`ci-image-cache.yml` (new)** builds the image per Open edX branch and pushes it to GHCR. It sits off the critical path, so `packages:write` is never held by a job that runs pull request code, and the nightly cadence bounds how far the image's pinned dependencies can drift.
- **`setup-tutor` composite action (new)** is shared by the workflow that pushes the cache and the one that pulls it, so the two cannot disagree about the tag.
- **Pins the image build to the edx-platform branch under test** via `OPENEDX_COMMON_VERSION`. Tutor otherwise defaults to its own target branch, which baked in dependencies that did not match the source mounted at test time.
- **Resolves the Python version per branch** — `master` now requires >= 3.12 while the release branches are still on 3.11.
- **Builds the plugin packages once** in their own job and shares them by artifact, rather than three legs each producing the same `dist/`.
- **Reads the branch matrix from `.github/edx-branches.json`** so both workflows stay in step.
- **`ghcr-cleanup.yml` (new)** prunes superseded cache images.
- **`run_edx_integration_tests.sh`** installs uv with `pip` rather than the network install script, and uses `uv pip install` throughout.

If the pull misses, the job falls back to building locally, so tests stay runnable against an empty or stale cache.

### How can this be tested?

CI on this PR is the primary test — all three legs (`master`, `release/teak`, `release/ulmo`) should be green.

To confirm the caching path specifically, check a leg's logs for:

- `Pull cached openedx-dev image` reporting a hit, with `Build Tutor images` then skipped. Only `release/teak` has a cache image today, so it is the only leg expected to hit before merge — see Additional Context.
- The image's dependencies matching the mounted source. On `master` this is visible as `openedx-filters==3.8.0`; the mismatch this PR fixes showed up as `3.4.1`.

After merge, `ci-image-cache.yml` runs for the first time (nightly at 04:00 UTC, or trigger it directly via `workflow_dispatch`). Confirm it pushes an image for each branch, then confirm a later PR gets cache hits on all three legs.

### Additional Context

Replaces #802, which accumulated a long exploratory history while the caching approach was worked out. The code review thread and CI iterations there are useful background; this PR is the same net change squashed into one commit.

Deliberate tradeoffs and things worth a reviewer's attention:

- **The cache is empty for two of three branches until this merges.** `ci-image-cache.yml` cannot run until it exists on the default branch, so `master` and `release/ulmo` still pay the full local build on this PR. `release/teak` hits an image that predates this work, which also means its leg is not yet exercising the new `OPENEDX_COMMON_VERSION` pin — the first nightly after merge is what to watch. `master` and `release/ulmo` did build fresh under the pin and passed.
- **Up to a day of dependency drift remains possible.** The image bakes dependencies when it is built; tests mount the branch tip at PR time. A dependency bump landing between the two reintroduces the class of `ImportError` this PR fixes, and on a cache hit there is no fallback build to absorb it. Closing that gap fully means either putting the edx-platform SHA in the cache tag (which would eliminate `master`'s hit rate) or reinstalling requirements in-container. A re-run is the intended mitigation for now.
- **`master` structurally misses the cache between 00:00 and 04:00 UTC**, since its tag names the current date but the nightly that creates it has not run yet.
- **Two cache steps were removed rather than repaired.** The `pip` cache had no content component, so `actions/cache` skipped the save on every hit and froze the entry permanently while holding ~30 MB per leg. The `edx-platform` cache logged `Invalid pattern ... '..' is not allowed` and never saved at all — the checkout has to be a sibling of the workspace, so the `..` is unavoidable. Both guarded work measured in seconds.
- **`ghcr-cleanup.yml` keeps 15 tagged versions.** `master` adds one per day while the release branches reuse stable tags, so a long-unchanged release tag could in principle age out and be trimmed while still in use.
- **The `if [ $CI ]` block in `run_edx_integration_tests.sh` is inert** under this workflow, because `docker compose run` does not forward `CI`. It is kept with a comment rather than deleted, since it predates this PR and a hand-run `CI=1` from `/openedx/edx-platform` is still coherent.
