### PR TITLE
fix: route ol_openedx_git_auto_export tests to cms.envs.test, harden collection-failure gate

### DIFF
--- a/run_edx_integration_tests.sh
+++ b/run_edx_integration_tests.sh
@@ -171,6 +171,14 @@ run_plugin_tests() {
 	if [[ "$plugin_dir" == *"ol_openedx_uai_content_customization"* ]]; then
 		echo "Using CMS settings only for $plugin_dir (skipping LMS run)."
 		pytest_command="pytest . --cov . --ds=cms.envs.test"
+	elif [[ "$plugin_dir" == *"ol_openedx_git_auto_export"* ]]; then
+		# CMS-only plugin (cms.djangoapp entry point, no lms.djangoapp). Under
+		# LMS settings its app isn't installed at all, so its models/tasks fail
+		# to import. --nomigrations matches edx-platform's own test convention,
+		# which isn't inherited when pytest runs from inside a plugin directory
+		# with its own pyproject.toml as the rootdir config.
+		echo "Using CMS settings only for $plugin_dir (skipping LMS run)."
+		pytest_command="pytest . --cov . --ds=cms.envs.test --nomigrations"
 	# Check for the existence of settings/test.py
 	elif [ -f "settings/test.py" ]; then
 		pytest_command="pytest . --cov . --ds=settings.test"

--- a/run_edx_integration_tests.sh
+++ b/run_edx_integration_tests.sh
@@ -196,11 +196,20 @@ run_plugin_tests() {
 
 	# Run the pytest command
 	local PYTEST_SUCCESS=0
-	if $pytest_command --collect-only; then
+	$pytest_command --collect-only
+	local COLLECT_STATUS=$?
+	if [[ $COLLECT_STATUS -eq 0 ]]; then
 		$pytest_command
 		PYTEST_SUCCESS=$?
-	else
+	elif [[ $COLLECT_STATUS -eq 5 ]]; then
+		# Exit code 5 is pytest's own "no tests collected" -- benign for a
+		# plugin with no tests matching this settings module. Any other
+		# nonzero status is a real collection error (bad import, missing
+		# setting, etc.) and must fail the build, not be treated the same way.
 		echo "No tests found, skipping pytest."
+	else
+		echo "pytest collection failed with status $COLLECT_STATUS"
+		exit $COLLECT_STATUS
 	fi
 
 	if [[ $PYTEST_SUCCESS -ne 0 ]]; then

--- a/src/ol_openedx_course_sync/tests/test_tasks.py
+++ b/src/ol_openedx_course_sync/tests/test_tasks.py
@@ -14,12 +14,15 @@ from tests.utils import OLOpenedXCourseSyncTestCase
 
 
 @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
+@skip_unless_cms
 class TestReSyncTasks(OLOpenedXCourseSyncTestCase):
     """
     Test the ol_openedx_course_sync tasks.
+
+    These tasks orchestrate course_sync's Studio-only utilities, so this
+    whole class only runs during the plugin's CMS test pass.
     """
 
-    @skip_unless_cms
     def test_async_course_sync(self):
         """
         Test the async_course_sync task works as expected.
@@ -121,7 +124,6 @@ class TestReSyncTasks(OLOpenedXCourseSyncTestCase):
                 self.target_course.usage_key.course_key,
             )
 
-    @skip_unless_cms
     def test_async_discussions_configuration_sync(self):
         """
         Test the async_discussions_configuration_sync task works as expected.

--- a/src/ol_openedx_course_sync/tests/test_utils.py
+++ b/src/ol_openedx_course_sync/tests/test_utils.py
@@ -5,10 +5,6 @@ Tests for ol-openedx-course-sync utils.
 from unittest import mock
 
 import pytest
-from cms.djangoapps.contentstore.course_info_model import (
-    get_course_updates,
-    save_course_update_items,
-)
 from common.djangoapps.student.tests.factories import UserFactory
 from ddt import data, ddt, unpack
 from django.core.exceptions import ImproperlyConfigured
@@ -131,10 +127,18 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
                 continue
             assert tab.is_hidden is True
 
+    @skip_unless_cms
     def test_sync_course_updates(self):
         """
         Test the sync_course_updates function.
         """
+        # CMS-only: importing this at module level breaks collection under
+        # LMS settings, where cms.djangoapps.contentstore isn't installed.
+        from cms.djangoapps.contentstore.course_info_model import (  # noqa: PLC0415
+            get_course_updates,
+            save_course_update_items,
+        )
+
         source_course_key = self.source_course.usage_key.course_key
         target_course_key = self.target_course.usage_key.course_key
         source_location = source_course_key.make_usage_key("course_info", "updates")

--- a/src/ol_openedx_course_sync/tests/test_utils.py
+++ b/src/ol_openedx_course_sync/tests/test_utils.py
@@ -76,6 +76,7 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
             )
             split_modulestore_mock.copy.assert_called_once()
 
+    @skip_unless_cms
     def test_copy_static_tabs(self):
         """
         Test the copy_static_tabs function.

--- a/src/ol_openedx_course_sync/tests/test_utils.py
+++ b/src/ol_openedx_course_sync/tests/test_utils.py
@@ -43,12 +43,15 @@ from tests.utils import OLOpenedXCourseSyncTestCase
 
 
 @ddt
+@skip_unless_cms
 class TestUtils(OLOpenedXCourseSyncTestCase):
     """
     Test the ol_openedx_course_sync utils.
+
+    course_sync's utilities are Studio/authoring features, so this whole
+    class only runs during the plugin's CMS test pass.
     """
 
-    @skip_unless_cms
     @data(ModuleStoreEnum.BranchName.draft, ModuleStoreEnum.BranchName.published)
     def test_copy_course_content(self, branch):
         """
@@ -76,7 +79,6 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
             )
             split_modulestore_mock.copy.assert_called_once()
 
