### PR TITLE
feat(course_translations): negotiate per-model temperature with fallback

### DIFF
--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/providers/llm_providers.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/providers/llm_providers.py
@@ -9,7 +9,8 @@ from typing import Any
 
 import srt
 from django.conf import settings
-from litellm import completion
+from litellm import BadRequestError, completion
+from litellm.utils import UnsupportedParamsError
 
 from .base import TranslationProvider
 
@@ -43,6 +44,29 @@ TRANSLATION_MARKER_END = ":::TRANSLATION_END:::"
 
 MAX_CHUNK_RETRIES = 3
 
+# Validation reviews a whole document in one call, so it needs a longer timeout
+VALIDATION_TIMEOUT = 90
+
+# Translation wants the most deterministic output a model will give us.
+TRANSLATION_TEMPERATURE = 0.0
+
+# Reasoning models (OpenAI o-series, some gpt-5 configurations) accept only
+# their default temperature of 1 and reject anything else.
+FALLBACK_TEMPERATURE = 1.0
+
+# Model name -> temperature that model actually accepts. Populated the first
+# time a model rejects TRANSLATION_TEMPERATURE so the rejection is paid once
+# per process instead of once per request. Deliberately process-wide: the
+# answer depends only on the model, not on the provider instance.
+_MODEL_TEMPERATURES: dict[str, float] = {}
+
+# litellm rejects some models locally while mapping parameters
+# (UnsupportedParamsError), and lets others through to the provider, which
+# returns a 400 (BadRequestError). Both are caught below so any
+# litellm-supported model gets the same fallback treatment without us
+# maintaining a list of which models have a temperature floor.
+_TEMPERATURE_REJECTION_ERRORS = (UnsupportedParamsError, BadRequestError)
+
 
 class LLMProvider(TranslationProvider):
     """
@@ -59,11 +83,11 @@ class LLMProvider(TranslationProvider):
     def __init__(  # noqa: PLR0913, PLR0917
         self,
         primary_api_key: str,
-        model_name: str | None = None,
+        model_name: str,
         litellm_timeout: int = settings.LITE_LLM_REQUEST_TIMEOUT,
         srt_batch_size: int = 50,
         max_chunk_retries: int = MAX_CHUNK_RETRIES,
-        temperature: float = 0.0,
+        temperature: float = TRANSLATION_TEMPERATURE,
     ):
         """
         Initialize LLM provider with API key and model name.
@@ -314,14 +338,40 @@ class LLMProvider(TranslationProvider):
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_content},
         ]
-        llm_response = completion(
-            model=self.model_name,
-            messages=llm_messages,
-            api_key=self.primary_api_key,
-            timeout=self.litellm_timeout,
-            temperature=self.temperature,
-            **additional_kwargs,
-        )
+        timeout = additional_kwargs.pop("timeout", self.litellm_timeout)
+
+        temperature = _MODEL_TEMPERATURES.get(self.model_name, self.temperature)
+        try:
+            llm_response = completion(
+                model=self.model_name,
+                messages=llm_messages,
+                api_key=self.primary_api_key,
+                timeout=timeout,
+                temperature=temperature,
+                **additional_kwargs,
+            )
+        except _TEMPERATURE_REJECTION_ERRORS as error:
+            if (
+                temperature == FALLBACK_TEMPERATURE
+                or "temperature" not in str(error).lower()
+            ):
+                raise
+            logger.info(
+                "%s rejected temperature=%s; falling back to %s for this process.",
+                self.model_name,
+                temperature,
+                FALLBACK_TEMPERATURE,
+            )
+            _MODEL_TEMPERATURES[self.model_name] = FALLBACK_TEMPERATURE
+            llm_response = completion(
+                model=self.model_name,
+                messages=llm_messages,
+                api_key=self.primary_api_key,
+                timeout=timeout,
+                temperature=FALLBACK_TEMPERATURE,
+                **additional_kwargs,
+            )
+
         return llm_response.choices[0].message.content.strip()
 
     def _translate_plain_text_unit(
@@ -858,8 +908,9 @@ class LLMProvider(TranslationProvider):
             f"{translated_content}\n"
         )
 
