### PR TITLE
fix: return focus to the feedback trigger when the drawer closes

### DIFF
--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/html/student_view.html
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/html/student_view.html
@@ -1,7 +1,7 @@
 <div class="ol-feedback-container">
   <span class="ol-feedback-anchor">
     <button class="ol-feedback-trigger{% if show_label %} ol-feedback-trigger--with-text{% endif %}" id="ol-feedback-trigger-{{ block_id }}" type="button"
-            aria-haspopup="dialog" aria-label="{{ aria_label }}" title="{{ aria_label }}">
+            aria-label="{{ aria_label }}" title="{{ aria_label }}">
       <svg class="ol-fb-ic" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M9 17C9 17 16 18 19 21H20C20.5523 21 21 20.5523 21 20V13.937C21.8626 13.715 22.5 12.9319 22.5 12C22.5 11.0681 21.8626 10.285 21 10.063V4C21 3.44772 20.5523 3 20 3H19C16 6 9 7 9 7H5C3.89543 7 3 7.89543 3 9V15C3 16.1046 3.89543 17 5 17H6L7 22H9V17ZM11 8.6612C11.6833 8.5146 12.5275 8.31193 13.4393 8.04373C15.1175 7.55014 17.25 6.77262 19 5.57458V18.4254C17.25 17.2274 15.1175 16.4499 13.4393 15.9563C12.5275 15.6881 11.6833 15.4854 11 15.3388V8.6612ZM5 9H9V15H5V9Z"/></svg>
       <span class="ol-fb-label" aria-hidden="true">{{ label }}</span>
     </button>

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
@@ -30,8 +30,17 @@
         // Remember which trigger opened the drawer so focus can return here when
         // the drawer closes.
         lastTrigger = $trigger[0];