-    @skip_unless_cms
     def test_copy_static_tabs(self):
         """
         Test the copy_static_tabs function.
@@ -128,7 +130,6 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
                 continue
             assert tab.is_hidden is True
 
-    @skip_unless_cms
     def test_sync_course_updates(self):
         """
         Test the sync_course_updates function.
@@ -294,7 +295,6 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
         ],
     )
     @unpack
-    @skip_unless_cms
     @override_settings(OL_OPENEDX_COURSE_SYNC_SERVICE_WORKER_USERNAME="service_worker")
     def test_sync_discussions_configuration(
         self, source_fields, target_fields, expected_fields
@@ -374,7 +374,6 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
         ],
     )
     @unpack
-    @skip_unless_cms
     def test_get_syncable_course_mappings(  # noqa: PLR0913, PLR0917
         self,
         course_sync_org_exists,
@@ -422,14 +421,12 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
             else:
                 assert actual_sync_mappings.count() == expected_sync_mappings_count
 
-    @skip_unless_cms
     def test_get_all_source_courses_no_mappings(self):
         """
         Test get_all_source_courses returns None when no mappings exist.
         """
         assert get_all_source_courses() is None
 
-    @skip_unless_cms
     def test_get_all_source_courses_no_active_mappings(self):
         """
         Test get_all_source_courses returns None when no mapping is active.
@@ -444,7 +441,6 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
 
         assert get_all_source_courses() is None
 
-    @skip_unless_cms
     def test_get_all_source_courses_returns_distinct_active_sources(self):
         """
         Test get_all_source_courses returns a distinct list of the active
@@ -585,7 +581,6 @@ class TestUtils(OLOpenedXCourseSyncTestCase):
         },
     )
     @unpack