-        self.litellm_timeout = 90  # 90s timeout for the validation
-        llm_response = self._call_llm(system_prompt, user_payload)
+        llm_response = self._call_llm(
+            system_prompt, user_payload, timeout=VALIDATION_TIMEOUT
+        )
         return self._parse_text_response(llm_response)
 
     def translate_grading_types(
@@ -992,7 +1043,7 @@ class OpenAIProvider(LLMProvider):
         srt_batch_size: int = 50,
         litellm_timeout: int = settings.LITE_LLM_REQUEST_TIMEOUT,
         max_chunk_retries: int = MAX_CHUNK_RETRIES,
-        temperature: float = 0.0,
+        temperature: float = TRANSLATION_TEMPERATURE,
     ):
         """
         Initialize OpenAI provider.
@@ -1015,22 +1066,6 @@ class OpenAIProvider(LLMProvider):
             max_chunk_retries=max_chunk_retries,
             temperature=temperature,
         )
-
-    def _call_llm(
-        self, system_prompt: str, user_content: str, **additional_kwargs: Any
-    ) -> str:
-        """
-        Call OpenAI API with prompts.
-
-        Args:
-            system_prompt: System prompt defining behavior
-            user_content: User content to translate
-            **additional_kwargs: Additional arguments for the API
-
-        Returns:
-            OpenAI response content
-        """
-        return super()._call_llm(system_prompt, user_content, **additional_kwargs)
 
     def _get_subtitle_system_prompt(
         self,
@@ -1143,7 +1178,7 @@ class GeminiProvider(LLMProvider):
         srt_batch_size: int = 50,
         litellm_timeout: int = settings.LITE_LLM_REQUEST_TIMEOUT,
         max_chunk_retries: int = MAX_CHUNK_RETRIES,
-        temperature: float = 1.0,
+        temperature: float = TRANSLATION_TEMPERATURE,
     ):
         """
         Initialize Gemini provider.
@@ -1235,7 +1270,7 @@ class MistralProvider(LLMProvider):
         srt_batch_size: int = 20,
         litellm_timeout: int = 600,
         max_chunk_retries: int = 2,