+        // Keyboard-fired click has detail === 0 (mouse >= 1); tell the drawer so
+        // it rings the heading for keyboard opens only (it renders cross-origin,
+        // so it can't infer this via :focus-visible).
+        var nativeEvent = event.originalEvent || event;
+        var viaKeyboard = nativeEvent.detail === 0;
         window.parent.postMessage(
-          { type: "ol-feedback::drawer-open", payload: payload },
+          {
+            type: "ol-feedback::drawer-open",
+            payload: payload,
+            viaKeyboard: viaKeyboard,
+          },
           mfeBaseUrl
         );
       });

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
@@ -1,4 +1,11 @@
 (function ($) {
+  // The megaphone that last opened the drawer. The drawer renders in the parent
+  // MFE (cross-origin), so when it closes it can't focus our button directly;
+  // it messages us back and we return focus to this trigger.
+  var lastTrigger = null;
+  // The drawer-closed listener is global, so bind it once across all blocks.
+  var closeListenerBound = false;
+
   function initFeedback(initArgs) {
     var blockId = initArgs.block_id;
     var mfeBaseUrl = initArgs.learning_mfe_base_url;
@@ -20,11 +27,39 @@
         if (!mfeBaseUrl) {
           return;
         }
+        // Remember which trigger opened the drawer so focus can return here when
+        // the drawer closes.
+        lastTrigger = $trigger[0];
         window.parent.postMessage(
           { type: "ol-feedback::drawer-open", payload: payload },
           mfeBaseUrl
         );
       });
+
+    // Bind once (not per block): when the drawer closes it posts back so we can
+    // return keyboard focus to the megaphone that opened it (WCAG 2.4.3).
+    if (!closeListenerBound && mfeBaseUrl) {
+      closeListenerBound = true;
+      var mfeOrigin;
+      try {
+        mfeOrigin = new URL(mfeBaseUrl).origin;
+      } catch (e) {
+        mfeOrigin = mfeBaseUrl;
+      }
+      window.addEventListener("message", function (event) {
+        if (event.origin !== mfeOrigin) {
+          return;
+        }
+        if (
+          event.data &&
+          event.data.type === "ol-feedback::drawer-closed" &&
+          lastTrigger
+        ) {
+          lastTrigger.focus();
+          lastTrigger = null;
+        }
+      });
+    }
 
     // Placement: left of the AskTIM trigger when present, else right-aligned.
     var $chatBtn = $("#chat-button-" + blockId);

--- a/src/ol_openedx_feedback/pyproject.toml
+++ b/src/ol_openedx_feedback/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-feedback"
-version = "0.2.0"
+version = "0.2.1"
 description = "An Open edX plugin to collect per-block learner feedback"
 authors = [{name = "MIT Office of Digital Learning"}]
 license = "BSD-3-Clause"

--- a/src/ol_openedx_feedback/tests/test_aside.py
+++ b/src/ol_openedx_feedback/tests/test_aside.py
@@ -51,6 +51,21 @@ class FeedbackAsideTests(OLFeedbackTestCase):
             assert fragment.content == ""
             assert fragment.js_init_fn is None
 
+    @skip_unless_lms
+    def test_trigger_is_not_marked_as_a_dialog_popup(self):
+        """
+        The drawer is a non-modal region (not a dialog), so the trigger must
+        not advertise `aria-haspopup="dialog"`; it exposes an aria-label instead.
+        """
+        self.runtime.user_id = 5
+        self.runtime.is_author_mode = False
+        self.video_aside_instance.runtime = self.runtime
+
+        fragment = self.video_aside_instance.student_view_aside(self.video_block)
+
+        assert "aria-haspopup" not in fragment.content
+        assert 'aria-label="' in fragment.content
+
     @data(
         *[
             ["video", True, False, True],

--- a/uv.lock
+++ b/uv.lock
@@ -2316,7 +2316,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-feedback"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "src/ol_openedx_feedback" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?

- Fixes [mitodl/hq#12876](https://github.com/mitodl/hq/issues/12876)

### Description (What does it do?)

Courseware-iframe (`ol_openedx_feedback`) side of the feedback-trigger focus fix.

- **Focus return (WCAG 2.4.3):** when the feedback drawer (rendered in the parent MFE) closes, it posts `ol-feedback::drawer-closed` back to this iframe; a single origin-checked listener returns keyboard focus to the 📣 megaphone that opened it. The parent can't focus a cross-origin iframe element directly, so the return trip has to happen here.
- **Report open modality:** the trigger now tells the drawer whether it was opened by keyboard (native click `detail === 0`) or mouse, via a `viaKeyboard` flag on the `ol-feedback::drawer-open` message. The drawer renders cross-origin in the parent MFE, so it can't infer this with `:focus-visible`; it uses the flag to show a focus ring on keyboard opens only (consumed in smoot [#250](https://github.com/mitodl/smoot-design/pull/250)).
- **Drop `aria-haspopup="dialog"`** from the trigger — the drawer is a non-modal `role="region"`, not a dialog, so the attribute mis-described the popup.

### Screenshots (if appropriate):

N/A — keyboard/focus behavior. See **How can this be tested?**

### How can this be tested?

- Install the plugin in the LMS and enable the `ol_openedx_feedback.feedback_enabled` CourseWaffleFlag (globally or per course). The focus-return round-trip also needs the companion smoot bundle ([#250](https://github.com/mitodl/smoot-design/pull/250)) deployed in the Learning MFE.
- Open a courseware unit as a signed-in learner → the 📣 "Send feedback" megaphone renders on leaf blocks. Then, keyboard-only:
  1. **Focus-in** — Tab to the 📣 (or click), press Enter → the drawer opens in the MFE sidebar and focus lands inside it (heading). One more Tab → a reaction/Close, not the page. ← core [#12876](https://github.com/mitodl/hq/issues/12876) fix
  2. **Escape** — press Escape → the drawer closes.
  3. **Focus-return** — after Escape or Close, focus jumps back to the 📣 (focus ring; Enter reopens). ← cross-iframe half

- Automated: `pytest src/ol_openedx_feedback/tests` — `test_aside.py` covers trigger rendering/gating (authenticated non-author learners, leaf blocks only) and asserts the trigger no longer emits `aria-haspopup`. The focus-return and keyboard/mouse modality are browser + cross-iframe behavior, so they're verified manually above rather than in these tests.

### Additional Context

- Companion PR (drawer / smoot bundle side): https://github.com/mitodl/smoot-design/pull/250
- Focus-return needs both sides: the smoot drawer posts `ol-feedback::drawer-closed`; this listener consumes it.