### PR TITLE
fix(sentry): stop capturing request bodies and scrub Postgres DETAIL rows

### DIFF
--- a/src/ol_openedx_sentry/README.rst
+++ b/src/ol_openedx_sentry/README.rst
@@ -68,9 +68,14 @@ never initialized.
      - Release identifier, passed to ``sentry_sdk.init(release=...)`` for
        associating events with a build.
    * - ``SENTRY_SEND_HTTP_REQUEST_BODIES``
-     - ``"small"``
+     - ``"never"``
      - Maps to the SDK's ``max_request_body_size`` (``"never"``, ``"small"``,
-       ``"medium"``, ``"always"``).
+       ``"medium"``, ``"always"``). Request bodies are *not* gated on
+       ``SENTRY_SEND_DEFAULT_PII`` -- the SDK sets ``request.data``
+       unconditionally and this is the only control -- so it defaults to
+       ``"never"``. ``"small"`` still admits 1,000-byte bodies, which is
+       enough for a graded xblock submission; operators opt in per
+       deployment.
    * - ``SENTRY_SEND_DEFAULT_PII``
      - ``False``
      - When ``True``, attaches identifying data (user id, username, client IP)
@@ -121,8 +126,11 @@ Behavior notes / design decisions
 **``before_send`` is fail-open.** The event filter drops events whose raised
 exception is a subclass of an ignored class, or whose message matches an ignored
 regex. If the filter itself raises for any reason, the error is logged and the
-original event is returned unfiltered. A bug in filtering can never silently
-blackhole error reporting. Relatedly, ignored classes and message regexes are
+event is returned rather than dropped. A bug in filtering can never silently
+blackhole error reporting. The one thing that is *not* skipped on that path is
+the Postgres ``DETAIL`` scrub: it runs as the filter's first statement, before
+anything else can raise, so a fail-open return is still a scrubbed event. A
+privacy control that fails open is not one. Relatedly, ignored classes and message regexes are
 resolved and compiled once at init time (not per event), so a bad import path or
 invalid regex is reported once and skipped rather than raising inside
 ``before_send``.

--- a/src/ol_openedx_sentry/README.rst
+++ b/src/ol_openedx_sentry/README.rst
@@ -130,10 +130,10 @@ event is returned rather than dropped. A bug in filtering can never silently
 blackhole error reporting. The one thing that is *not* skipped on that path is
 the Postgres ``DETAIL`` scrub: it runs as the filter's first statement, before
 anything else can raise, so a fail-open return is still a scrubbed event. A
-privacy control that fails open is not one. Relatedly, ignored classes and message regexes are
-resolved and compiled once at init time (not per event), so a bad import path or
-invalid regex is reported once and skipped rather than raising inside
-``before_send``.
+privacy control that fails open is not one. Relatedly, ignored classes and
+message regexes are resolved and compiled once at init time (not per event), so
+a bad import path or invalid regex is reported once and skipped rather than
+raising inside ``before_send``.
 
 **LoggingIntegration is configured explicitly with ``event_level=None``.** By
 default the Sentry SDK promotes ``ERROR``-and-above log records into standalone

--- a/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
+++ b/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
@@ -7,8 +7,10 @@ operator-configured exception types or message regexes.
 Design notes
 ------------
 * ``before_send`` is *fail-open*: any unexpected error is logged and the event
-  is returned unfiltered, so a bug in the filter can never silently blackhole
-  error reporting.
+  is returned rather than dropped, so a bug in the filter can never silently
+  blackhole error reporting.  The DETAIL scrub below is the exception to
+  "unfiltered" -- it runs as the filter's first statement, before anything
+  else can raise, so even a fail-open return is scrubbed.
 * Ignored exception classes and message regexes are resolved/compiled once at
   init time (not per event), so a bad import path or invalid regex is reported
   once and skipped rather than raising inside ``before_send``.
@@ -174,26 +176,39 @@ def _scrub_pg_detail(text: str) -> str:
 
 
 def _scrub_pg_details(event: dict[str, Any]) -> dict[str, Any]:
-    """Apply :func:`_scrub_pg_detail` everywhere an error string lands.
+    """Truncate Postgres ``DETAIL`` lines everywhere in a Sentry event.
 
