### PR TITLE
fix(ci): pin pyOpenSSL to avoid X509Extension crash on verawood leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,15 +205,13 @@ jobs:
     # build can resolve to a different point release. 26.1.0 still has the
     # deprecated OpenSSL.crypto.X509Extension class, which references
     # cryptography's _lib.GEN_EMAIL -- removed from cryptography 46.0.5's
-    # bindings, so importing it raises AttributeError. 26.2.0+ deleted that
-    # class entirely, sidestepping the bug rather than fixing the underlying
-    # mismatch (pyOpenSSL's own metadata claims cryptography>=49 from 26.3.0
-    # on, but 26.4.0 runs fine against the 46.0.5 pinned here in practice,
-    # since nothing in this test suite exercises the incompatible surface).
-    # --no-deps avoids pulling that unneeded cryptography bump in. Floor, not
-    # exact pin: accepting the (small, known) risk that some future pyOpenSSL
-    # release reintroduces a different incompatibility -- revisit this if CI
-    # breaks again.
+    # bindings, so importing it raises AttributeError. 26.2.0 deleted that
+    # class entirely and is the first release whose own declared requirement
+    # (cryptography<49,>=46.0.0) actually matches the 46.0.5 pinned here;
+    # 26.3.0+ raises that floor to >=49, which this image doesn't have, so
+    # capped below it rather than forcing an unsupported pair with --no-deps.
+    # Floor, not exact pin, so a future 26.2.x regression fix needs no manual
+    # bump; revisit the cap if CI needs something past 26.2.x.
     - name: Run tests on tutor
       env:
         TUTOR_ROOT_DIR: ${{ steps.tutor.outputs.tutor_root }}
@@ -226,7 +224,7 @@ jobs:
           --project-name "$COMPOSE_PROJECT" \
           run -v "$PWD:/openedx/open-edx-plugins" \
           lms bash -c '
-            pip install --no-deps "pyOpenSSL>=26.4.0" &&
+            pip install "pyOpenSSL>=26.2.0,<26.3.0" &&
             /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,10 @@ jobs:
     # mismatch (pyOpenSSL's own metadata claims cryptography>=49 from 26.3.0
     # on, but 26.4.0 runs fine against the 46.0.5 pinned here in practice,
     # since nothing in this test suite exercises the incompatible surface).
-    # --no-deps avoids pulling that unneeded cryptography bump in; pinned to
-    # the exact version already proven in production on this same image
-    # rather than an open-ended floor that could land on a future release
-    # with its own bug.
+    # --no-deps avoids pulling that unneeded cryptography bump in. Floor, not
+    # exact pin: accepting the (small, known) risk that some future pyOpenSSL
+    # release reintroduces a different incompatibility -- revisit this if CI
+    # breaks again.
     - name: Run tests on tutor
       env:
         TUTOR_ROOT_DIR: ${{ steps.tutor.outputs.tutor_root }}
@@ -226,7 +226,7 @@ jobs:
           --project-name "$COMPOSE_PROJECT" \
           run -v "$PWD:/openedx/open-edx-plugins" \
           lms bash -c '
-            pip install --no-deps "pyOpenSSL==26.4.0" &&
+            pip install --no-deps "pyOpenSSL>=26.4.0" &&
             /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,20 @@ jobs:
         cd "${{ github.workspace }}/../edx-platform"
         tutor mounts add .
 
+    # pyOpenSSL is an unpinned transitive dependency (pulled in via
+    # pymongo[ocsp]) that edx-platform never pins, so each openedx-dev image
+    # build can resolve to a different point release. 26.1.0 still has the
+    # deprecated OpenSSL.crypto.X509Extension class, which references
+    # cryptography's _lib.GEN_EMAIL -- removed from cryptography 46.0.5's
+    # bindings, so importing it raises AttributeError. 26.2.0+ deleted that
+    # class entirely, sidestepping the bug rather than fixing the underlying
+    # mismatch (pyOpenSSL's own metadata claims cryptography>=49 from 26.3.0
+    # on, but 26.4.0 runs fine against the 46.0.5 pinned here in practice,
+    # since nothing in this test suite exercises the incompatible surface).
+    # --no-deps avoids pulling that unneeded cryptography bump in; pinned to
+    # the exact version already proven in production on this same image
+    # rather than an open-ended floor that could land on a future release
+    # with its own bug.
     - name: Run tests on tutor
       env:
         TUTOR_ROOT_DIR: ${{ steps.tutor.outputs.tutor_root }}
