### PR TITLE
feat(ol_openedx_feedback): return-to-block focus + trigger hover refinements

### DIFF
--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
@@ -55,8 +55,6 @@
   color: #5f6b7a;
 }
 
-/* Hover: #F3F4F8 fill + dark border, matching the AskTIM button's hover.
-   :not(:disabled) outranks the LMS button:hover:not(:disabled) fill (#E4E4E4). */
 .ol-feedback-trigger:hover:not(:disabled) {
   background: #f3f4f8;
   border-color: #212326;

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
@@ -18,14 +18,14 @@
 /* Docked next to AskTIM: positioning only; the button styling stays on
    .ol-feedback-trigger so the megaphone looks the same docked or standalone. */
 .ol-feedback-anchor--docked {
-  margin-right: 10px;
+  margin-right: 16px;
   z-index: 1;
 }
 
 /* Problem blocks draw a notification line behind the button row; mask it across
    the docked gap to the AskTIM button (offset matches margin-right above). */
 .ol-feedback-anchor--line-masked {
-  box-shadow: 10px 0 0 0 #fff;
+  box-shadow: 16px 0 0 0 #fff;
 }
 
 /* Matches the AskTIM button's resting treatment and 50px height; box-sizing is
@@ -46,12 +46,18 @@
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
-/* Hover, active, and mouse-focus share one look; keyboard focus is handled below. */
-.ol-feedback-trigger:hover,
+/* Active/mouse-focus: subtle grey. Kept before :hover so hover wins on a focused button. */
 .ol-feedback-trigger:active,
 .ol-feedback-trigger:focus {
   background: #f0f1f4;
   border-color: #b8c2cc;
+  color: #5f6b7a;
+}
+
+/* Hover: #F3F4F8 fill + dark border, matching the AskTIM button's hover. */
+.ol-feedback-trigger:hover {
+  background: #f3f4f8;
+  border-color: #212326;
   color: #5f6b7a;
 }
 
@@ -62,8 +68,8 @@
 }
 
 .ol-feedback-trigger .ol-fb-ic {
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
   display: block;
 }
 

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/css/feedback.css
@@ -46,16 +46,18 @@
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
-/* Active/mouse-focus: subtle grey. Kept before :hover so hover wins on a focused button. */
-.ol-feedback-trigger:active,
-.ol-feedback-trigger:focus {
+/* Active/mouse-focus: subtle grey. Kept before :hover so hover wins on a focused
+   button. :not(:disabled) matches the LMS button rules' specificity so ours win. */
+.ol-feedback-trigger:active:not(:disabled),
+.ol-feedback-trigger:focus:not(:disabled) {
   background: #f0f1f4;
   border-color: #b8c2cc;
   color: #5f6b7a;
 }
 
-/* Hover: #F3F4F8 fill + dark border, matching the AskTIM button's hover. */
-.ol-feedback-trigger:hover {
+/* Hover: #F3F4F8 fill + dark border, matching the AskTIM button's hover.
+   :not(:disabled) outranks the LMS button:hover:not(:disabled) fill (#E4E4E4). */
+.ol-feedback-trigger:hover:not(:disabled) {
   background: #f3f4f8;
   border-color: #212326;
   color: #5f6b7a;

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
@@ -91,12 +91,6 @@
       var alignFrame = null;
       var alignToChatButton = function () {
         $anchor.css("transform", "");
-        // Clear our prior inline height first: the megaphone is docked inside
-        // AskTIM's flex row (align-items: stretch), so a stale tall height would
-        // inflate the row, stretch AskTIM to match, and then get read back below
-        // as AskTIM's "height" -- a self-locking loop that stays tall forever
-        // once a transient narrow-width wrap trips it. Resetting lets the row
-        // collapse to AskTIM's real (text-driven) height before we measure it.
         $trigger.css("height", "");
         var btnRect = $chatBtn[0].getBoundingClientRect();
         // Match the megaphone's height to the AskTIM button so the two stay

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
@@ -59,13 +59,17 @@
         if (event.origin !== mfeOrigin) {
           return;
         }
-        if (
-          event.data &&
-          event.data.type === "ol-feedback::drawer-closed" &&
-          lastTrigger
-        ) {
+        if (!event.data || !lastTrigger) {
+          return;
+        }
+        if (event.data.type === "ol-feedback::drawer-closed") {
+          // Drawer is gone: return focus, then forget the trigger.
           lastTrigger.focus();
           lastTrigger = null;
+        } else if (event.data.type === "ol-feedback::focus-trigger") {
+          // "Return to block" skip link: focus the trigger but keep the drawer
+          // open, so keep lastTrigger for the eventual close message.
+          lastTrigger.focus();
         }
       });
     }

--- a/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
+++ b/src/ol_openedx_feedback/ol_openedx_feedback/static/js/feedback.js
@@ -91,6 +91,13 @@
       var alignFrame = null;
       var alignToChatButton = function () {
         $anchor.css("transform", "");
+        // Clear our prior inline height first: the megaphone is docked inside
+        // AskTIM's flex row (align-items: stretch), so a stale tall height would
+        // inflate the row, stretch AskTIM to match, and then get read back below
+        // as AskTIM's "height" -- a self-locking loop that stays tall forever
+        // once a transient narrow-width wrap trips it. Resetting lets the row
+        // collapse to AskTIM's real (text-driven) height before we measure it.
+        $trigger.css("height", "");
         var btnRect = $chatBtn[0].getBoundingClientRect();
         // Match the megaphone's height to the AskTIM button so the two stay
         // equal-height peers even when AskTIM's label wraps to two lines on

--- a/src/ol_openedx_feedback/pyproject.toml
+++ b/src/ol_openedx_feedback/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-feedback"
-version = "0.2.1"
+version = "0.2.2"
 description = "An Open edX plugin to collect per-block learner feedback"
 authors = [{name = "MIT Office of Digital Learning"}]
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -2318,7 +2318,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-feedback"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "src/ol_openedx_feedback" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/13062

Part of mitodl/hq#11629.

Companion PR: [mitodl/smoot-design#259](https://github.com/mitodl/smoot-design/pull/259) — drawer copy, required-comment gating, and the "return to block" skip link that drives the new message below.

### Description (What does it do?)

Courseware-iframe (`ol_openedx_feedback`) side of the "return to block" skip link, plus a small trigger restyle.

- **Return-to-block focus:** on `ol-feedback::focus-trigger` from the drawer, return keyboard focus to the 📣 megaphone **without closing** it (distinct from `ol-feedback::drawer-closed`, which also forgets the trigger).
- **Trigger polish:** `#F3F4F8` hover fill + dark border (matching AskTIM's hover), 24px icon, 16px docked gap.
- Bumps the plugin **0.2.1 → 0.2.2** (+ `uv.lock`).

### Screenshots (if appropriate):
<img width="511" height="827" alt="Screenshot 2026-09-02 at 6 00 26 PM" src="https://github.com/user-attachments/assets/a750a610-180d-4b32-b7c9-1d4c7bbe1400" />
<img width="426" height="157" alt="Screenshot 2026-09-02 at 6 00 37 PM" src="https://github.com/user-attachments/assets/b10583ea-9e9a-44dd-b7a4-727a41d7f854" />


### How can this be tested?

- Install the plugin in the LMS and enable the `ol_openedx_feedback.feedback_enabled` CourseWaffleFlag (globally or per course). The return-to-block round-trip also needs the companion smoot bundle ([mitodl/smoot-design#259](https://github.com/mitodl/smoot-design/pull/259)) deployed in the Learning MFE.
- Open a courseware unit as a signed-in learner → the 📣 "Send feedback" megaphone renders on leaf blocks, docked next to AskTIM when present. Then, keyboard-only:
  1. **Open** — Tab to the 📣 (or click), press Enter → the drawer opens in the MFE sidebar and focus lands inside it (heading).
  2. **Return to block** — Tab to the **"Return to the …"** skip link (the first Tab stop) and activate it → keyboard focus returns to the 📣 megaphone **and the drawer stays open**.
  3. **Contrast with close** — press Escape or Close → focus also returns to the 📣, but the drawer **dismisses** (the `ol-feedback::drawer-closed` path, vs. `ol-feedback::focus-trigger` above).
  4. **Trigger polish** — hover the 📣 → **dark border + `#F3F4F8` fill**; the megaphone icon renders at **24px**, with a 16px gap to the docked AskTIM button.

- Automated: `pytest src/ol_openedx_feedback/tests` — `test_aside.py` covers trigger rendering/gating (authenticated non-author learners, leaf blocks only). The cross-iframe focus round-trip is browser behavior, verified manually above.

### Additional Context

Not live until the smoot bundle ([mitodl/smoot-design#259](https://github.com/mitodl/smoot-design/pull/259)) is version-bumped, published, and picked up by the Learning MFE.