-    Covers exception values, the ``logentry`` message/formatted pair, and the
-    legacy top-level ``message``, so the scrub holds whether the event arrived
-    as an uncaught exception or via ``logger.exception``.
+    The row echo reaches Sentry through more fields than the exception value:
+    ``LoggingIntegration`` puts the log message in a breadcrumb
+    (``integrations/logging.py:311``), ``logger.error("...: %s", exc)`` puts it
+    in ``logentry.params`` (``:274``), and captured stack-frame locals carry it
+    in frame ``vars`` because ``include_local_variables`` defaults to ``True``
+    (``consts.py:1028``, ``utils.py:616``).  Walking the whole event covers
+    those without enumerating them, and does not go stale when the SDK grows
+    another such field.
+
+    Safe to walk naively because ``client._prepare_event`` serializes the event
+    before calling ``before_send`` (``client.py:650`` vs ``:658``), so every
+    leaf here is already a JSON primitive -- there are no live exception
+    objects left to coerce.
     """
-    for entry in (event.get("exception") or {}).get("values") or []:
-        value = entry.get("value")
-        if isinstance(value, str):
-            entry["value"] = _scrub_pg_detail(value)
-    logentry = event.get("logentry")
-    if isinstance(logentry, dict):
-        for key in ("formatted", "message"):
-            value = logentry.get(key)
-            if isinstance(value, str):
-                logentry[key] = _scrub_pg_detail(value)
-    top_message = event.get("message")
-    if isinstance(top_message, str):
-        event["message"] = _scrub_pg_detail(top_message)
-    return event
+    return _scrub_node(event)
+
+
+def _scrub_node(node: Any) -> Any:
+    """Recurse through the serialized event, rewriting strings in place."""
+    if isinstance(node, str):
+        return _scrub_pg_detail(node)
+    if isinstance(node, dict):
+        for key, value in node.items():
+            node[key] = _scrub_node(value)
+        return node
+    if isinstance(node, list):
+        node[:] = [_scrub_node(item) for item in node]
+        return node
+    if isinstance(node, tuple):
+        return tuple(_scrub_node(item) for item in node)
+    return node
 
 
 def _tag_otel_context(event: dict[str, Any]) -> dict[str, Any]:

--- a/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
+++ b/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
@@ -18,9 +18,9 @@ Design notes
   ``event_level=None`` so that stdlib/structlog log records become breadcrumbs
   only, never standalone Sentry issues.  Uncaught exceptions are still captured
   by the Django integration.
-* Postgres ``DETAIL:`` lines are truncated out of exception values and log
-  messages before send.  They echo the offending row verbatim -- learner name,
-  email, external UUID -- and no SDK privacy option covers exception text.
+* Postgres ``DETAIL:`` lines are truncated out of every string in the event
+  before send.  They echo the offending row verbatim -- learner name, email,
+  external UUID -- and no SDK privacy option covers exception text.
 * OpenTelemetry ``trace_id``/``span_id`` are stamped onto every event as tags
   using the same formatting as ``ol_openedx_logging`` so Sentry issues and the
   structured logs in Loki correlate on identical values.  ``opentelemetry`` is
@@ -157,8 +157,11 @@ def _event_messages(event: dict[str, Any], exception_value: object) -> list[str]
 # exception text.  Measured on mitxonline MITXONLINE-6PK, where a SCIM PATCH
 # IntegrityError reproduced a learner email address three times per event across
 # 46,764 occurrences.
-_PG_DETAIL_MARKER = "\nDETAIL:"
-_PG_DETAIL_REPLACEMENT = "\nDETAIL:  [scrubbed by ol_openedx_sentry]"
+#
+# The newline is matched both raw and as a literal backslash-n: the SDK repr()s
+# frame locals and non-string logging params during serialization, so there the
+# DETAIL line arrives as "...constraint\\nDETAIL: ..." inside a repr string.
+_PG_DETAIL_RE = re.compile(r"(\n|\\n)DETAIL:.*", re.DOTALL)
 
 
 def _scrub_pg_detail(text: str) -> str:
@@ -169,10 +172,11 @@ def _scrub_pg_detail(text: str) -> str:
     appends after DETAIL -- those are diagnostic only and can quote row data
     too.
     """
-    index = text.find(_PG_DETAIL_MARKER)
-    if index == -1:
-        return text
-    return text[:index] + _PG_DETAIL_REPLACEMENT
+    return _PG_DETAIL_RE.sub(
+        lambda match: match.group(1) + "DETAIL:  [scrubbed by ol_openedx_sentry]",
+        text,
+        count=1,
+    )
 
 
 def _scrub_pg_details(event: dict[str, Any]) -> dict[str, Any]:
@@ -180,17 +184,17 @@ def _scrub_pg_details(event: dict[str, Any]) -> dict[str, Any]:
 
     The row echo reaches Sentry through more fields than the exception value:
     ``LoggingIntegration`` puts the log message in a breadcrumb