-        temperature: float = 0.0,
+        temperature: float = TRANSLATION_TEMPERATURE,
     ):
         """
         Initialize Mistral provider.

--- a/src/ol_openedx_course_translations/ol_openedx_course_translations/providers/llm_providers.py
+++ b/src/ol_openedx_course_translations/ol_openedx_course_translations/providers/llm_providers.py
@@ -54,11 +54,15 @@ TRANSLATION_TEMPERATURE = 0.0
 # their default temperature of 1 and reject anything else.
 FALLBACK_TEMPERATURE = 1.0
 
-# Model name -> temperature that model actually accepts. Populated the first
-# time a model rejects TRANSLATION_TEMPERATURE so the rejection is paid once
-# per process instead of once per request. Deliberately process-wide: the
-# answer depends only on the model, not on the provider instance.
-_MODEL_TEMPERATURES: dict[str, float] = {}
+# (model name, requested temperature) -> temperature that model actually
+# accepts. Populated the first time a model rejects the requested value, so
+# the rejection is paid once per process instead of once per request.
+# Deliberately process-wide: the answer depends on the model and on what was
+# asked for, not on which provider instance asked. The requested temperature
+# is part of the key so that a provider configured with a non-default
+# temperature still gets to try its own value rather than inheriting a
+# fallback another instance negotiated.
+_MODEL_TEMPERATURES: dict[tuple[str, float], float] = {}
 
 # litellm rejects some models locally while mapping parameters
 # (UnsupportedParamsError), and lets others through to the provider, which
@@ -340,7 +344,8 @@ class LLMProvider(TranslationProvider):
         ]
         timeout = additional_kwargs.pop("timeout", self.litellm_timeout)
 
-        temperature = _MODEL_TEMPERATURES.get(self.model_name, self.temperature)
+        cache_key = (self.model_name, self.temperature)
+        temperature = _MODEL_TEMPERATURES.get(cache_key, self.temperature)
         try:
             llm_response = completion(
                 model=self.model_name,
@@ -362,7 +367,7 @@ class LLMProvider(TranslationProvider):
                 temperature,
                 FALLBACK_TEMPERATURE,
             )
-            _MODEL_TEMPERATURES[self.model_name] = FALLBACK_TEMPERATURE
+            _MODEL_TEMPERATURES[cache_key] = FALLBACK_TEMPERATURE
             llm_response = completion(
                 model=self.model_name,
                 messages=llm_messages,

--- a/src/ol_openedx_course_translations/pyproject.toml
+++ b/src/ol_openedx_course_translations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-course-translations"
-version = "0.9.0"
+version = "0.9.1"
 description = "An Open edX plugin to translate courses"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_course_translations/tests/test_temperature_fallback.py
+++ b/src/ol_openedx_course_translations/tests/test_temperature_fallback.py
@@ -100,3 +100,53 @@ def test_unrelated_errors_are_not_retried(provider):
         provider._call_llm("system", "user")  # noqa: SLF001
 
     assert completion.call_count == 1
+
+
+def test_fallback_does_not_leak_across_requested_temperatures(provider):
+    """
+    A provider asking for its own temperature must get to try it.
+
+    The cache is keyed by requested temperature as well as model, so the
+    fallback negotiated for the default does not silently replace the value
+    another instance explicitly asked for.
+    """
+    with mock.patch.object(
+        llm_providers, "completion", side_effect=[_local_rejection(), _response()]
+    ):
+        provider._call_llm("system", "user")  # noqa: SLF001
+
+    warm = OpenAIProvider("test-key", "gpt-test", temperature=0.5)
+    with mock.patch.object(
+        llm_providers, "completion", return_value=_response()
+    ) as completion:
+        warm._call_llm("system", "user")  # noqa: SLF001
+
+    assert completion.call_args.kwargs["temperature"] == 0.5  # noqa: PLR2004
+
+
+def test_validation_uses_a_longer_timeout_without_mutating_the_provider(provider):
+    """
+    The validation timeout applies to that call only.
+
+    It used to be applied by assigning self.litellm_timeout, which left every
+    later call on the same provider instance using the validation timeout.
+    """
+    original_timeout = provider.litellm_timeout
+
+    with mock.patch.object(
+        llm_providers, "completion", return_value=_response("fixed")
+    ) as completion:
+        provider.validate_translation(
+            source_language="en",
+            target_language="hi",
+            source_content="<p>Hello</p>",
+            translated_content="<p>नमस्ते</p>",
+        )
+        assert (
+            completion.call_args.kwargs["timeout"] == llm_providers.VALIDATION_TIMEOUT
+        )
+
+        provider._call_llm("system", "user")  # noqa: SLF001
+        assert completion.call_args.kwargs["timeout"] == original_timeout
+
+    assert provider.litellm_timeout == original_timeout

--- a/src/ol_openedx_course_translations/tests/test_temperature_fallback.py
+++ b/src/ol_openedx_course_translations/tests/test_temperature_fallback.py
@@ -1,0 +1,102 @@
+"""
+Tests for per-model temperature negotiation in LLMProvider._call_llm.
+
+Translation wants the lowest temperature a model will accept. Some models
+(OpenAI o-series, some gpt-5 configurations) allow only their default of 1 and
+reject anything else — litellm raises locally for some of them and lets others
+through to the provider, which returns a 400. Both are treated the same way.
+"""
+
+from unittest import mock
+
+import pytest
+from litellm import BadRequestError
+from litellm.utils import UnsupportedParamsError
+from ol_openedx_course_translations.providers import llm_providers
+from ol_openedx_course_translations.providers.llm_providers import (
+    FALLBACK_TEMPERATURE,
+    TRANSLATION_TEMPERATURE,
+    OpenAIProvider,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_temperature_cache():
+    llm_providers._MODEL_TEMPERATURES.clear()  # noqa: SLF001
+    yield
+    llm_providers._MODEL_TEMPERATURES.clear()  # noqa: SLF001
+
+
+@pytest.fixture
+def provider():
+    return OpenAIProvider("test-key", "gpt-test")
+
+
+def _response(text="ok"):
+    return mock.Mock(choices=[mock.Mock(message=mock.Mock(content=text))])
+
+
+def _local_rejection():
+    return UnsupportedParamsError(
+        status_code=400,
+        message="models don't support temperature=0.0. Only temperature=1 is supported",
+    )
+
+
+def _api_rejection():
+    return BadRequestError(
+        message="Unsupported value: 'temperature' does not support 0.0 with this model",
+        model="gpt-test",
+        llm_provider="openai",
+    )
+
+
+def test_uses_lowest_temperature_when_model_accepts_it(provider):
+    with mock.patch.object(
+        llm_providers, "completion", return_value=_response()
+    ) as completion:
+        assert provider._call_llm("system", "user") == "ok"  # noqa: SLF001
+
+    assert completion.call_count == 1
+    assert completion.call_args.kwargs["temperature"] == TRANSLATION_TEMPERATURE
+
+
+@pytest.mark.parametrize("rejection", [_local_rejection, _api_rejection])
+def test_retries_at_fallback_when_model_rejects_low_temperature(provider, rejection):
+    with mock.patch.object(
+        llm_providers, "completion", side_effect=[rejection(), _response()]
+    ) as completion:
+        assert provider._call_llm("system", "user") == "ok"  # noqa: SLF001
+
+    temperatures = [c.kwargs["temperature"] for c in completion.call_args_list]
+    assert temperatures == [TRANSLATION_TEMPERATURE, FALLBACK_TEMPERATURE]
+
+
+def test_rejection_is_remembered_for_later_calls(provider):
+    with mock.patch.object(
+        llm_providers, "completion", side_effect=[_local_rejection(), _response()]
+    ):
+        provider._call_llm("system", "user")  # noqa: SLF001
+
+    # A second provider instance for the same model must not repeat the probe.
+    other = OpenAIProvider("test-key", "gpt-test")
+    with mock.patch.object(
+        llm_providers, "completion", return_value=_response()
+    ) as completion:
+        other._call_llm("system", "user")  # noqa: SLF001
+
+    assert completion.call_count == 1
+    assert completion.call_args.kwargs["temperature"] == FALLBACK_TEMPERATURE
+
+
+def test_unrelated_errors_are_not_retried(provider):
+    error = BadRequestError(
+        message="context_length_exceeded", model="gpt-test", llm_provider="openai"
+    )
+    with (
+        mock.patch.object(llm_providers, "completion", side_effect=error) as completion,
+        pytest.raises(BadRequestError),
+    ):
+        provider._call_llm("system", "user")  # noqa: SLF001
+
+    assert completion.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -2272,7 +2272,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-course-translations"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "src/ol_openedx_course_translations" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Translation wants the most deterministic output a model will give us, so every provider asks for `temperature=0.0`. Some reasoning models (OpenAI o-series, and some gpt-5 configurations) accept only their default temperature of `1` and reject anything else, which fails the request outright.

litellm surfaces that rejection two different ways depending on the model — `UnsupportedParamsError` raised locally while mapping parameters, or `BadRequestError` returned by the provider as a 400. Both are now caught in `LLMProvider._call_llm` and retried once at `FALLBACK_TEMPERATURE`. Matching on the error rather than on a hardcoded list of model names means any litellm-supported model gets the same treatment without us maintaining that list.

The temperature a model actually accepts is memoized in a process-wide dict keyed by model name, so the rejection costs one extra request per process rather than one per translation unit, and is shared across provider instances for the same model.

Three smaller changes ride along because they touch the same `_call_llm` code path:

- **Callers can now pass `timeout=`.** Previously `validate_and_fix_translation` did `self.litellm_timeout = 90`, which permanently changed the timeout of that provider instance for every subsequent call, not just the validation one. It now passes `timeout=VALIDATION_TIMEOUT` per call.
- **`model_name` is a required `str`.** Every concrete subclass already raises `ValueError` if it is falsy before calling `super().__init__`, and the base class is abstract, so the `str | None = None` hint was never accurate.
- **Removed the dead `OpenAIProvider._call_llm`,** which only called `super()` with the same arguments.

Note one behavior change: `GeminiProvider`'s default temperature goes from `1.0` to `0.0`, matching the other providers. If Gemini rejects it, the fallback above catches it.

### How can this be tested?
`src/ol_openedx_course_translations/tests/test_temperature_fallback.py` covers this with mocked litellm responses — no API keys or network needed:

```
tutor dev exec lms bash
cd /openedx/open-edx-plugins
./run_edx_integration_tests.sh --plugin ol_openedx_course_translations --skip-build
```

The tests assert that the low temperature is used when the model accepts it, that both rejection types trigger exactly one retry at the fallback, that the result is cached so a second provider instance for the same model does not re-probe, and that unrelated `BadRequestError`s (e.g. `context_length_exceeded`) still propagate rather than being retried.

To check against a real model, run a translation with an o-series model and confirm the log line `... rejected temperature=0.0; falling back to 1.0 for this process.` appears once, with the translation completing normally.

### Additional Context
Split out of #856, which originally carried both this and the prompt/inline-markup work. The two are independent and touch different regions of `llm_providers.py`; they merge together cleanly apart from the version line in `pyproject.toml`/`uv.lock`, so whichever lands second needs a one-line rebase.
