### PR TITLE
ci: resolve the tutor root and dev project from tutor itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,13 @@ jobs:
 
     - name: Run tests on tutor
       run: |
-        if [[ "${{ matrix.edx_branch }}" == "master" ]]; then
-          DEV="tutor_main_dev"
-          DIRECTORY="tutor-main"
-        else
-          DEV="tutor_dev"
-          DIRECTORY="tutor"
-        fi
-        EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/$DIRECTORY/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
+        # Ask tutor where its root and dev project are rather than hardcoding
+        # them. Both depend on tutor's __app__, which gains a "-<suffix>" only
+        # while a branch carries a __version_suffix__ (empty on main between
+        # releases), so any hardcoded value goes stale without warning.
+        TUTOR_ROOT_DIR="$(tutor config printroot)"
+        DEV_PROJECT_NAME="$(tutor config printvalue DEV_PROJECT_NAME)"
+        EDX_WORKSPACE=$PWD/.. docker compose -f "$TUTOR_ROOT_DIR/env/local/docker-compose.yml" -f "$TUTOR_ROOT_DIR/env/dev/docker-compose.yml" --project-name "$DEV_PROJECT_NAME" run -v $PWD:/openedx/open-edx-plugins lms /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
     - name: Upload coverage to CodeCov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:


### PR DESCRIPTION
## What are the relevant tickets?

None — CI fix. The `integration-tests (3.11, master)` leg has been failing on `main` since 2026-08-05 (e.g. runs 31376617021, 31173837912, 31104657062); the `release/teak` and `release/ulmo` legs are unaffected.

## Description (What does it do?)

The `Run tests on tutor` step hardcoded `~/.local/share/tutor-main` and the `tutor_main_dev` project name for the `master` matrix leg, which installs tutor from its `main` branch. Both values derive from tutor's `__app__`, which only gains a `-<suffix>` while a branch carries a `__version_suffix__` — that suffix is currently empty on tutor `main`, so the root is plain `~/.local/share/tutor` and the step failed with:

```
open /home/runner/.local/share/tutor-main/env/local/docker-compose.yml: no such file or directory
```

Now the step asks tutor: `tutor config printroot` and `tutor config printvalue DEV_PROJECT_NAME`. That drops the per-branch conditional entirely and keeps working whichever way the suffix flips on a future tutor release.

## How can this be tested?

CI on this PR — all three `integration-tests` legs (`master`, `release/teak`, `release/ulmo`) should pass. `master` is the one that was red.

Locally, both commands resolve correctly against an installed tutor:

```
$ tutor config printroot
/Users/<me>/Library/Application Support/tutor
$ tutor config printvalue DEV_PROJECT_NAME
tutor_dev
```

and the two compose files are present under that root. `pre-commit` passes, including `actionlint` and `zizmor`.