-    (``integrations/logging.py:311``), ``logger.error("...: %s", exc)`` puts it
-    in ``logentry.params`` (``:274``), and captured stack-frame locals carry it
-    in frame ``vars`` because ``include_local_variables`` defaults to ``True``
-    (``consts.py:1028``, ``utils.py:616``).  Walking the whole event covers
-    those without enumerating them, and does not go stale when the SDK grows
-    another such field.
+    (``BreadcrumbHandler._breadcrumb_from_record``),
+    ``logger.error("...: %s", exc)`` puts it in ``logentry.params``
+    (``EventHandler._emit``), and captured stack-frame locals carry it in frame
+    ``vars`` because ``include_local_variables`` defaults to ``True``
+    (``serialize_frame``).  Walking the whole event covers those without
+    enumerating them, and does not go stale when the SDK grows another such
+    field.
 
-    Safe to walk naively because ``client._prepare_event`` serializes the event
-    before calling ``before_send`` (``client.py:650`` vs ``:658``), so every
-    leaf here is already a JSON primitive -- there are no live exception
-    objects left to coerce.
+    Safe to walk naively because ``Client._prepare_event`` serializes the event
+    before calling ``before_send``, so every leaf here is already a JSON
+    primitive -- there are no live exception objects left to coerce.
     """
     return _scrub_node(event)
 
@@ -206,8 +210,6 @@ def _scrub_node(node: Any) -> Any:
     if isinstance(node, list):
         node[:] = [_scrub_node(item) for item in node]
         return node
-    if isinstance(node, tuple):
-        return tuple(_scrub_node(item) for item in node)
     return node
 
 
@@ -340,12 +342,12 @@ def plugin_settings(app_settings):
         send_default_pii=env_tokens.get("SENTRY_SEND_DEFAULT_PII", False),
         release=env_tokens.get("SENTRY_RELEASE_SPECIFIER"),
         # HTTP request bodies are NOT gated on send_default_pii -- the SDK sets
-        # request.data unconditionally and max_request_body_size is the only
-        # control (sentry_sdk/integrations/_wsgi_common.py:61,123).  On Open edX
-        # the write endpoints that actually error are xblock handler POSTs, i.e.
-        # graded problem submissions, and those are routinely under the 1,000
-        # bytes that "small" still admits.  Default to "never" here; operators
-        # can widen it per deployment.
+        # request.data unconditionally (RequestExtractor.extract_into_event) and
+        # max_request_body_size is the only control (request_body_within_bounds).
+        # On Open edX the write endpoints that actually error are xblock handler
+        # POSTs, i.e. graded problem submissions, and those are routinely under
+        # the 1,000 bytes that "small" still admits.  Default to "never" here;
+        # operators can widen it per deployment.
         max_request_body_size=env_tokens.get(
             "SENTRY_SEND_HTTP_REQUEST_BODIES", "never"
         ),

--- a/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
+++ b/src/ol_openedx_sentry/ol_openedx_sentry/settings/sentry.py
@@ -16,6 +16,9 @@ Design notes
   ``event_level=None`` so that stdlib/structlog log records become breadcrumbs
   only, never standalone Sentry issues.  Uncaught exceptions are still captured
   by the Django integration.
+* Postgres ``DETAIL:`` lines are truncated out of exception values and log
+  messages before send.  They echo the offending row verbatim -- learner name,
+  email, external UUID -- and no SDK privacy option covers exception text.
 * OpenTelemetry ``trace_id``/``span_id`` are stamped onto every event as tags
   using the same formatting as ``ol_openedx_logging`` so Sentry issues and the
   structured logs in Loki correlate on identical values.  ``opentelemetry`` is
@@ -143,6 +146,56 @@ def _event_messages(event: dict[str, Any], exception_value: object) -> list[str]
     return candidates
 
 
+# Postgres appends a DETAIL line to constraint violations that echoes the whole
+# offending row verbatim -- on a users table that is the learner's name, email
+# and external UUID.  psycopg surfaces it as part of str(exc), so it reaches
+# Sentry inside the exception value and the log message, where no SDK privacy
+# setting applies: send_default_pii governs user/cookie/header capture and
+# max_request_body_size governs request bodies, neither of which touches the
+# exception text.  Measured on mitxonline MITXONLINE-6PK, where a SCIM PATCH
+# IntegrityError reproduced a learner email address three times per event across
+# 46,764 occurrences.
+_PG_DETAIL_MARKER = "\nDETAIL:"
+_PG_DETAIL_REPLACEMENT = "\nDETAIL:  [scrubbed by ol_openedx_sentry]"
+
+
+def _scrub_pg_detail(text: str) -> str:
+    """Truncate a Postgres error string at its ``DETAIL:`` line.
+
+    Keeps the primary message, which is what identifies the failure, and drops
+    the row echo that follows it.  Also removes any HINT/CONTEXT that Postgres
+    appends after DETAIL -- those are diagnostic only and can quote row data
+    too.
+    """
+    index = text.find(_PG_DETAIL_MARKER)
+    if index == -1:
+        return text
+    return text[:index] + _PG_DETAIL_REPLACEMENT
+
+
+def _scrub_pg_details(event: dict[str, Any]) -> dict[str, Any]:
+    """Apply :func:`_scrub_pg_detail` everywhere an error string lands.
+
+    Covers exception values, the ``logentry`` message/formatted pair, and the
+    legacy top-level ``message``, so the scrub holds whether the event arrived
+    as an uncaught exception or via ``logger.exception``.
+    """
+    for entry in (event.get("exception") or {}).get("values") or []:
+        value = entry.get("value")
+        if isinstance(value, str):
+            entry["value"] = _scrub_pg_detail(value)
+    logentry = event.get("logentry")
+    if isinstance(logentry, dict):
+        for key in ("formatted", "message"):
+            value = logentry.get(key)
+            if isinstance(value, str):
+                logentry[key] = _scrub_pg_detail(value)
+    top_message = event.get("message")
+    if isinstance(top_message, str):
+        event["message"] = _scrub_pg_detail(top_message)
+    return event
+
+
 def _tag_otel_context(event: dict[str, Any]) -> dict[str, Any]:
     """Stamp the active OTel ``trace_id``/``span_id`` onto the event as tags.
 
