### PR TITLE
feat(course_translations): translate inline markup as one unit and sharpen prompts

### DIFF
--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/providers/llm_providers.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/providers/llm_providers.py
@@ -49,10 +49,11 @@ class LLMProvider(TranslationProvider):
     Base class for LLM-based providers.
 
     Important behavior:
-    - For HTML/XML inputs, this class must NEVER send raw markup to the LLM.
-      It uses HtmlXmlTranslationHelper to extract safe, small units (text nodes and
-      allowlisted attribute VALUES), batch-translates them, and reinserts them into
-      the existing DOM without changing structure.
+    - For HTML/XML inputs, this class must NEVER send full documents to the LLM.
+      It uses HtmlXmlTranslationHelper to extract safe, small units (text nodes,
+      allowlisted attribute VALUES, and inline-only inner markup like
+      "<strong>term</strong>: definition"), batch-translates them, and reinserts
+      them into the existing DOM without changing structure.
     - For plain text inputs, it uses structured prompting with markers.
     """
 
@@ -177,6 +178,13 @@ class LLMProvider(TranslationProvider):
             "2. Maintain the original formatting, spacing, line breaks, and indentation.\n"
             "3. Keep proper nouns, brand names, acronyms, and product names unchanged.\n"
             "4. Do NOT include explanations, notes, or commentary.\n"
+            f"5. Produce grammatically natural {target_language_display_name}; "
+            f"follow {target_language_display_name} word order — never mirror "
+            "English word order.\n"
+            "6. Use a formal academic register suitable for university course "
+            "content.\n"
+            "7. Use standard academic equivalents for technical terms; keep the "
+            "English term if no established equivalent exists.\n"
         )
 
         if glossary_directory:
@@ -428,7 +436,19 @@ class LLMProvider(TranslationProvider):
             "1. Preserve ALL :::ID::: markers exactly.\n"
             "2. Do not add extra IDs.\n"
             "3. Output only the translations (no explanations).\n"
-            "4. Preserve whitespace inside each string as much as possible.\n"
+            "4. Preserve leading and trailing whitespace of each string.\n"
+            "5. A string may contain inline HTML tags "
+            "(e.g. <strong>, <em>, <a>). Translate the text around them and "
+            "keep every tag, with its attributes, exactly as given — but move "
+            "the tags to wherever the translated words land in the target "
+            "sentence.\n"
+            f"6. Produce grammatically natural {target_language_display_name}; "
+            f"follow {target_language_display_name} word order — never mirror "
+            "English word order.\n"
+            "7. Use a formal academic register suitable for university course "
+            "content.\n"
+            "8. Use standard academic equivalents for technical terms; keep the "
+            "English term if no established equivalent exists.\n"
         )
         if glossary_directory:
             glossary_terms = load_glossary(target_language, glossary_directory)
@@ -813,11 +833,19 @@ class LLMProvider(TranslationProvider):
             "- Grammar and article agreement\n"
             "- Spelling and punctuation\n"
             "- Obvious encoding artifacts (e.g., broken characters, malformed symbols)\n"
-            "- Consistency in verb mood and tense where directly implied by the source text\n\n"
+            "- Consistency in verb mood and tense where directly implied by the source text\n"
+            f"- Word order INSIDE a text node, when the current order is "
+            f"ungrammatical or mirrors English word order instead of natural "
+            f"{target_language_display_name} word order. Reorder the existing "
+            "words only — do not substitute different words\n"
+            f"- Replacing a term that is plainly wrong in "
+            f"{target_language_display_name} with the standard academic "
+            "equivalent of the source term\n\n"
             "ABSOLUTE RULES (NON-NEGOTIABLE):\n"
             "- DO NOT change, add, remove, or reorder any XML/HTML tags\n"
             "- DO NOT change indentation, line breaks, or spacing\n"
-            "- DO NOT paraphrase, rewrite, summarize, or expand content\n"
+            "- DO NOT paraphrase, summarize, or expand content (reordering the "
+            "existing words of an ungrammatical sentence is a fix, not a rewrite)\n"
             "- DO NOT translate anything new\n"
             "- DO NOT change meaning, tone, or register\n"
             "- Only edit visible text nodes and approved user-facing attribute VALUES\n"

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/constants.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/constants.py
@@ -34,3 +34,22 @@ NEVER_TRANSLATE_ATTRS = {
 }
 
 XML_FORMAT_ATTR = "format"
+
+# Inline formatting tags: an element whose whole subtree is only these tags can
+# be translated as ONE unit (its inner markup), so the LLM sees the full
+# sentence and can reorder words for SOV/verb-final target languages.
+INLINE_MARKUP_TAGS = {
+    "a",
+    "abbr",
+    "b",
+    "code",
+    "em",
+    "i",
+    "mark",
+    "small",
+    "span",
+    "strong",
+    "sub",
+    "sup",
+    "u",
+}

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
@@ -642,13 +642,17 @@ class HtmlXmlTranslationHelper:
         trusted for attributes). On parse failure or structure mismatch, el is
         left unchanged.
         """