-    @skip_unless_cms
     def test_verify_static_assets(
         self,
         source_assets,

--- a/src/ol_openedx_git_auto_export/tests/test_migrate_giturl.py
+++ b/src/ol_openedx_git_auto_export/tests/test_migrate_giturl.py
@@ -67,9 +67,11 @@ class TestProcessRepositoriesInParallel(TestCase):
         task_callable = cast("Callable[..., object]", async_create_github_repo.run)
         task_signature = inspect.signature(task_callable)
         for signature in captured:
-            # ``self`` is bound by Celery, so stand it in here. Raises TypeError
-            # if the command passes a keyword the task does not accept.
-            task_signature.bind(None, *signature.args, **signature.kwargs)
+            # async_create_github_repo.run is a bound method on the task
+            # instance, so its signature already excludes self. Raises
+            # TypeError if the command passes a keyword the task doesn't
+            # accept.
+            task_signature.bind(*signature.args, **signature.kwargs)
             assert signature.kwargs == {"export_content": True}
 
     def test_dispatches_one_signature_per_repo(self):


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- `ol_openedx_git_auto_export` only registers a `cms.djangoapp` entry point, but the test runner's fallback logic defaulted it to `--ds=lms.envs.test`. Under LMS settings the app isn't installed at all, so its models/tasks fail to import.
- That collection failure wasn't turning CI red: `run_edx_integration_tests.sh` treated any `pytest --collect-only` failure as "no tests found" and skipped running pytest entirely, rather than failing the build. Reproduced this locally against the current `main`-branch content of the plugin (this branch predates the debounce work in #860), confirming the whole test suite has never actually executed in CI, independent of that PR.
- Routes this plugin to `--ds=cms.envs.test`, matching the existing `ol_openedx_uai_content_customization` precedent, and adds `--nomigrations` (edx-platform's own root pytest config defaults to it, but that default isn't inherited when pytest runs from inside a plugin's own directory).
- Along the way, running the suite for real for the first time surfaced one genuine, previously-undetected test bug, fixed here too.
- **Also hardens the collection-failure gate itself** (Copilot review feedback): the old gate treated *any* nonzero `--collect-only` exit as "no tests, skip," so a future regression under the new `cms.envs.test` invocation would have gone right back to silently passing — the exact failure mode this PR exists to close. The gate now distinguishes pytest's exit code 5 ("no tests collected," genuinely benign) from every other nonzero status (a real collection error), and fails the build on the latter. This changes the gate for every plugin, not just this one.
- That gate change immediately did its job: CI on this PR turned up two rounds of pre-existing, unrelated failures in `ol_openedx_course_sync` (a collection error, then a per-test failure) that had been silently swallowed by the exact same bug the whole time. Fixed both (see below), then proactively audited the rest of that plugin's test suite for the same shape of gap rather than waiting for CI to reveal them one at a time — found and consolidated two more, and confirmed no other test file or production module in the plugin has the same issue.

<details>
<summary><b>Implementation details</b></summary>
<br>

Verified end to end in a live Tutor container (`tutor dev launch`, plugin installed in dev mode), reproducing each failure before fixing it:

- `--ds=lms.envs.test` (the old default): reproduces the exact "`ContentGitRepository` doesn't declare an explicit app_label" collection error seen in CI.
- `--ds=cms.envs.test` alone: collection succeeds, but the real run then hits `Table course_overviews_courseoverview does not exist` — pytest-django applying migrations from scratch trips over an old data migration (`0009_readd_facebook_url.py`) that introspects a table before it exists. Added `--nomigrations`.
- With both: collection and setup succeed, then `test_dispatched_kwargs_accepted_by_task` fails for real — it passed `None` as a stand-in for `self` before binding a captured Celery signature against the task's signature, but `async_create_github_repo.run` is a bound method on the task instance, so its introspected signature already excludes `self`. The stray `None` shifted every following argument by one slot, producing "multiple values for argument 'export_content'". Fixed by dropping it; confirmed the corrected bind succeeds against the real task signature interactively before applying it.

All 6 tests in the plugin now collect and pass for real, with coverage, under the same invocation CI uses.

For the gate change, verified pytest's actual exit codes with a clean local repro outside Docker (this repo's own venv, a throwaway scratch directory): a real collection error (bad import) exits `2`, a genuinely empty match (`-k` matching nothing) exits `5`, success exits `0`. Only `5` means "nothing to do here." Re-verified all three scenarios end to end against the new gate logic, not just the bare exit codes.

For `ol_openedx_course_sync`: `tests/test_utils.py` imported `cms.djangoapps.contentstore.course_info_model` at module level, which transitively needs the CMS-only `SearchAccess` model to have an app_label — true only when `cms.djangoapps.contentstore` is installed, i.e. only under CMS settings. This plugin registers as both `lms.djangoapp` and `cms.djangoapp` and runs its suite under both, so collection has been failing under the LMS leg the whole time, hidden by the same swallowing bug. Only one test (`test_sync_course_updates`) actually uses those CMS-only functions, and — unlike its sibling tests that exercise CMS-only functionality — it was missing the `@skip_unless_cms` decorator they already use for exactly this reason. Added it, and moved the import inside the test body so merely importing the module doesn't require CMS settings.

This fix was not independently re-verified live end to end: the Tutor container used for this session's verification work was left in a broken, unrelated package-conflict state by an earlier mistake, and repeated attempts to repair it were unsuccessful. Confidence rests on: the plugin's production code never calls these two functions (only the test file does, confirmed by grep — one call site, now inside the newly-skipped test), and the fix is structurally identical to how every other CMS-only dependency in this same file is already handled correctly (`@skip_unless_cms` gating a test body that only then does CMS-only work). The CI run on this PR is the actual, uncorrupted confirmation.

The next CI run (still under the LMS leg) found a second, distinct failure in the same file: `test_copy_static_tabs` calls `copy_static_tabs()`, whose production code already does its own lazy `from cms.djangoapps.contentstore.utils import duplicate_block` inside the function body — so the CMS-only dependency was already handled correctly on the production side, but the *test* was simply missing the `@skip_unless_cms` decorator every sibling CMS-dependent test already carries. Checked every other production function in `utils.py` for the same shape (a `from cms.` import); `copy_static_tabs` is the only one, and the CI failure list confirmed no other test in the file needed the same fix.

At that point, 9 of `TestUtils`'s 11 methods carried `@skip_unless_cms` individually — added one at a time as each was discovered by a separate CI run. Since course_sync's utilities are inherently Studio/authoring features, consolidated this into a single class-level `@skip_unless_cms` (matching the pattern already used by two other classes in this same plugin, `TestCoursePublishSignal` and `TestMigrateLegacyLibraryBlocksToItemBank`) and dropped the 8 now-redundant per-method decorators. This also skips the 2 previously-undecorated methods (`test_copy_default_tabs`, `test_sync_course_handouts`) under LMS — they still run under the CMS pass of the same file, so nothing goes unexercised, they're just no longer separately validated under both settings modules. The module-level CMS-only import inside `test_sync_course_updates` stays local: a class-level skip only prevents method *execution*, not module *import*, so collection under LMS still needs it kept out of the top-level import list.

Applied the same class-level consolidation to `test_tasks.py`'s `TestReSyncTasks` (2 of 3 methods already decorated; the third, `test_async_course_assets_sync`, mocks away everything CMS-related so it was already safe under LMS, and now also runs CMS-only for consistency). Audited every remaining test file in the plugin (`test_signals.py`, `test_models.py`, `test_migrate_legacy_library_blocks_to_item_bank.py`) and every production module — everything else already correctly decorated or genuinely LMS-safe.
</details>

### How can this be tested?
- Ran the exact CI invocation locally against a live Tutor container: `pytest . --cov . --ds=cms.envs.test --nomigrations` inside the `cms` service, plugin installed in dev mode via `pip install -e src/ol_openedx_git_auto_export` — all 6 tests pass.
- Confirmed the collection failure reproduces under the old `--ds=lms.envs.test` invocation, and confirmed each intermediate failure (missing `--nomigrations`, then the test bug) before applying its fix, rather than changing everything at once and hoping.
- Verified the new collection-failure gate against three scenarios (real collection error, benign zero-tests-matched, normal success) with a clean local pytest repro outside Docker, isolated from the Tutor-container work above.
- `uv run ruff format` / `uv run ruff check` pass; `bash -n run_edx_integration_tests.sh` confirms shell syntax is valid.
- Each push of the gate/course_sync changes turned the integration-tests matrix red on a real, specific problem (never a flake) — first the `ol_openedx_course_sync` collection error, then `test_copy_static_tabs` — confirming the gate change works as intended (it fails the build on a real problem, not just in theory) and giving live examples of the class of bug this PR closes. A reviewer should confirm the matrix is green on the latest commit before merging.

### Additional Context
Found while investigating why tests written for a separate PR (#860, the git-export debounce fix) never seemed to catch regressions the way they should have — this is the root cause: `ol_openedx_git_auto_export`'s whole test suite has been silently skipped by CI, not just those new tests. This PR fixes test infrastructure only (the shared runner script, plus `ol_openedx_course_sync`'s CMS/LMS test skip decoration) — it does not touch either plugin's production code.

A note on process: while re-verifying the `ol_openedx_git_auto_export` fix in the same Tutor container used earlier, an errant `pip install openedx-learning` downgraded `openedx-core` and left the container unable to populate Django's app registry under `cms.envs.test` at all. That container is no longer being used for verification in this PR; it doesn't affect the code changes here, which were checked by other means as noted above.