@@ -211,8 +225,10 @@ jobs:
           -f "$TUTOR_ROOT_DIR/env/dev/docker-compose.yml" \
           --project-name "$COMPOSE_PROJECT" \
           run -v "$PWD:/openedx/open-edx-plugins" \
-          lms /openedx/open-edx-plugins/run_edx_integration_tests.sh \
-          --mount-dir /openedx/open-edx-plugins
+          lms bash -c '
+            pip install --no-deps "pyOpenSSL==26.4.0" &&
+            /openedx/open-edx-plugins/run_edx_integration_tests.sh --mount-dir /openedx/open-edx-plugins
+          '
 
     - name: Upload coverage to CodeCov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Pins `pyOpenSSL>=26.2.0,<26.3.0` in the CI test-run step, across all three `integration-tests` matrix legs.
- Fixes a test-collection crash on the `release/verawood` leg (`AttributeError: module 'lib' has no attribute 'GEN_EMAIL'`) that fails every plugin's tests on that leg, not just one.

<details>
<summary><b>Implementation details</b></summary><br>

`edx-platform` never pins `pyOpenSSL` — it's a bare transitive dependency of `pymongo[ocsp]` — so each `openedx-dev` image build resolves it independently, with no lockfile to keep the result consistent across builds. The image currently cached for the verawood leg resolved to `pyOpenSSL==26.1.0`, which still has pyOpenSSL's now-deprecated `OpenSSL.crypto.X509Extension` class. That class references `cryptography`'s `_lib.GEN_EMAIL`, a constant `cryptography==46.0.5`'s compiled bindings don't expose, so importing it (via `pymongo.pyopenssl_context`) raises `AttributeError` at class-definition time.

`pyOpenSSL` 26.2.0 is both the release that deleted `X509Extension` entirely and the last one whose own declared requirement (`cryptography<49,>=46.0.0`) actually covers the pinned `cryptography==46.0.5`. 26.3.0+ raises that floor to `>=49`, which this image doesn't have, so the range is capped below it — that lets pip's real resolver settle on a genuinely valid combination with no `--no-deps` and no collateral `cryptography` bump. (An earlier revision of this PR pinned `pyOpenSSL==26.4.0` with `--no-deps`; a Copilot review caught that 26.4.0 declares `cryptography>=49,<51`, which `46.0.5` doesn't satisfy — that pin worked only because nothing in this test suite happens to exercise the incompatible surface, not because the pair was actually supported.)

A floor rather than an exact pin, so a future `26.2.x` regression-only release (per pyOpenSSL's own versioning policy, the third digit is patch/regression fixes only) is picked up automatically with no manual bump needed.

Confirmed via mitodl/open-edx-plugins#860's CI: not caused by any application code change. PR #845 (which added verawood to the matrix) passed because its own CI ran a from-scratch image build two days before `ci-image-cache.yml`'s merge-triggered rebuild populated the cache everyone actually pulls from — two independent, unlocked pip resolutions of the same requirements landed on different `pyOpenSSL` point releases.
</details>

### How can this be tested?
- Verified on this PR's own CI: all three `integration-tests` matrix legs pass, including `release/verawood` (19m9s, previously failing on test collection).

### Additional Context
- Surfaced while debugging CI failures on #860 — unrelated to that PR's own changes.
- This is a CI-infra workaround, not a fix to the actual root cause (edx-platform leaving `pyOpenSSL` unpinned). Worth reporting upstream to `overhangio/tutor` or `openedx/edx-platform` separately.