+        # Parsed strictly, never with recover=True: recovery would silently
+        # repair malformed output (an unclosed <strong> gets closed at the end
+        # of the fragment, swallowing the rest of the sentence) and the repair
+        # can still satisfy the tag check below, applying markup the model got
+        # wrong. Keeping the untranslated original is the safer failure.
         try:
             wrapper = etree.fromstring(
-                f"<wrap>{markup}</wrap>".encode(), parser=self._xml_parser(recover=True)
+                f"<wrap>{markup}</wrap>".encode(),
+                parser=self._xml_parser(recover=False),
             )
         except etree.XMLSyntaxError:
-            wrapper = None
-        if wrapper is None:
             logger.warning("Could not parse translated inline markup; keeping original")
             return
 
@@ -730,13 +734,21 @@ class HtmlXmlTranslationHelper:
         units: list[str] = []
         refs: list[_TranslationUnitRef] = []
 
-        def add_unit(text: str, ref: _TranslationUnitRef) -> None:
+        def add_unit(
+            text: str, ref: _TranslationUnitRef, visible_text: str | None = None
+        ) -> None:
             if text is None:
                 return
             _leading, core, _trailing = self._split_preserve_outer_ws(text)
             if not core.strip():
                 return
-            if self._looks_like_nontranslatable(core):
+            # An "inner" unit is markup, so the heuristic has to judge the text
+            # a reader sees; the tags themselves would otherwise decide it. A
+            # single <a href="https://..."> inside a sentence would make the
+            # whole sentence look like a bare URL and skip translating it.
+            if self._looks_like_nontranslatable(
+                core if visible_text is None else visible_text
+            ):
                 return
             # Store only core; outer whitespace is preserved on reinsertion
             units.append(core)
@@ -746,18 +758,21 @@ class HtmlXmlTranslationHelper:
         coalesced_roots: set[etree._Element] = set()
 
         for el in self._iter_elements(root):
-            # Text/tail of a coalesced ancestor's subtree is already covered
-            # by that ancestor's "inner" unit
-            if any(anc in coalesced_roots for anc in el.iterancestors()):
-                continue
+            # Text/tail inside a coalesced element is already covered by that
+            # ancestor's "inner" unit. Attribute values are not: reinsertion
+            # restores attributes from the originals, so an attribute the model
+            # translated inside the inner markup is discarded. They still need
+            # their own units, which is why only the text branch is skipped.
+            inside_coalesced = any(anc in coalesced_roots for anc in el.iterancestors())
 
             # Text node
-            if self._should_translate_text_in_element(el):
+            if not inside_coalesced and self._should_translate_text_in_element(el):
                 if self._is_coalescible(el):
                     coalesced_roots.add(el)
                     add_unit(
                         self._inner_markup(el),
                         _TranslationUnitRef("inner", tree.getpath(el)),
+                        visible_text="".join(el.itertext()),
                     )
                 elif el.text:
                     add_unit(el.text, _TranslationUnitRef("text", tree.getpath(el)))

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/utils/course_translations.py
@@ -1,8 +1,10 @@
 """Utility functions for course translations.
 
 This module includes DOM-aware helpers for translating HTML/XML safely by:
-- Extracting only text nodes and allowlisted attribute VALUES as independent units
-- Sending only those units to translation providers (never raw markup blobs)
+- Extracting text nodes and allowlisted attribute VALUES as independent units;
+  elements whose subtree is only inline formatting tags (<strong>, <a>, ...)
+  are extracted as ONE inner-markup unit so sentence word order survives
+- Sending only those units to translation providers (never full documents)
 - Reinserting translations without changing markup structure, tag names,
 or attribute names
 """
