### PR TITLE
feat(ol_openedx_chat): accessibility for the AskTIM trigger

### DIFF
--- a/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css
@@ -70,12 +70,22 @@
         box-shadow: none !important;
     }
 
-    &:focus,
-    &:focus-visible {
+    /* Mouse focus: red border, no ring (matches :active). */
+    &:focus:not(:focus-visible) {
         border: 2px solid #c00 !important;
         background: #FFF !important;
         box-shadow: none !important;
         outline: none;
+    }
+
+    /* Keyboard focus: keep the red border but add a visible ring (WCAG 2.4.7);
+       an outline also survives forced-colors mode. */
+    &:focus-visible {
+        border: 2px solid #c00 !important;
+        background: #FFF !important;
+        box-shadow: none !important;
+        outline: 2px solid #005a9c;
+        outline-offset: 2px;
     }
 }
 

--- a/src/ol_openedx_chat/ol_openedx_chat/static/html/student_view.html
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/html/student_view.html
@@ -1,6 +1,6 @@
 <div class="{{ block_type }}-block-chat-button-container">
   <button class="ai-chat-button {{ block_type }}-block-chat-button" id="chat-button-{{ block_id }}" data-block-id="{{ block_id }}" type="button">
-    <img src="/static/images/icon.svg" class="chat-icon">
+    <img src="/static/images/icon.svg" class="chat-icon" alt="">
     <p>Ask<b>TIM</b> {{ about_block }}</p>
   </button>
   <div id="app-root-{{ block_id }}"></div>

--- a/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
@@ -1,20 +1,65 @@
 (function ($) {
+  // The AskTIM button that last opened the drawer. The drawer renders in the
+  // parent MFE (cross-origin), so when it closes it can't focus our button
+  // directly; it messages us back and we return focus to this trigger.
+  var lastTrigger = null;
+  // The drawer-closed listener is global, so bind it once across all blocks.
+  var closeListenerBound = false;
+
   function AiChatAsideView(runtime, element, block_element, init_args) {
     $(function ($) {
+      var mfeBaseUrl = init_args.learning_mfe_base_url;
 
-      $(`#chat-button-${init_args.block_id}`).on("click", {
-        payload: init_args.drawer_payload,
-      }, function (event) {
+      $(`#chat-button-${init_args.block_id}`).on(
+        "click",
+        {
+          payload: init_args.drawer_payload,
+        },
+        function (event) {
+          // Remember which button opened the drawer so focus can return here
+          // when the drawer closes.
+          lastTrigger = this;
+          // Keyboard-fired click has detail === 0 (mouse >= 1); tell the drawer
+          // so it rings the heading for keyboard opens only (it renders
+          // cross-origin, so it can't infer this via :focus-visible).
+          var nativeEvent = event.originalEvent || event;
+          var viaKeyboard = nativeEvent.detail === 0;
 
-        window.parent.postMessage(
-          {
-            type: "smoot-design::tutor-drawer-open",
-            payload: event.data.payload
-          },
-          init_args.learning_mfe_base_url, // Ensure correct parent origin
-        );
+          window.parent.postMessage(
+            {
+              type: "smoot-design::tutor-drawer-open",
+              payload: event.data.payload,
+              viaKeyboard: viaKeyboard,
+            },
+            mfeBaseUrl, // Ensure correct parent origin
+          );
+        },
+      );
 
-      });
+      // Bind once (not per block): when the drawer closes it posts back so we
+      // can return keyboard focus to the button that opened it (WCAG 2.4.3).
+      if (!closeListenerBound && mfeBaseUrl) {
+        closeListenerBound = true;
+        var mfeOrigin;
+        try {
+          mfeOrigin = new URL(mfeBaseUrl).origin;
+        } catch (e) {
+          mfeOrigin = mfeBaseUrl;
+        }
+        window.addEventListener("message", function (event) {
+          if (event.origin !== mfeOrigin) {
+            return;
+          }
+          if (!event.data || !lastTrigger) {
+            return;
+          }
+          if (event.data.type === "smoot-design::tutor-drawer-closed") {
+            // Drawer is gone: return focus, then forget the trigger.
+            lastTrigger.focus();
+            lastTrigger = null;
+          }
+        });
+      }
     });
   }
 

--- a/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
@@ -1,9 +1,8 @@
 (function ($) {
-  // The AskTIM button that last opened the drawer. The drawer renders in the
-  // parent MFE (cross-origin), so when it closes it can't focus our button
-  // directly; it messages us back and we return focus to this trigger.
+  // The button that last opened the drawer. The drawer lives in the parent MFE
+  // (cross-origin), so on close it messages us back to refocus this trigger.
   var lastTrigger = null;
-  // The drawer-closed listener is global, so bind it once across all blocks.
+  // The message listener is global; bind it once across all blocks.
   var closeListenerBound = false;
 
   function AiChatAsideView(runtime, element, block_element, init_args) {
@@ -16,12 +15,9 @@
           payload: init_args.drawer_payload,
         },
         function (event) {
-          // Remember which button opened the drawer so focus can return here
-          // when the drawer closes.
           lastTrigger = this;
-          // Keyboard-fired click has detail === 0 (mouse >= 1); tell the drawer
-          // so it rings the heading for keyboard opens only (it renders
-          // cross-origin, so it can't infer this via :focus-visible).
+          // A keyboard-fired click has detail === 0 (mouse is >= 1); pass it so
+          // the drawer rings the heading for keyboard opens only.
           var nativeEvent = event.originalEvent || event;
           var viaKeyboard = nativeEvent.detail === 0;
 
@@ -36,8 +32,7 @@
         },
       );
 
-      // Bind once (not per block): when the drawer closes it posts back so we
-      // can return keyboard focus to the button that opened it (WCAG 2.4.3).
+      // Return keyboard focus to the trigger on the drawer's post-backs (WCAG 2.4.3).
       if (!closeListenerBound && mfeBaseUrl) {
         closeListenerBound = true;
         var mfeOrigin;
@@ -54,14 +49,14 @@
             return;
           }
           if (event.data.type === "smoot-design::tutor-drawer-closed") {
-            // Drawer is gone: return focus, then forget the trigger.
+            // Drawer closed: return focus, then forget the trigger.
             lastTrigger.focus();
             lastTrigger = null;
           } else if (
             event.data.type === "smoot-design::tutor-drawer-focus-trigger"
           ) {
-            // "Return to block" skip link: focus the trigger but keep the drawer
-            // open, so keep lastTrigger for the eventual close message.
+            // "Return to block" skip link: refocus the trigger but keep the
+            // drawer open (so keep lastTrigger for the later close).
             lastTrigger.focus();
           }
         });

--- a/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
@@ -1,6 +1,4 @@
 (function ($) {
-  // The button that last opened the drawer. The drawer lives in the parent MFE
-  // (cross-origin), so on close it messages us back to refocus this trigger.
   var lastTrigger = null;
   // The message listener is global; bind it once across all blocks.
   var closeListenerBound = false;

--- a/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
+++ b/src/ol_openedx_chat/ol_openedx_chat/static/js/ai_chat.js
@@ -57,6 +57,12 @@
             // Drawer is gone: return focus, then forget the trigger.
             lastTrigger.focus();
             lastTrigger = null;
+          } else if (
+            event.data.type === "smoot-design::tutor-drawer-focus-trigger"
+          ) {
+            // "Return to block" skip link: focus the trigger but keep the drawer
+            // open, so keep lastTrigger for the eventual close message.
+            lastTrigger.focus();
           }
         });
       }