@@ -173,10 +226,12 @@ def sentry_event_filter(
 
     Drops the event (returns ``None``) when the raised exception is a subclass
     of an ignored type, or when any candidate message matches an ignored regex.
-    Otherwise stamps OTel trace context and returns the event.
+    Otherwise scrubs Postgres ``DETAIL`` row echoes, stamps OTel trace context,
+    and returns the event.
 
     Fail-open: any unexpected error is logged and the event is returned, so a
-    bug here can never silently drop error reporting.
+    bug here can never silently drop error reporting.  The scrub runs first so
+    that the fail-open path still returns a scrubbed event.
 
     :param event: Sentry event payload.
     :param hint: Sentry event hint (may contain ``exc_info``).
@@ -186,6 +241,9 @@ def sentry_event_filter(
     :returns: The (possibly tagged) event, or ``None`` to drop it.
     """
     try:
+        # Scrub before anything else can raise: the fail-open handler below
+        # returns this same dict, and a privacy control must not fail open.
+        _scrub_pg_details(event)
         exception_info = hint.get("exc_info")
         exception_value: object = ""
         if exception_info:
@@ -266,8 +324,15 @@ def plugin_settings(app_settings):
         # PII (user id/username/IP) is opt-in — FERPA-sensitive by default.
         send_default_pii=env_tokens.get("SENTRY_SEND_DEFAULT_PII", False),
         release=env_tokens.get("SENTRY_RELEASE_SPECIFIER"),
+        # HTTP request bodies are NOT gated on send_default_pii -- the SDK sets
+        # request.data unconditionally and max_request_body_size is the only
+        # control (sentry_sdk/integrations/_wsgi_common.py:61,123).  On Open edX
+        # the write endpoints that actually error are xblock handler POSTs, i.e.
+        # graded problem submissions, and those are routinely under the 1,000
+        # bytes that "small" still admits.  Default to "never" here; operators
+        # can widen it per deployment.
         max_request_body_size=env_tokens.get(
-            "SENTRY_SEND_HTTP_REQUEST_BODIES", "small"
+            "SENTRY_SEND_HTTP_REQUEST_BODIES", "never"
         ),
         # Explicit LoggingIntegration: log records are breadcrumbs only
         # (event_level=None) so structlog/stdlib logs don't become duplicate,

--- a/src/ol_openedx_sentry/pyproject.toml
+++ b/src/ol_openedx_sentry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ol-openedx-sentry"
-version = "0.4.0"
+version = "0.5.0"
 description = "An Open edX plugin to enable error tracking with Sentry"
 readme = "README.rst"
 authors = [

--- a/src/ol_openedx_sentry/tests/test_sentry.py
+++ b/src/ol_openedx_sentry/tests/test_sentry.py
@@ -249,6 +249,67 @@ class TestCoerceLogEventLevel:
         assert sentry._coerce_log_event_level("bogus") is None
 
 
+# A real MITXONLINE-6PK exception value, with the learner identifiers replaced.
+PG_INTEGRITY_ERROR = (
+    'null value in column "name" of relation "users_user" violates not-null '
+    "constraint\n"
+    "DETAIL:  Failing row contains (1863408, , 2026-08-07 18:38:14.503726+00, f, "
+    "learner@example.invalid, learner@example.invalid, null, f, t, "
+    "12d7dfc5-6f84-46db-9383-2d7079434173, 1863408, learner@example.invalid, f)."
+)
+PG_PRIMARY_MESSAGE = (
+    'null value in column "name" of relation "users_user" violates not-null constraint'
+)
+
+
+class TestScrubPgDetail:
+    """Tests for the Postgres ``DETAIL:`` row-echo scrub."""
+
+    def test_detail_line_is_truncated(self):
+        scrubbed = sentry._scrub_pg_detail(PG_INTEGRITY_ERROR)
+        assert scrubbed.startswith(PG_PRIMARY_MESSAGE)
+        assert "learner@example.invalid" not in scrubbed
+        assert "12d7dfc5-6f84-46db-9383-2d7079434173" not in scrubbed
+        assert "[scrubbed by ol_openedx_sentry]" in scrubbed
+
+    def test_message_without_detail_is_unchanged(self):
+        message = "connection to server failed"
+        assert sentry._scrub_pg_detail(message) == message
+
+    def test_hint_and_context_after_detail_are_dropped(self):
+        text = "boom\nDETAIL:  row data\nHINT:  try again\nCONTEXT:  SQL statement"
+        scrubbed = sentry._scrub_pg_detail(text)
+        assert "row data" not in scrubbed
+        assert "try again" not in scrubbed
+        assert "SQL statement" not in scrubbed
+
+    def test_scrubs_exception_values_logentry_and_message(self):
+        event = {
+            "exception": {"values": [{"value": PG_INTEGRITY_ERROR}]},
+            "logentry": {
+                "message": PG_INTEGRITY_ERROR,
+                "formatted": PG_INTEGRITY_ERROR,
+            },
+            "message": PG_INTEGRITY_ERROR,
+        }
+        sentry._scrub_pg_details(event)
+        assert "learner@example.invalid" not in repr(event)
+
+    def test_filter_scrubs_on_the_normal_path(self):
+        event = {"exception": {"values": [{"value": PG_INTEGRITY_ERROR}]}}
+        result = sentry.sentry_event_filter(event, {})
+        assert "learner@example.invalid" not in repr(result)
+
+    def test_filter_scrubs_even_when_it_fails_open(self, mocker):
+        # The fail-open handler returns the same event dict, so the scrub must
+        # already have been applied before anything else can raise.
+        mocker.patch.object(sentry, "_event_messages", side_effect=RuntimeError("boom"))
+        event = {"exception": {"values": [{"value": PG_INTEGRITY_ERROR}]}}
+        result = sentry.sentry_event_filter(event, {})
+        assert result is event
+        assert "learner@example.invalid" not in repr(result)
+
+
 class TestPluginSettings:
     """Tests for ``plugin_settings`` SDK initialization."""
 
@@ -267,6 +328,7 @@ class TestPluginSettings:
         init.assert_called_once()
         kwargs = init.call_args.kwargs
         assert kwargs["send_default_pii"] is False
+        assert kwargs["max_request_body_size"] == "never"
         assert kwargs["before_send"] is not None
         integrations = kwargs["integrations"]
         logging_integrations = [
@@ -285,6 +347,17 @@ class TestPluginSettings:
         )
         sentry.plugin_settings(app_settings)
         assert init.call_args.kwargs["send_default_pii"] is True
+
+    def test_request_bodies_opt_in(self, mocker):
+        init = mocker.patch.object(sentry.sentry_sdk, "init")
+        app_settings = types.SimpleNamespace(
+            ENV_TOKENS={
+                "SENTRY_DSN": "https://example.invalid/1",
+                "SENTRY_SEND_HTTP_REQUEST_BODIES": "small",
+            }
+        )
+        sentry.plugin_settings(app_settings)
+        assert init.call_args.kwargs["max_request_body_size"] == "small"
 
     def test_bare_string_ignored_classes_is_not_iterated_per_char(self, mocker):
         # A misconfigured bare string must resolve as a single class spec, not

--- a/src/ol_openedx_sentry/tests/test_sentry.py
+++ b/src/ol_openedx_sentry/tests/test_sentry.py
@@ -257,6 +257,9 @@ PG_INTEGRITY_ERROR = (
     "learner@example.invalid, learner@example.invalid, null, f, t, "
     "12d7dfc5-6f84-46db-9383-2d7079434173, 1863408, learner@example.invalid, f)."
 )
+EXPECTED_RETRIES = 3
+EXPECTED_TIMESTAMP = 1757345533.179
+
 PG_PRIMARY_MESSAGE = (
     'null value in column "name" of relation "users_user" violates not-null constraint'
 )
@@ -308,6 +311,71 @@ class TestScrubPgDetail:
         result = sentry.sentry_event_filter(event, {})
         assert result is event
         assert "learner@example.invalid" not in repr(result)
+
+    def test_scrubs_breadcrumb_messages(self):
+        """LoggingIntegration records the log message as a breadcrumb."""
+        event = {
+            "breadcrumbs": {
+                "values": [
+                    {
+                        "type": "log",
+                        "category": "django_scim.views",
+                        "message": PG_INTEGRITY_ERROR,
+                    }
+                ]
+            }
+        }
+        sentry._scrub_pg_details(event)
+        assert "learner@example.invalid" not in repr(event)
+
+    def test_scrubs_logentry_params(self):
+        """logger.error("...: %s", exc) puts the exception in logentry.params."""
+        event = {
+            "logentry": {
+                "message": "Unable to complete SCIM call: %s",
+                "formatted": "Unable to complete SCIM call: " + PG_INTEGRITY_ERROR,
+                "params": [PG_INTEGRITY_ERROR],
+            }
+        }
+        sentry._scrub_pg_details(event)
+        assert "learner@example.invalid" not in repr(event)
+
+    def test_scrubs_captured_frame_locals(self):
+        """include_local_variables defaults to True, so frame vars carry it too."""
+        event = {
+            "exception": {
+                "values": [
+                    {
+                        "value": "boom",
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "save",
+                                    "vars": {"exc": PG_INTEGRITY_ERROR, "retries": 3},
+                                }
+                            ]
+                        },
+                    }
+                ]
+            }
+        }
+        sentry._scrub_pg_details(event)
+        assert "learner@example.invalid" not in repr(event)
+        frame = event["exception"]["values"][0]["stacktrace"]["frames"][0]
+        assert frame["vars"]["retries"] == EXPECTED_RETRIES
+
+    def test_walk_preserves_non_string_leaves(self):
+        """The walk must not coerce timestamps, ints or None into strings."""
+        event = {
+            "timestamp": EXPECTED_TIMESTAMP,
+            "level": "error",
+            "extra": {"count": 42, "missing": None, "flag": True},
+            "message": PG_INTEGRITY_ERROR,
+        }
+        sentry._scrub_pg_details(event)
+        assert event["timestamp"] == EXPECTED_TIMESTAMP
+        assert event["extra"] == {"count": 42, "missing": None, "flag": True}
+        assert "learner@example.invalid" not in event["message"]
 
 
 class TestPluginSettings:

--- a/src/ol_openedx_sentry/tests/test_sentry.py
+++ b/src/ol_openedx_sentry/tests/test_sentry.py
@@ -2,12 +2,16 @@
 # ruff: noqa: SLF001 - this suite intentionally exercises private helpers.
 
 import decimal
+import json
 import logging
 import re
 import types
 
+import pytest
+import sentry_sdk
 from ol_openedx_sentry.settings import sentry
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.transport import Transport
 
 
 class TestLoadExceptionClass:
@@ -265,6 +269,36 @@ PG_PRIMARY_MESSAGE = (
 )
 
 
+class FakeTransport(Transport):
+    """Collect outgoing events instead of sending them."""
+
+    def __init__(self):
+        super().__init__()
+        self.events = []
+
+    def capture_envelope(self, envelope):
+        self.events.extend(
+            item.payload.json for item in envelope.items if item.type == "event"
+        )
+
+
+@pytest.fixture
+def sentry_transport():
+    """Initialize the real SDK with the event filter, and detach it afterwards."""
+    transport = FakeTransport()
+    sentry_sdk.init(
+        dsn="https://k@o0.ingest.sentry.io/0",
+        transport=transport,
+        before_send=sentry.sentry_event_filter,
+        default_integrations=False,
+        integrations=[
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR)
+        ],
+    )
+    yield transport
+    sentry_sdk.get_global_scope().set_client(None)
+
+
 class TestScrubPgDetail:
     """Tests for the Postgres ``DETAIL:`` row-echo scrub."""
 
@@ -274,6 +308,12 @@ class TestScrubPgDetail:
         assert "learner@example.invalid" not in scrubbed
         assert "12d7dfc5-6f84-46db-9383-2d7079434173" not in scrubbed
         assert "[scrubbed by ol_openedx_sentry]" in scrubbed
+
+    def test_escaped_detail_line_is_truncated(self):
+        """repr() turns the newline into a literal backslash-n; that form goes too."""
+        scrubbed = sentry._scrub_pg_detail(repr(Exception(PG_INTEGRITY_ERROR)))
+        assert PG_PRIMARY_MESSAGE in scrubbed
+        assert "learner@example.invalid" not in scrubbed
 
     def test_message_without_detail_is_unchanged(self):
         message = "connection to server failed"
@@ -329,19 +369,19 @@ class TestScrubPgDetail:
         assert "learner@example.invalid" not in repr(event)
 
     def test_scrubs_logentry_params(self):
-        """logger.error("...: %s", exc) puts the exception in logentry.params."""
+        """logger.error("...: %s", exc) puts the repr'd exception in logentry.params."""
         event = {
             "logentry": {
                 "message": "Unable to complete SCIM call: %s",
                 "formatted": "Unable to complete SCIM call: " + PG_INTEGRITY_ERROR,
-                "params": [PG_INTEGRITY_ERROR],
+                "params": [repr(Exception(PG_INTEGRITY_ERROR))],
             }
         }
         sentry._scrub_pg_details(event)
         assert "learner@example.invalid" not in repr(event)
 
     def test_scrubs_captured_frame_locals(self):
-        """include_local_variables defaults to True, so frame vars carry it too."""
+        """include_local_variables defaults to True, so repr'd frame vars carry it."""
         event = {
             "exception": {
                 "values": [
@@ -351,7 +391,10 @@ class TestScrubPgDetail:
                             "frames": [
                                 {
                                     "function": "save",
-                                    "vars": {"exc": PG_INTEGRITY_ERROR, "retries": 3},
+                                    "vars": {
+                                        "exc": repr(Exception(PG_INTEGRITY_ERROR)),
+                                        "retries": 3,
+                                    },
                                 }
                             ]
                         },
@@ -376,6 +419,26 @@ class TestScrubPgDetail:
         assert event["timestamp"] == EXPECTED_TIMESTAMP
         assert event["extra"] == {"count": 42, "missing": None, "flag": True}
         assert "learner@example.invalid" not in event["message"]
+
+    def test_real_sdk_scrubs_params_and_local_variables(self, sentry_transport):
+        """Go through the real SDK, which repr()s params and locals before
+        before_send."""
+
+        def save():
+            exc = Exception(PG_INTEGRITY_ERROR)
+            raise exc
+
+        try:
+            save()
+        except Exception as e:  # noqa: BLE001
+            logging.getLogger("x").error("Unable to save: %s", e)  # noqa: TRY400
+            sentry_sdk.capture_exception(e)
+        sentry_sdk.flush()
+
+        expected_events = 2
+        assert len(sentry_transport.events) == expected_events
+        for event in sentry_transport.events:
+            assert "learner@example.invalid" not in json.dumps(event)
 
 
 class TestPluginSettings:

--- a/uv.lock
+++ b/uv.lock
@@ -2442,7 +2442,7 @@ requires-dist = [
 
 [[package]]
 name = "ol-openedx-sentry"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/ol_openedx_sentry" }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## This repo

Changes the `SENTRY_SEND_HTTP_REQUEST_BODIES` default in `ol_openedx_sentry` from `"small"` to `"never"`, and adds the Postgres `DETAIL:` scrub to the existing `sentry_event_filter`.

Unlike the standalone Django apps in this change, this plugin was never on the SDK default — the author chose `"small"` deliberately, in the same commit that made PII opt-in. But `"small"` still admits bodies up to 1,000 bytes, and the Open edX write endpoints that show up in the error data are xblock handler POSTs, whose payloads can fall under that cap. So the setting does not reliably protect the payload it was chosen to protect. `"never"` does; operators can still widen it per deployment via the env token.

The scrub runs as the **first** statement in the filter, so the module's documented fail-open handler returns an already-scrubbed event. A privacy control that fails open is not one.

This applies to every Open edX deployment that installs `ol_openedx_sentry`.

## What

Two independent ways learner data reaches Sentry, neither of them governed by `send_default_pii`. Part of a ten-repo change on branch `tmacey/sentry-scrub-request-bodies`.

### 1. HTTP request bodies are captured with no PII gate

`request_info["data"]` is set unconditionally in `RequestExtractor.extract_into_event`. The only control is `max_request_body_size`, checked by `request_body_within_bounds`:

| value | effect |
| --- | --- |
| `never` | no bodies |
| `small` | bodies <= 1,000 bytes |
| `medium` | bodies <= 10,000 bytes — **the SDK default** |
| `always` | no limit |

Verified against sentry-sdk source: `request_body_within_bounds` does the bounds check, `RequestExtractor.extract_into_event` sets the body unconditionally, and `"medium"` is the `max_request_body_size` default. The repos in this change pin 1.9.0 to 2.68.0, and the behaviour is the same across them.

The bound is checked against the declared `Content-Length`, and a missing or malformed header counts as 0. Under WSGI, Django then reads 0 bytes, so nothing gets past it. Under ASGI, Django takes `CONTENT_LENGTH` from the header and reads the whole body, so on learn-ai and mit-learn a chunked request with no `Content-Length` is captured in full. The Starlette integration (ol-analytics-api) attaches no body when the header is absent.

Which endpoints that actually means, measured in Sentry over the 30 days to 2026-09-08 (`dataset=errors`, `http.method:[POST,PUT,PATCH]`, grouped by transaction):

| transaction | project | events |
| --- | --- | --- |
| `PATCH /scim/v2/Users/{uuid}` | mitxonline | 17,610 |
| `POST /api/v1/webhooks/content_files/` | mit-learn | 5,039 |
| `POST /api/v1/enrollments/` | mitxonline | 1,436 |
| `POST .../xblock/{usage_id}/handler/{handler}/` | openedx-mitxpro | 553 |
| `POST /cms/pages/{page_id}/edit/` | micromasters | 273 |
| `POST /api/profile/details/` | mitxonline | 132 |
| `POST /api/checkout/result/` | mitxonline | 65 |
| `POST /api/checkout/redeem_discount/` | mitxonline | 46 |

Enrollment, checkout, profile edits, SCIM user attributes, and xblock handler submissions — governed by a knob nobody set.

### 2. Postgres `DETAIL:` lines leak rows through the exception text

A constraint violation carries a `DETAIL:  Failing row contains (...)` line reproducing the whole offending row, and psycopg puts it in `str(exc)`. It therefore ships inside the *exception value*, where no SDK privacy option reaches it — `send_default_pii` governs user/cookie/header capture and `max_request_body_size` governs bodies; neither touches exception text.

Measured on [MITXONLINE-6PK](https://mit-office-of-digital-learning.sentry.io/issues/MITXONLINE-6PK): a SCIM `PATCH` `IntegrityError` on `users_user` whose `DETAIL` line reproduces a learner email address three times per event. First seen 2026-05-27, **46,764 occurrences**, last seen 2026-09-08 — still firing.

`before_send` now walks the whole serialized event and truncates any string at its `DETAIL:` line, whether the newline arrives raw or as a literal `\n` (the SDK `repr()`s frame locals and non-string log params before `before_send` runs). It keeps the primary error that names the failure and drops the row echo plus any `HINT`/`CONTEXT` after it.

## Testing

Unit tests next to the module use a real MITXONLINE-6PK exception value with the learner identifiers replaced. They assert the primary message survives, the email and external UUID do not, and `HINT`/`CONTEXT` are dropped, for both the raw `DETAIL:` line and the repr'd form the SDK produces for frame locals and log params. One test goes through a real SDK client, with `sentry_event_filter` and a fake transport, and checks that no outgoing event carries the email. Against the pre-review module, 4 of the tests fail, that one included.

## Not in scope

`send_default_pii` and the salted-user-hash work are deliberately untouched here — different knob, different failure mode, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVJKTGk9KHUTN2xfU59ujX

## The other nine PRs

Same branch name (`tmacey/sentry-scrub-request-bodies`) in each repo. Independent — no merge order required.

| repo | PR | body size |
| --- | --- | --- |
| open-edx-plugins | mitodl/open-edx-plugins#866 | `never` |
| mit-learn | mitodl/mit-learn#3915 | `small` |
| mitxonline | mitodl/mitxonline#3936 | `small` |
| mitxpro | mitodl/mitxpro#4088 | `small` |
| ocw-studio | mitodl/ocw-studio#3198 | `small` |
| odl-video-service | mitodl/odl-video-service#1591 | `small` |
| micromasters | mitodl/micromasters#5561 | `small` (as `request_bodies`, SDK 1.9.0) |
| open-discussions | mitodl/open-discussions#4463 | `small` |
| learn-ai | mitodl/learn-ai#62 | `small` |
| ol-analytics-api | mitodl/ol-analytics-api#54 | `small` |