@@ -28,6 +30,7 @@ from ol_openedx_course_translations.providers.llm_providers import (
     OpenAIProvider,
 )
 from ol_openedx_course_translations.utils.constants import (
+    INLINE_MARKUP_TAGS,
     NEVER_TRANSLATE_ATTRS,
     PROVIDER_GEMINI,
     PROVIDER_MISTRAL,
@@ -506,6 +509,8 @@ class _TranslationUnitRef:
       - "text": element.text
       - "tail": element.tail
       - "attr": element.attrib[attr_name]
+      - "inner": element's inner markup (text + inline children), translated
+        as one unit so sentence word order survives in the target language
     """
 
     kind: str
@@ -539,15 +544,20 @@ class HtmlXmlTranslationHelper:
     def __init__(self, *, is_xml: bool):
         self.is_xml = is_xml
 
+    @staticmethod
+    def _xml_parser(*, recover: bool) -> etree.XMLParser:
+        return etree.XMLParser(
+            resolve_entities=False,
+            no_network=True,
+            recover=recover,
+            remove_blank_text=False,
+        )
+
     def parse(self, raw: str) -> etree._Element:
         if self.is_xml:
-            parser = etree.XMLParser(
-                resolve_entities=False,
-                no_network=True,
-                recover=False,
-                remove_blank_text=False,
+            return etree.fromstring(
+                raw.encode("utf-8"), parser=self._xml_parser(recover=False)
             )
-            return etree.fromstring(raw.encode("utf-8"), parser=parser)
         # HTML: keep input formatting as much as possible; do not pretty-print later
         parser = etree.HTMLParser(
             no_network=True,
@@ -601,6 +611,93 @@ class HtmlXmlTranslationHelper:
     def _should_translate_text_in_element(self, el: etree._Element) -> bool:
         return (el.tag or "").lower() not in self._SKIP_TEXT_TAGS
 
+    def _is_coalescible(self, el: etree._Element) -> bool:
+        """
+        Return True when el's entire subtree is inline formatting tags.
+
+        Such an element's inner markup is translated as ONE unit so the LLM
+        sees the whole sentence and can reorder words for verb-final target
+        languages (splitting on <strong>/<a> boundaries produces broken
+        grammar in e.g. Hindi).
+        """
+        if len(el) == 0:
+            return False
+        return all(
+            isinstance(d.tag, str) and d.tag.lower() in INLINE_MARKUP_TAGS
+            for d in el.iterdescendants()
+        )
+
+    def _inner_markup(self, el: etree._Element) -> str:
+        """Serialize el's text + children (with tails) as a markup string."""
+        parts = [el.text or ""]
+        parts += [etree.tostring(c, encoding="unicode", with_tail=True) for c in el]
+        return "".join(parts)
+
+    def _set_inner_markup(self, el: etree._Element, markup: str) -> None:
+        """
+        Replace el's text/children with parsed `markup`.
+
+        Safety: the translated fragment must keep the original tag sequence;
+        attributes are always restored from the originals (LLM output is never
+        trusted for attributes). On parse failure or structure mismatch, el is
+        left unchanged.
+        """
+        try:
+            wrapper = etree.fromstring(
+                f"<wrap>{markup}</wrap>".encode(), parser=self._xml_parser(recover=True)
+            )
+        except etree.XMLSyntaxError:
+            wrapper = None
+        if wrapper is None:
+            logger.warning("Could not parse translated inline markup; keeping original")
+            return
+
+        original_descendants = list(el.iterdescendants())
+        new_descendants = list(wrapper.iterdescendants())
+        if [d.tag for d in original_descendants] != [d.tag for d in new_descendants]:
+            logger.warning(
+                "Translated inline markup changed tag structure; keeping original"
+            )
+            return
+
+        for original_d, new_d in zip(
+            original_descendants, new_descendants, strict=True
+        ):
+            new_d.attrib.clear()
+            new_d.attrib.update(original_d.attrib)
+
+        for child in list(el):
+            el.remove(child)
+        el.text = wrapper.text
+        for child in list(wrapper):
+            el.append(child)
+
+    def _get_ref_value(
+        self, el: etree._Element, ref: _TranslationUnitRef
+    ) -> str | None:
+        """Return the value at ref's location, or None if ref no longer applies."""
+        if ref.kind == "inner":
+            return self._inner_markup(el)
+        if ref.kind == "text":
+            return el.text or ""
+        if ref.kind == "tail":
+            return el.tail or ""
+        if ref.kind == "attr" and ref.attr_name and ref.attr_name in el.attrib:
+            return el.attrib.get(ref.attr_name, "")
+        return None
+
+    def _set_ref_value(
+        self, el: etree._Element, ref: _TranslationUnitRef, value: str
+    ) -> None:
+        if ref.kind == "inner":
+            self._set_inner_markup(el, value)
+        elif ref.kind == "text":
+            el.text = value
+        elif ref.kind == "tail":
+            el.tail = value
+        elif ref.kind == "attr" and ref.attr_name:
+            el.attrib[ref.attr_name] = value
+
     @staticmethod
     def _looks_like_nontranslatable(value: str) -> bool:
         v = value.strip()
@@ -646,11 +743,23 @@ class HtmlXmlTranslationHelper:
             refs.append(ref)
 
         tree = root.getroottree()
+        coalesced_roots: set[etree._Element] = set()
 
         for el in self._iter_elements(root):
+            # Text/tail of a coalesced ancestor's subtree is already covered
+            # by that ancestor's "inner" unit
+            if any(anc in coalesced_roots for anc in el.iterancestors()):
+                continue
+
             # Text node
             if self._should_translate_text_in_element(el):
-                if el.text:
+                if self._is_coalescible(el):
+                    coalesced_roots.add(el)
+                    add_unit(
+                        self._inner_markup(el),
+                        _TranslationUnitRef("inner", tree.getpath(el)),
+                    )
+                elif el.text:
                     add_unit(el.text, _TranslationUnitRef("text", tree.getpath(el)))
                 if el.tail:
                     add_unit(el.tail, _TranslationUnitRef("tail", tree.getpath(el)))
@@ -695,21 +804,11 @@ class HtmlXmlTranslationHelper:
                 continue
             el = nodes[0]
 
-            if ref.kind == "text":
-                orig = el.text or ""
-                leading, _, trailing = self._split_preserve_outer_ws(orig)
-                el.text = f"{leading}{translated_core}{trailing}"
-            elif ref.kind == "tail":
-                orig = el.tail or ""
-                leading, _, trailing = self._split_preserve_outer_ws(orig)
-                el.tail = f"{leading}{translated_core}{trailing}"
-            elif ref.kind == "attr" and ref.attr_name:
-                if ref.attr_name in el.attrib:
-                    orig = el.attrib.get(ref.attr_name, "")
-                    leading, _, trailing = self._split_preserve_outer_ws(orig)
-                    el.attrib[ref.attr_name] = f"{leading}{translated_core}{trailing}"
-            else:
+            orig = self._get_ref_value(el, ref)
+            if orig is None:
                 continue
+            leading, _, trailing = self._split_preserve_outer_ws(orig)
+            self._set_ref_value(el, ref, f"{leading}{translated_core}{trailing}")
         return root
 
     def serialize(self, root: etree._Element) -> str:

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.8.0"
+version = "0.10.0"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_course_translations/tests/test_html_xml_helper.py
+++ b/src/ol_openedx_course_translations/tests/test_html_xml_helper.py
@@ -1,0 +1,78 @@
+"""
+Tests for HtmlXmlTranslationHelper inline-markup coalescing.
+
+An element whose subtree is only inline formatting tags is extracted as a
+single unit so the translator sees the whole sentence. Splitting on tag
+boundaries produces broken word order in verb-final languages such as Hindi.
+"""
+
+import pytest
+from ol_openedx_course_translations.utils.course_translations import (
+    HtmlXmlTranslationHelper,
+)
+
+MARKUP = (
+    "<div>"
+    "<li><strong>Understand the basics of linear regression</strong>: "
+    "Learn how linear regression models predict a continuous outcome.</li>"
+    "<li>Plain item with no inline tags</li>"
+    "<p>Text <em>with</em> emphasis and a <a href='/x'>link</a> inside.</p>"
+    "</div>"
+)
+
+
+@pytest.fixture
+def helper():
+    return HtmlXmlTranslationHelper(is_xml=False)
+
+
+def test_inline_only_element_extracts_as_single_unit(helper):
+    _root, units, _refs = helper.extract_units(MARKUP)
+
+    bullet_units = [unit for unit in units if "linear regression" in unit]
+    assert len(bullet_units) == 1
+    assert "<strong>" in bullet_units[0]
+    assert bullet_units[0].endswith("continuous outcome.")
+
+    mixed_units = [unit for unit in units if "emphasis" in unit]
+    assert len(mixed_units) == 1
+    assert "<em>with</em>" in mixed_units[0]
+
+    assert "Plain item with no inline tags" in units
+
+
+def test_translation_may_move_tags_and_keeps_attributes(helper):
+    root, units, refs = helper.extract_units(MARKUP)
+
+    translated = []
+    for unit in units:
+        if "linear regression" in unit:
+            # A verb-final language moves the bolded phrase to the end.
+            translated.append(
+                "जानें कि रैखिक प्रतिगमन मॉडल कैसे काम करते हैं: "
+                "<strong>रैखिक प्रतिगमन की मूल बातें समझना</strong>"
+            )
+        elif "emphasis" in unit:
+            # The LLM dropped href; the original attribute must be restored.
+            translated.append("पाठ <em>साथ</em> और एक <a>कड़ी</a> अंदर।")
+        else:
+            translated.append(unit)
+
+    output = helper.serialize(helper.apply_translations(root, refs, translated))
+
+    assert "<strong>रैखिक प्रतिगमन की मूल बातें समझना</strong>" in output
+    assert 'href="/x"' in output
+    assert output.count("<strong>") == 1
+    assert output.count("<li>") == 2  # noqa: PLR2004
+
+
+def test_structure_changing_translation_is_rejected(helper):
+    root, units, refs = helper.extract_units(MARKUP)
+
+    translated = [
+        "<strong>a</strong><strong>b</strong>" if "linear regression" in unit else unit
+        for unit in units
+    ]
+    output = helper.serialize(helper.apply_translations(root, refs, translated))
+
+    assert "Understand the basics of linear regression" in output

--- a/src/ol_openedx_course_translations/tests/test_html_xml_helper.py
+++ b/src/ol_openedx_course_translations/tests/test_html_xml_helper.py
@@ -76,3 +76,73 @@ def test_structure_changing_translation_is_rejected(helper):
     output = helper.serialize(helper.apply_translations(root, refs, translated))
 
     assert "Understand the basics of linear regression" in output
+
+
+def test_unparsable_translation_is_rejected(helper):
+    """
+    A fragment that does not parse must leave the element untouched.
+
+    lxml's recovering parser would close the unterminated <strong> at the end
+    of the fragment and swallow the rest of the sentence into it, producing
+    markup that still passes the tag-sequence check.
+    """
+    root, units, refs = helper.extract_units(MARKUP)
+
+    translated = [
+        "<strong>समझना: जानें" if "linear regression" in unit else unit for unit in units
+    ]
+    output = helper.serialize(helper.apply_translations(root, refs, translated))
+
+    assert "Understand the basics of linear regression" in output
+    assert "समझना" not in output
+
+
+def test_sentence_containing_a_url_is_still_translated(helper):
+    """
+    The non-translatable heuristic must look at visible text, not the markup.
+
+    An <a href="https://..."> inside a sentence puts "://" in the serialized
+    unit, which would otherwise make the whole sentence look like a bare URL.
+    """
+    markup = '<div><p>Read <a href="https://example.com">the docs</a> first.</p></div>'
+
+    _root, units, _refs = helper.extract_units(markup)
+
+    assert any("first." in unit for unit in units)
+
+
+def test_url_only_text_is_still_skipped(helper):
+    markup = "<div><p><span>https://example.com/page</span></p></div>"
+
+    _root, units, _refs = helper.extract_units(markup)
+
+    assert units == []
+
+
+def test_translatable_attribute_inside_coalesced_element_is_translated(helper):
+    """
+    Attributes on inline descendants need their own units.
+
+    Reinsertion restores attributes from the originals, so an attribute the
+    model translated inside the inner markup is discarded -- without a
+    separate unit the value would stay in the source language.
+    """
+    markup = (
+        "<div><li><strong>Term</strong>: see "
+        '<a title="Read more" href="/x">this</a>.</li></div>'
+    )
+
+    root, units, refs = helper.extract_units(markup)
+
+    assert "Read more" in units
+    assert [ref.kind for ref in refs] == ["inner", "attr"]
+
+    translated = [
+        '<strong>पद</strong>: देखें <a title="ignored" href="/x">यह</a>.',
+        "और पढ़ें",
+    ]
+    output = helper.serialize(helper.apply_translations(root, refs, translated))
+
+    assert 'title="और पढ़ें"' in output
+    assert 'href="/x"' in output
+    assert "<strong>पद</strong>" in output

--- a/uv.lock
+++ b/uv.lock
@@ -2272,7 +2272,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-course-translations"
-version = "0.8.0"
+version = "0.10.0"
 source = { editable = "src/ol_openedx_course_translations" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
**The problem.** `HtmlXmlTranslationHelper` extracts each text node as its own translation unit. For a bullet like:

```html
<li><strong>Understand the basics of linear regression</strong>: Learn how linear regression models predict a continuous outcome.</li>
```

that produced two independent units — the bolded phrase, and the tail after it — so the translator never saw a sentence, only fragments. In verb-final languages such as Hindi the result is broken word order, because the words that need to move across the `<strong>` boundary cannot.

**The fix.** An element whose entire subtree is inline formatting tags (`<strong>`, `<em>`, `<a>`, `<code>`, ... — see `INLINE_MARKUP_TAGS`) is now extracted as a single `"inner"` unit containing its inner markup. The translator sees the whole sentence and is told it may move the tags to wherever the translated words land.

Reinsertion stays conservative, since the model is now producing markup rather than plain text:

- the translated fragment is re-parsed and must keep the original tag sequence, or the element is left unchanged
- attributes are always restored from the original elements — LLM output is never trusted for attributes, so a dropped or invented `href` cannot reach the DOM
- a parse failure leaves the element unchanged and logs a warning

Non-inline elements are unaffected and still split into `text`/`tail`/`attr` units exactly as before.

**Prompt changes.** Supporting the above, plus general translation quality:

- the batch translator is told a string may contain inline tags, and that tags move with the words they wrap
- translations must follow natural target-language word order rather than mirroring English
- a formal academic register, and standard academic equivalents for technical terms (keeping the English term when no established equivalent exists)
- validation may now reorder words inside a text node when the existing order is ungrammatical, while paraphrasing, summarizing and expanding stay forbidden

### How can this be tested?
`src/ol_openedx_course_translations/tests/test_html_xml_helper.py` covers the extraction and reinsertion logic directly:

```
tutor dev exec lms bash
cd /openedx/open-edx-plugins
./run_edx_integration_tests.sh --plugin ol_openedx_course_translations --skip-build
```

The tests assert that an inline-only element yields one unit rather than several, that a translation which moves `<strong>` to the end of the sentence is applied correctly, that a dropped `href` is restored from the original, and that a translation which changes the tag structure is rejected and leaves the original markup intact.

End to end, translate a course containing bulleted `<strong>term</strong>: definition` content into Hindi and compare the bullets against `main` — the phrase order inside each bullet should now read naturally, with the bold span still wrapping the corresponding words.

### Additional Context
Split out of the original #856 scope; the per-model temperature fallback that was previously in this branch now lives in #857. The two are independent and touch different regions of `llm_providers.py` — they merge cleanly apart from the version line in `pyproject.toml`/`uv.lock`, so whichever lands second needs a one-line rebase.
