### PR TITLE
fix(ci): only override OPENEDX_COMMON_VERSION on the master leg

### DIFF
--- a/.github/actions/setup-tutor/action.yml
+++ b/.github/actions/setup-tutor/action.yml
@@ -58,7 +58,15 @@ runs:
       set -euo pipefail
 
       version=$(tutor --version | awk '{print $NF}')
+      # Tutor from git main, i.e. the master leg; the version tag and the pin
+      # below both branch on it. if/else, not `&&`: `set -e` sees the nonzero.
       if [[ -d "./tutor/.git" ]]; then
+        tutor_from_main=true
+      else
+        tutor_from_main=false
+      fi
+
+      if [[ "$tutor_from_main" == true ]]; then
         # Installed from git main, where the reported version stands still
         # across commits. Tag by UTC date, not the exact commit SHA: this
         # job and the nightly cache-build workflow each clone main
@@ -71,19 +79,19 @@ runs:
       version_tag=${version//[^A-Za-z0-9_.-]/-}
       branch_slug=${EDX_BRANCH//\//-}
 
-      # The openedx-dev image bakes in its own edx-platform checkout (via a
-      # Dockerfile ADD of $EDX_PLATFORM_REPOSITORY#$EDX_PLATFORM_VERSION),
-      # separate from the source this job resolves and mounts at test time.
-      # Without this override, EDX_PLATFORM_VERSION/OPENEDX_COMMON_VERSION
-      # falls back to Tutor's own default, which does not necessarily match
-      # $EDX_BRANCH - e.g. a Tutor install from git main defaults to its own
-      # upcoming release branch (release/verawood.1 as of this writing), not
-      # edx-platform's actual master, so the image's baked-in dependencies
-      # (e.g. openedx-filters) can silently drift out of sync with the
-      # mounted code. Pin it so the image always tracks the exact branch
-      # under test. Also renders env/, which the test step's docker compose
-      # invocation reads.
-      tutor config save --set OPENEDX_COMMON_VERSION="$EDX_BRANCH"
+      # EDX_PLATFORM_VERSION defaults to OPENEDX_COMMON_VERSION and picks the
+      # edx-platform baked into the image. Release legs keep Tutor's default:
+      # it tracks the matching release line, and Tutor's Dockerfile `git am`s
+      # security fixes that landed after its pinned tag, which exits 128 on a
+      # branch tip that already has them (GHSA-rh64-vc2h-7wfj on teak). Tutor
+      # from git main instead pins its own upcoming release branch, not
+      # edx-platform master, so pin that leg or the image's baked dependencies
+      # drift from the mounted code. Also renders env/, read by the test step.
+      if [[ "$tutor_from_main" == true ]]; then
+        tutor config save --set OPENEDX_COMMON_VERSION="$EDX_BRANCH"
+      else
+        tutor config save
+      fi
 
       openedx_dev_image="$(tutor config printvalue DOCKER_IMAGE_OPENEDX_DEV)"
       if [ -z "$openedx_dev_image" ]; then


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

The `release/teak` leg of `Refresh CI image cache` has failed on every run since the workflow landed in #848, at the `Build openedx-dev image` step. Example: [run 31993703192](https://github.com/mitodl/open-edx-plugins/actions/runs/31993703192/job/95281561167).

```
#23 [code 5/5] RUN curl -fsSL https://github.com/openedx/edx-platform/commit/ea63816f91f5b7b1caf6b6d8f6aa6c45d346e80f.patch | git am
#23 2.203 error: patch failed: common/djangoapps/student/auth.py:24
#23 2.203 error: common/djangoapps/student/auth.py: patch does not apply
#23 2.204 Applying: fix: CourseLimitedStaffRole should not be able to access studio.
ERROR: failed to build: failed to solve: process "/bin/sh -c curl -fsSL ... | git am" did not complete successfully: exit code: 128
```

**Root cause.** Tutor 20.0.5 pins `OPENEDX_COMMON_VERSION` to `release/teak.3`, a tag that predates the fix for [GHSA-rh64-vc2h-7wfj](https://github.com/openedx/edx-platform/security/advisories/GHSA-rh64-vc2h-7wfj). To cover that gap, its `openedx` Dockerfile layers the fix in as a `git am` of the upstream commit, authored against that exact tag ([template source](https://github.com/overhangio/tutor/blob/v20.0.5/tutor/templates/build/openedx/Dockerfile#L50-L60)):

```dockerfile
{%- if patch("openedx-dockerfile-git-patches-default") %}
{{ patch("openedx-dockerfile-git-patches-default") }}
{%- elif TUTOR_BRANCH_IS_MAIN %}
{%- else %}
RUN curl -fsSL https://github.com/openedx/edx-platform/commit/ea63816f...patch | git am
{%- endif %}
```

`.github/actions/setup-tutor` overrode that pin to the branch tip:

```bash
tutor config save --set OPENEDX_COMMON_VERSION="$EDX_BRANCH"   # release/teak
```

`EDX_PLATFORM_VERSION` defaults to `OPENEDX_COMMON_VERSION`, so the image checked out `release/teak`, whose tip already contains `ea63816f`. The patch was therefore already applied, and `git am` cannot tell "already applied" from "conflicts" — both surface as `patch does not apply`, exit 128.

More generally: a Tutor release-mode hotfix exists precisely because the commit was merged upstream *after* the pinned tag, so any such hotfix is already present in the branch tip. Pinning to the tip makes every one of them fail, not just this SHA.

**Fix.** Apply the override only to the master leg. Tutor's default pin already tracks the matching release line on the release legs (20.0.5 → `release/teak.3`, 21.0.9 → `release/ulmo.4`), so the hotfix applies against the ref it was written for. A Tutor install from git main has no matching default — it pins its own upcoming release branch (`release/verawood.1` at present) rather than edx-platform's `master`, which would let the image's baked-in dependencies drift from the mounted master code — and it carries no release-mode hotfix patches for `git am` to collide with.

The `./tutor/.git` check is now derived once into `$tutor_from_main` instead of being spelled out twice. It is an `if/else` rather than `[[ ... ]] && var=true` on purpose: the latter returns nonzero on the release legs, which `set -e` would treat as a failure and abort the step before `tutor config save`.

Why `master` and `release/ulmo` were unaffected: Tutor `main` and `21.0.9` both have that Dockerfile line commented out, and the master leg additionally takes the `TUTOR_BRANCH_IS_MAIN` branch.

### How can this be tested?

Verified locally against a real Tutor 20.0.5 install by extracting the `Derive image names` step body from the composite action and running it for both legs, checking the rendered `env/` rather than paying for a full image build:

| Check | Result |
| --- | --- |
| `bash -n` on the extracted step | OK |
| `release/teak` leg, exit code | `0` |
| `release/teak` baked `EDX_PLATFORM_VERSION` | `release/teak.3` — the tag the hotfix was authored against |
| hotfix `RUN ... git am` in rendered Dockerfile | present, and now applies cleanly |
| `master` leg (git-main install simulated), exit code | `0`, override intact, baked ref `master` |
| `cache_image_tag` on both legs | unchanged |
| `pre-commit run --files .github/actions/setup-tutor/action.yml` | exit 0 |

Confirmed independently that the patch is redundant on the branch tip but required on the tag, via the compare API:

- `ea63816f...release/teak` → `ahead` (tip contains the commit)
- `ea63816f...release/teak.3` → `behind` (tag lacks it)

**What local testing cannot prove, and how to validate this PR:** the actual `docker buildx build`. Note that the `CI` run on this PR will *not* exercise the fixed path — `ci.yml` pulls `ghcr.io/mitodl/openedx-dev-cache:release-teak-20.0.5` and only falls back to a local build on a cache miss, so a green `CI` here says nothing about the fix. To validate, dispatch `Refresh CI image cache` against this branch and confirm the `release/teak` leg reaches `Push image to GHCR cache`:

```
gh workflow run ci-image-cache.yml --ref asad/fix-teak-image-build-git-am
```

That will overwrite the `release-teak-20.0.5` tag in GHCR with a correctly built image, which is the desired end state (see below).

### Additional Context

Worth knowing while reviewing: **the `release/teak` leg of `CI` is currently green only because of a stale cached image that the nightly refresh cannot reproduce.** `ci.yml` pulls `release-teak-20.0.5` successfully, but no main-branch run of `ci-image-cache.yml` has ever pushed that tag — its teak leg has failed 6/6 times. The image therefore predates the override and was baked at `release/teak.3` while `ci.yml` mounts the branch tip. Two consequences:

1. Teak has effectively been testing under the same tag-pinned configuration this PR restores, which is reassuring for the change but means the override never really took effect on that leg.
2. Once Tutor releases 20.0.6 (changing the cache tag) or the stale tag is pruned, `ci.yml`'s teak leg would fall back to a local build and fail exactly as the cache workflow does today.

Since `cache_image_tag` is unchanged by this PR, no tag deletion is needed: `ci.yml` keeps hitting the cache while the next refresh overwrites it with a correctly built image.

**Trade-off this accepts.** The release legs now bake Tutor's pinned tag (`release/teak.3`, `release/ulmo.4`) while `ci.yml` mounts the branch tip. That baked-vs-mounted drift is what the override was originally written to prevent, so if a plugin ever breaks on a dependency that moved on a release branch after its tag, this is the first place to look. Within a release line the drift is patch-level, and it is the configuration teak has been running under all along per the note above. The alternative — keeping the branch-tip pin and suppressing Tutor's hotfix via the `openedx-dockerfile-git-patches-default` patch hook — was considered and rejected as the more surprising of the two, since it means opting out of an upstream security patch step in order to keep a pin.

### Checklist:

- [ ] After merge, dispatch `Refresh CI image cache` (or wait for the 04:00 UTC nightly) so the `release-teak-20.0.5` tag in GHCR is replaced by a reproducibly built image