--- a/src/ol_openedx_chat/pyproject.toml
+++ b/src/ol_openedx_chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-chat"
-version = "0.6.0"
+version = "0.6.1"
 description = "An Open edX plugin to add Open Learning AI chat aside to xBlocks"
 authors = [
   {name = "MIT Office of Digital Learning"}

--- a/src/ol_openedx_chat/tests/test_aside.py
+++ b/src/ol_openedx_chat/tests/test_aside.py
@@ -89,6 +89,9 @@ class OLChatAsideTests(OLChatTestCase):
             if not should_render_aside:
                 return
 
+            # The decorative chat icon must be hidden from screen readers (alt="").
+            assert 'class="chat-icon" alt=""' in fragment.content
+
             expected_json_init_args_keys = [
                 "block_id",
                 "learning_mfe_base_url",

--- a/uv.lock
+++ b/uv.lock
@@ -2118,7 +2118,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-chat"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "src/ol_openedx_chat" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/12975

### Description (What does it do?)

LMS-side (XBlockAside trigger) companion to the smoot-design AiDrawer a11y work ([smoot-design#260](https://github.com/mitodl/smoot-design/pull/260)), bringing the AskTIM button to accessibility parity with the content-feedback megaphone:

- **`student_view.html`** — mark the decorative chat icon `alt=""` so screen readers skip it.
- **`ai_chat.css`** — split focus styling: mouse focus keeps just the red border, keyboard `:focus-visible` adds a visible ring (WCAG 2.4.7).
- **`ai_chat.js`** — track the last-clicked trigger; flag keyboard activation (`detail === 0`) as `viaKeyboard` on the `tutor-drawer-open` message; refocus the trigger on the drawer's `tutor-drawer-closed` and `tutor-drawer-focus-trigger` ("Return to block") post-backs (WCAG 2.4.3).
- Bump `ol-openedx-chat` 0.5.10 → 0.5.11.

### Screenshots (if appropriate):
https://www.loom.com/share/e162eced32f040898b7eda34c0bc4523

### How can this be tested?

- Install the plugin in the LMS and enable AskTIM for a course (waffle flag + per-course video/problem settings). The full round-trip also needs the companion smoot bundle ([smoot-design#260](https://github.com/mitodl/smoot-design/pull/260)) deployed in the Learning MFE.
- Open a courseware unit as a signed-in learner → the AskTIM button renders on video/problem blocks. Then, keyboard-only:
  1. **Focus ring** — Tab to the AskTIM button → a visible keyboard focus ring appears (clicking with the mouse shows only the red border, no ring).
  2. **Focus-in** — press Enter → the drawer opens in the MFE sidebar and focus lands on the heading. ← core fix
  3. **Return-to-block** — activate the drawer's "Return to block" skip link → focus returns to the AskTIM button **without** closing the drawer.
  4. **Focus-return** — after Escape or Close, focus jumps back to the AskTIM button (focus ring; Enter reopens). ← cross-iframe half
- Automated: `pytest src/ol_openedx_chat/tests` — `test_aside.py` asserts the decorative `alt=""` renders. The focus-return / keyboard-vs-mouse modality is browser + cross-iframe behavior, so it's verified manually above rather than in these tests. (Runs in an edx environment, not locally.)

### Additional Context

- Drawer companion (drawer / smoot bundle side): [smoot-design#260](https://github.com/mitodl/smoot-design/pull/260) — `viaKeyboard` + focus ring + `tutor-drawer-closed` / `tutor-drawer-focus-trigger` post-backs + Tab focus-trap live there.
- Precedent: content-feedback trigger a11y (#839 / #853 / #861).
- Not live until the smoot bundle is version-bumped + published and lehrer bumps `@mitodl/smoot-design`.
