### PR TITLE
fix(course_translations): skip non-source-language SRTs before dispatch, add configurable batch size

### DIFF
--- a/src/ol_openedx_course_translations/README.rst
+++ b/src/ol_openedx_course_translations/README.rst
@@ -159,6 +159,7 @@ file handling is required.
 - ``--translation-validation-provider``: Optional provider to validate/fix XML/HTML translations after translation.
 - ``--content-glossary``: Path to glossary directory for content (XML/HTML and text) translation (optional)
 - ``--srt-glossary``: Path to glossary directory for SRT subtitle translation (optional)
+- ``--batch-size``: Number of translation tasks to run concurrently per batch (optional, default: 20). SRT tasks are still forced to a batch size of 1 when using the Mistral provider, regardless of this setting.
 
 The command also translates ``course/info/updates.items.json`` (or the path
 configured in ``COURSE_TRANSLATIONS_UPDATES_ITEMS_JSON_RELATIVE_PATH``) by

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -93,6 +93,7 @@ class Command(BaseCommand):
         self.translation_validation_provider_name = None
         self.translation_validation_model = None
         self.grading_type_mapping: dict[str, str] = {}
+        self.batch_size = BATCH_SIZE
 
     def add_arguments(self, parser) -> None:
         """Entry point for subclassed commands to add custom arguments."""
@@ -182,6 +183,19 @@ class Command(BaseCommand):
             help=(
                 "Path to glossary directory for SRT subtitle translation. "
                 "Should contain language-specific glossary files."
+            ),
+        )
+        parser.add_argument(
+            "--batch-size",
+            dest="batch_size",
+            type=int,
+            required=False,
+            default=BATCH_SIZE,
+            help=(
+                "Number of translation tasks to run concurrently per batch. "
+                f"Defaults to {BATCH_SIZE}. SRT tasks are still forced to a "
+                "batch size of 1 when using the Mistral provider, regardless "
+                "of this setting."
             ),
         )
         parser.add_argument(
@@ -312,6 +326,12 @@ class Command(BaseCommand):
             self.content_glossary = options.get("content_glossary")
             self.srt_glossary = options.get("srt_glossary")
             self.keep_failure = options.get("keep_failure", False)
+
+            batch_size = options.get("batch_size", BATCH_SIZE)
+            if batch_size < 1:
+                error_msg = f"--batch-size must be at least 1, got {batch_size}."
+                raise CommandError(error_msg)  # noqa: TRY301
+            self.batch_size = batch_size
 
             # Parse and validate provider specifications (includes validation)
             content_provider_name, content_model = (
@@ -1055,15 +1075,17 @@ class Command(BaseCommand):
 
         non_srt_stats, non_srt_completed, non_srt_skipped, _ = self._run_task_batches(
             non_srt_tasks,
-            batch_size=BATCH_SIZE,
+            batch_size=self.batch_size,
             header="CONTENT(TEXT/XML)",
         )
         stats.extend(non_srt_stats)
 
         # Mistral has rate limits and can fail if we send too many requests in parallel,
         # so we process SRT tasks one at a time for Mistral.
-        # For other providers, we can use the normal batch size.
-        srt_batch_size = 1 if self.srt_provider_name == PROVIDER_MISTRAL else BATCH_SIZE
+        # For other providers, we can use the configured batch size.
+        srt_batch_size = (
+            1 if self.srt_provider_name == PROVIDER_MISTRAL else self.batch_size
+        )
         srt_stats, srt_completed, srt_skipped, _ = self._run_task_batches(
             srt_tasks,
             batch_size=srt_batch_size,

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/management/commands/translate_course.py
@@ -33,6 +33,7 @@ from ol_openedx_course_translations.utils.constants import (
     PROVIDER_MISTRAL,
 )
 from ol_openedx_course_translations.utils.course_translations import (
+    LanguageCode,
     create_translated_copy,
     get_translatable_file_paths,
     get_translation_provider,
@@ -697,8 +698,15 @@ class Command(BaseCommand):
         translatable_file_paths = get_translatable_file_paths(
             directory_path, recursive=recursive
         )
+        source_srt_suffix = f"-{LanguageCode(source_language).to_bcp47()}.srt"
 
         for file_path in translatable_file_paths:
+            if file_path.suffix == ".srt" and not file_path.name.endswith(
+                source_srt_suffix
+            ):
+                logger.info("Skipping non-source-language SRT file: %s", file_path)
+                continue
+
             # Tag SRT tasks separately so we can throttle them for Mistral.
             task_type = (
                 SRT_TRANSLATION_TASK_TYPE

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.8.0"
+version = "0.8.1"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.8.1"
+version = "0.9.0"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/uv.lock
+++ b/uv.lock
@@ -2272,7 +2272,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-course-translations"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "src/ol_openedx_course_translations" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Open edX platform names exported SRT transcript files as `<uuid>-<bcp47-lang-code>.srt`. `translate_file_task` already checked the source-language suffix and returned `{"status": "skipped"}` for non-source SRTs, but that check ran *inside* the Celery task — meaning a worker task was dispatched (and consumed a slot/quota) for every non-source-language SRT before being skipped.

This moves the filter to the dispatch site in `_add_file_translation_tasks` (`translate_course.py`), so non-source-language SRT files are excluded from the task list entirely and no Celery task is ever queued for them. The source-language suffix is derived via the existing `LanguageCode(...).to_bcp47()` helper for consistency with `get_srt_output_filename`.

Also adds a `--batch-size` option to `translate_course` so operators can tune how many tasks run concurrently per batch (previously hardcoded to 20). Default stays 20; SRT tasks still force a batch size of 1 when using the Mistral provider, regardless of this setting.

Bumped `ol-openedx-course-translations` from `0.8.0` to `0.9.0` (new CLI option) per this repo's release-on-`main` requirement.

### Screenshots (if appropriate):

### How can this be tested?
1. Run the `translate_course` management command against a course that has multiple SRT files for different languages (e.g. `intro-en.srt`, `intro-fr.srt`).
2. Confirm only `intro-en.srt` gets a translation task added (check logs for `Skipping non-source-language SRT file: ...` for the others).
3. Confirm the output SRT for the target language is still produced from the source-language file as before.
4. Run with `--batch-size 5` and confirm the batch summary logs show batches of 5 instead of the default 20.
5. Run with a Mistral SRT provider and confirm SRT batches still process one at a time regardless of `--batch-size`.

### Additional Context
The runtime check inside `translate_file_task` (`tasks.py`) is left in place as a defensive guard; the dispatch-site filter just prevents the wasted Celery dispatch.